### PR TITLE
Add breadcrumb navigation to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository hosts the documentation of [Tenzir](https://tenzir.com).
 
-## 🚧 WORK IN PROGRESS 🚧  
+## 🚧 WORK IN PROGRESS 🚧
 
 The content in this repository is not yet authoritative. If you look for the
 Tenzir documentation, go to [docs.tenzir.com](https://docs.tenzir.com).
@@ -26,8 +26,7 @@ can find a preview of the new documentation at
 - [x] Tweak `index.mdx` title
 - [x] Consider https://github.com/rehypejs/rehype-external-links
 - [ ] Fix Markdoc partial support (https://github.com/withastro/astro/issues/13575)
-- [ ] Use [breadcrumbs](https://docs.astro-breadcrumbs.kasimir.dev/) for
-      functions and operators
+- [x] Use [breadcrumbs](https://docs.astro-breadcrumbs.kasimir.dev/)
 - [x] Add Plausible analytics
 
 ### CI / Automation

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -58,6 +58,7 @@ export default defineConfig({
         "./src/assets/styles.css",
       ],
       components: {
+        PageTitle: './src/components/PageTitle.astro',
         Sidebar: './src/components/Sidebar.astro',
         SiteTitle: './src/components/SiteTitle.astro',
         ThemeSelect: './src/components/ThemeSelect.astro',

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fontsource-variable/inter": "^5.2.5",
     "@fontsource-variable/jetbrains-mono": "^5.2.5",
     "astro": "^5.8.0",
+    "astro-breadcrumbs": "^3.3.1",
     "node-html-parser": "^7.0.1",
     "rehype-external-links": "^3.0.0",
     "sharp": "^0.34.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       astro:
         specifier: ^5.8.0
         version: 5.8.0(@types/node@22.15.21)(rollup@4.41.1)(typescript@5.7.3)
+      astro-breadcrumbs:
+        specifier: ^3.3.1
+        version: 3.3.1(astro@5.8.0(@types/node@22.15.21)(rollup@4.41.1)(typescript@5.7.3))
       node-html-parser:
         specifier: ^7.0.1
         version: 7.0.1
@@ -851,6 +854,11 @@ packages:
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
+
+  astro-breadcrumbs@3.3.1:
+    resolution: {integrity: sha512-O3wWzlc4HOU//ePefcwk2F4yQn830buVUVn6h7+sGmVq7+xvv9JmHTcmihU18ISte72ELnJlG2U8s58nIuPXfg==}
+    peerDependencies:
+      astro: ^2.0.0-beta.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
 
   astro-expressive-code@0.41.2:
     resolution: {integrity: sha512-HN0jWTnhr7mIV/2e6uu4PPRNNo/k4UEgTLZqbp3MrHU+caCARveG2yZxaZVBmxyiVdYqW5Pd3u3n2zjnshixbw==}
@@ -2832,6 +2840,10 @@ snapshots:
   array-iterate@2.0.1: {}
 
   astring@1.9.0: {}
+
+  astro-breadcrumbs@3.3.1(astro@5.8.0(@types/node@22.15.21)(rollup@4.41.1)(typescript@5.7.3)):
+    dependencies:
+      astro: 5.8.0(@types/node@22.15.21)(rollup@4.41.1)(typescript@5.7.3)
 
   astro-expressive-code@0.41.2(astro@5.8.0(@types/node@22.15.21)(rollup@4.41.1)(typescript@5.7.3)):
     dependencies:

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -242,9 +242,36 @@ html[data-theme="dark"] {
   height: 0.75rem;
 }
 
-/* Hide breadcrumbs on mobile to save space */
+/* Adjust breadcrumbs on mobile */
 @media (max-width: 50rem) {
   .c-breadcrumbs {
-    display: none;
+    font-size: var(--sl-text-2xs);
+    margin-bottom: 1rem;
+  }
+  
+  .c-breadcrumbs__crumbs {
+    gap: 0.125rem;
+  }
+  
+  .c-breadcrumbs__link {
+    padding: 0.125rem;
+  }
+  
+  .c-breadcrumbs__link.is-index {
+    padding: 0.125rem;
+  }
+  
+  .c-breadcrumbs__link.is-index svg {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+  
+  .c-breadcrumbs__separator {
+    margin: 0;
+  }
+  
+  .c-breadcrumbs__separator svg {
+    width: 0.625rem;
+    height: 0.625rem;
   }
 }

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -173,3 +173,78 @@ html[data-theme="dark"] {
 .social-icons a {
   color: var(--sl-color-white);
 }
+
+/* Breadcrumb styling */
+.c-breadcrumbs {
+  margin-bottom: 1.5rem;
+  font-size: var(--sl-text-xs);
+  line-height: 1;
+}
+
+.c-breadcrumbs__crumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c-breadcrumbs__crumb {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.c-breadcrumbs__link {
+  color: var(--sl-color-gray-3);
+  text-decoration: none;
+  transition: color 0.2s;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+}
+
+.c-breadcrumbs__link:hover {
+  color: var(--sl-color-accent);
+  background-color: var(--sl-color-gray-6);
+}
+
+.c-breadcrumbs__link.is-current {
+  color: var(--sl-color-white);
+  font-weight: 500;
+  pointer-events: none;
+}
+
+/* Style the home icon */
+.c-breadcrumbs__link.is-index {
+  padding: 0.25rem;
+}
+
+.c-breadcrumbs__link.is-index svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+/* Style the separator chevrons */
+.c-breadcrumbs__separator {
+  color: var(--sl-color-gray-4);
+  opacity: 0.5;
+  display: flex;
+  align-items: center;
+  margin: 0 0.125rem;
+}
+
+.c-breadcrumbs__separator svg {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
+/* Hide breadcrumbs on mobile to save space */
+@media (max-width: 50rem) {
+  .c-breadcrumbs {
+    display: none;
+  }
+}

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -3,10 +3,53 @@ import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/PageTitle.astro';
 import { Breadcrumbs } from 'astro-breadcrumbs';
 import 'astro-breadcrumbs/breadcrumbs.css';
+import { getCollection } from 'astro:content';
+
+// Get all docs entries to check which paths actually exist
+const allDocs = await getCollection('docs');
+const existingPaths = new Set(
+  allDocs.map(doc => `/${doc.slug}`)
+);
+
+// Also add paths with trailing slashes
+allDocs.forEach(doc => {
+  existingPaths.add(`/${doc.slug}/`);
+});
+
+// Get the current path segments
+const currentPath = Astro.url.pathname;
+const segments = currentPath.split('/').filter(Boolean);
+
+// Build customization array for non-existent paths
+const customizeLinks = [];
+let pathSoFar = '';
+
+segments.forEach((segment, index) => {
+  pathSoFar += `/${segment}`;
+  
+  // Check if this intermediate path exists as a page
+  // Skip the last segment (current page)
+  if (index < segments.length - 1) {
+    const pathExists = existingPaths.has(pathSoFar) || 
+                      existingPaths.has(`${pathSoFar}/`) ||
+                      existingPaths.has(`${pathSoFar}/index`);
+    
+    if (!pathExists) {
+      // This intermediate path doesn't exist, so make it non-clickable
+      customizeLinks.push({
+        index: index + 1, // +1 because index 0 is Home
+        href: '#',
+        style: 'pointer-events: none; text-decoration: none; color: var(--sl-color-gray-3); cursor: default;',
+        onclick: 'return false;',
+        tabindex: '-1'
+      });
+    }
+  }
+});
 ---
 
 <div class="page-title-with-breadcrumbs">
-  <Breadcrumbs>
+  <Breadcrumbs customizeLinks={customizeLinks}>
     <svg
       slot="index"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -8,6 +8,9 @@ import 'astro-breadcrumbs/breadcrumbs.css';
 const currentPath = Astro.url.pathname;
 const segments = currentPath.split('/').filter(Boolean);
 
+// Don't show breadcrumbs on the home page
+const isHomePage = currentPath === '/' || segments.length === 0;
+
 // Build customization array for breadcrumb links
 const customizeLinks: any[] = [];
 
@@ -51,7 +54,8 @@ for (let i = 0; i < segments.length - 1; i++) {
 ---
 
 <div class="page-title-with-breadcrumbs">
-  <Breadcrumbs customizeLinks={customizeLinks}>
+  {!isHomePage && (
+    <Breadcrumbs customizeLinks={customizeLinks}>
     <svg
       slot="index"
       xmlns="http://www.w3.org/2000/svg"
@@ -83,7 +87,8 @@ for (let i = 0; i < segments.length - 1; i++) {
     >
       <polyline points="9 18 15 12 9 6"></polyline>
     </svg>
-  </Breadcrumbs>
+    </Breadcrumbs>
+  )}
   <Default {...Astro.props} />
 </div>
 

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -3,57 +3,51 @@ import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/PageTitle.astro';
 import { Breadcrumbs } from 'astro-breadcrumbs';
 import 'astro-breadcrumbs/breadcrumbs.css';
-import { getCollection } from 'astro:content';
-
-// Get all docs entries to check which paths actually exist
-const allDocs = await getCollection('docs');
-const existingPaths = new Set();
-
-// Add all document paths
-allDocs.forEach(doc => {
-  const slug = doc.slug || '';
-  
-  // Add the exact slug
-  existingPaths.add(`/${slug}`);
-  
-  // If it's an index page, also add the parent directory
-  if (slug.endsWith('/index') || slug.endsWith('index')) {
-    const parentPath = slug.replace(/\/?index$/, '');
-    existingPaths.add(`/${parentPath}`);
-    existingPaths.add(`/${parentPath}/`);
-  }
-});
 
 // Get the current path segments
 const currentPath = Astro.url.pathname;
 const segments = currentPath.split('/').filter(Boolean);
 
-// Build customization array for non-existent paths
-const customizeLinks = [];
-let pathSoFar = '';
+// Build customization array for breadcrumb links
+const customizeLinks: any[] = [];
 
-segments.forEach((segment, index) => {
-  pathSoFar += `/${segment}`;
+// For each intermediate segment, check if we need to customize it
+for (let i = 0; i < segments.length - 1; i++) {
+  const pathToCheck = '/' + segments.slice(0, i + 1).join('/');
   
-  // Check if this intermediate path exists as a page
-  // Skip the last segment (current page)
-  if (index < segments.length - 1) {
-    const pathExists = existingPaths.has(pathSoFar) || 
-                      existingPaths.has(`${pathSoFar}/`) ||
-                      existingPaths.has(`${pathSoFar}/index`);
+  // Check if a page exists at this path
+  let pageExists = true;
+  try {
+    // Use import.meta.glob to check if there's an index page at this path
+    const allPages = import.meta.glob('/src/content/docs/**/*.{md,mdx,mdoc}', { as: 'raw' });
     
-    if (!pathExists) {
-      // This intermediate path doesn't exist, so make it non-clickable
-      customizeLinks.push({
-        index: index + 1, // +1 because index 0 is Home
-        href: '#',
-        style: 'pointer-events: none; text-decoration: none; color: var(--sl-color-gray-3); cursor: default;',
-        onclick: 'return false;',
-        tabindex: '-1'
-      });
-    }
+    // Check if this path has a corresponding page
+    const hasIndex = Object.keys(allPages).some(key => 
+      key === `/src/content/docs${pathToCheck}/index.md` ||
+      key === `/src/content/docs${pathToCheck}/index.mdx` ||
+      key === `/src/content/docs${pathToCheck}/index.mdoc` ||
+      key === `/src/content/docs${pathToCheck.replace(/\/$/, '')}.md` ||
+      key === `/src/content/docs${pathToCheck.replace(/\/$/, '')}.mdx` ||
+      key === `/src/content/docs${pathToCheck.replace(/\/$/, '')}.mdoc`
+    );
+    
+    pageExists = hasIndex;
+  } catch (e) {
+    // If we can't determine, assume it exists
+    pageExists = true;
   }
-});
+  
+  if (!pageExists) {
+    // This intermediate path doesn't exist, so make it non-clickable
+    customizeLinks.push({
+      index: i + 1, // +1 because index 0 is Home
+      href: '#',
+      style: 'pointer-events: none; text-decoration: none; color: var(--sl-color-gray-3); cursor: default;',
+      onclick: 'return false;',
+      tabindex: '-1'
+    });
+  }
+}
 ---
 
 <div class="page-title-with-breadcrumbs">

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -1,0 +1,49 @@
+---
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/PageTitle.astro';
+import { Breadcrumbs } from 'astro-breadcrumbs';
+import 'astro-breadcrumbs/breadcrumbs.css';
+---
+
+<div class="page-title-with-breadcrumbs">
+  <Breadcrumbs>
+    <svg
+      slot="index"
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-label="Home"
+    >
+      <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+      <polyline points="9 22 9 12 15 12 15 22"></polyline>
+    </svg>
+    <svg
+      slot="separator"
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="9 18 15 12 9 6"></polyline>
+    </svg>
+  </Breadcrumbs>
+  <Default {...Astro.props} />
+</div>
+
+<style>
+  .page-title-with-breadcrumbs {
+    display: contents;
+  }
+</style>

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -7,13 +7,21 @@ import { getCollection } from 'astro:content';
 
 // Get all docs entries to check which paths actually exist
 const allDocs = await getCollection('docs');
-const existingPaths = new Set(
-  allDocs.map(doc => `/${doc.slug}`)
-);
+const existingPaths = new Set();
 
-// Also add paths with trailing slashes
+// Add all document paths
 allDocs.forEach(doc => {
-  existingPaths.add(`/${doc.slug}/`);
+  const slug = doc.slug || '';
+  
+  // Add the exact slug
+  existingPaths.add(`/${slug}`);
+  
+  // If it's an index page, also add the parent directory
+  if (slug.endsWith('/index') || slug.endsWith('index')) {
+    const parentPath = slug.replace(/\/?index$/, '');
+    existingPaths.add(`/${parentPath}`);
+    existingPaths.add(`/${parentPath}/`);
+  }
 });
 
 // Get the current path segments


### PR DESCRIPTION
This PR adds breadcrumb navigation to all documentation pages in the Starlight project.

## Changes

- Added astro-breadcrumbs package for breadcrumb functionality
- Created custom PageTitle component to display breadcrumbs above page titles
- Styled breadcrumbs to match the Starlight theme with:
  - Home icon instead of "Home" text
  - Chevron separators between items
  - Smaller, more subtle text size
  - Hover effects and proper color theming
  - Responsive design (hidden on mobile)
- Added logic to disable non-existent intermediate paths (e.g., /reference/language/ when no such page exists)

## Implementation Details

The breadcrumbs automatically detect which intermediate paths have corresponding pages using . Paths that don't have index pages are displayed but not clickable, preventing navigation to 404 pages.

## Screenshots

The breadcrumbs show the full navigation path on each page:
- Home icon → Section → Subsection → Current Page

Example: On :
- 🏠 → reference → language → statements

Where "language" is not clickable because  doesn't have an index page, but "reference" is clickable because  does.

The implementation is clean and follows Starlight's component override pattern.