### PR TITLE
Fix interactive docs structure overlay alignment

### DIFF
--- a/src/components/InteractiveDocsStructure.astro
+++ b/src/components/InteractiveDocsStructure.astro
@@ -115,8 +115,8 @@ const getHref = (section: string) => {
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: 46% 48% 6%;
+    grid-template-columns: 3.52% 39.55% 13.93% 39.55% 3.45%;
+    grid-template-rows: 2% 32% 24% 32% 10%;
     gap: 0;
   }
 
@@ -157,23 +157,23 @@ const getHref = (section: string) => {
 
   /* Specific positioning adjustments */
   .tutorials {
-    grid-column: 1;
-    grid-row: 1;
+    grid-column: 2;
+    grid-row: 2;
   }
 
   .guides {
-    grid-column: 2;
-    grid-row: 1;
+    grid-column: 4;
+    grid-row: 2;
   }
 
   .explanations {
-    grid-column: 1;
-    grid-row: 2;
+    grid-column: 2;
+    grid-row: 4;
   }
 
   .reference {
-    grid-column: 2;
-    grid-row: 2;
+    grid-column: 4;
+    grid-row: 4;
   }
 
   /* Responsive adjustments */


### PR DESCRIPTION
# Fix Interactive Docs Structure Overlay Alignment

## Problem

The interactive overlay on the main docs structure SVG was not properly aligned with the rectangle boundaries. The overlay areas were extending beyond the intended rectangle frames, particularly noticeable when hovering over the quadrants (Tutorials, Guides, Explanations, Reference).

**Issues identified:**
- Overlay extending beyond rectangle boundaries 
- Positioning "a tad too low" relative to actual SVG frames
- Simple 50/50 grid split didn't match actual SVG rectangle positions

## Solution

Analyzed the SVG coordinates and implemented precise CSS grid positioning based on the actual rectangle dimensions and positions from the SVG file.

### Technical Details

**Before:**
```css
grid-template-columns: 1fr 1fr;
grid-template-rows: 46% 48% 6%;
```

**After:**
```css
grid-template-columns: 3.52% 39.55% 13.93% 39.55% 3.45%;
grid-template-rows: 2% 32% 24% 32% 10%;
```

### Methodology

1. **SVG Analysis**: Extracted exact coordinates from SVG `transform` attributes
2. **Coordinate Mapping**: Calculated percentage-based positions relative to viewBox dimensions
3. **Iterative Refinement**: Fine-tuned positioning through visual feedback and testing
4. **Grid Implementation**: Created 5-column × 5-row grid matching SVG structure

### Results

- ✅ Overlay areas now align perfectly with SVG rectangle boundaries
- ✅ Consistent positioning across all four quadrants 
- ✅ Hover effects contained within intended rectangle frames
- ✅ Maintains responsive behavior and accessibility features

## Testing

Verified alignment by:
- Building and previewing the site locally
- Testing hover effects on all four quadrants
- Confirming overlay boundaries match rectangle frames
- Validating responsive behavior

The interactive diagram now provides precise, pixel-perfect alignment between the overlay areas and the underlying SVG rectangles.