### PR TITLE
Update HTTP guide with format and compression inference

### DIFF
--- a/src/content/docs/guides/data-loading/fetch-data-from-apis.mdx
+++ b/src/content/docs/guides/data-loading/fetch-data-from-apis.mdx
@@ -35,16 +35,48 @@ This pattern is useful when processing multiple URLs or when URLs are generated
 dynamically. Most of our subsequent examples use `from_http`, as the operator
 options are very similar.
 
-### Parsing the HTTP Rsponse Body
+### Parsing the HTTP Response Body
 
-The `from_http` and `http` operators attempt to find the right parser for the
-HTTP response body by inspecting the `Content-Type` header. For example, if the
-`Content-Type` is `application/json`, then Tenzir applies the
-[`read_json`](/reference/operators/read_json) operator.
+The `from_http` and `http` operators automatically determine how to parse the
+HTTP response body using multiple methods:
+
+1. **URL-based inference**: The operators first check the URL's file extension
+   to infer both the format (JSON, CSV, Parquet, etc.) and compression type
+   (gzip, zstd, etc.). This works just like the generic `from` operator.
+
+2. **Header-based inference**: If the format cannot be determined from the URL,
+   the operators fall back to using the HTTP `Content-Type` and
+   `Content-Encoding` response headers.
+
+3. **Manual specification**: You can always override automatic inference by
+   providing a parsing pipeline.
+
+#### Automatic Format and Compression Inference
+
+When the URL contains a recognizable file extension, the operators automatically
+handle decompression and parsing:
+
+```tql
+from_http "https://example.org/data/events.csv.zst"
+```
+
+This automatically infers `zstd` compression and `CSV` format from the file
+extension, decompresses, and parses accordingly.
+
+For URLs without clear extensions, the operators use HTTP headers:
+
+```tql
+from_http "https://example.org/download"
+```
+
+If the server responds with `Content-Type: application/json` and
+`Content-Encoding: gzip`, the operator will decompress and parse as JSON.
+
+#### Manual Format Specification
 
 You can manually override the parser for the response body by specifying a
 parsing pipeline, i.e., a pipeline that transforms bytes to events. For example,
-if an API returns CSV data without a proper `Conten-Type`, you can specify the
+if an API returns CSV data without a proper `Content-Type`, you can specify the
 parsing pipeline as follows:
 
 ```tql
@@ -55,6 +87,19 @@ from_http "https://api.example.com/users" {
 
 This parses the response from CSV into structured events that you can process
 further.
+
+Similarly, if you need to handle specific compression and format combinations
+that aren't automatically detected:
+
+```tql
+from_http "https://example.org/archive" {
+  decompress_gzip
+  read_json
+}
+```
+
+This explicitly specifies to decompress gzip and then parse as JSON, regardless
+of the URL or HTTP headers.
 
 ### POST Requests with Data
 
@@ -284,9 +329,11 @@ Follow these practices for reliable and efficient API integration:
    handling transient failures.
 3. **Respect rate limits**. Use `parallel` and `paginate_delay` to control
    request rates.
-4. **Handle errors gracefully**. Check status codes in metdata
+4. **Handle errors gracefully**. Check status codes in metadata
    (`metadata_field`) and implement fallback logic.
 5. **Secure credentials**. Access API keys and tokens via
    [secrets](/explanations/secrets), not in code.
 6. **Monitor API usage**. Track response times and error rates for
    performance.
+7. **Leverage automatic format inference**. Use descriptive file extensions in
+   URLs when possible to enable automatic format and compression detection.


### PR DESCRIPTION
## Summary

This PR integrates the HTTP format and compression inference feature introduced in v5.8.0 into the "Fetch data from APIs" guide.

## Changes

### Enhanced Documentation
- Added comprehensive explanation of the three-step inference process for HTTP responses:
  1. **URL-based inference** - Automatically detects format and compression from file extensions
  2. **Header-based inference** - Falls back to `Content-Type` and `Content-Encoding` headers
  3. **Manual specification** - Allows explicit override when needed

### New Examples
- Added example showing automatic handling of `.csv.zst` files
- Included fallback scenario when URL has no file extension
- Demonstrated manual compression and format specification

### Fixed Typos
- `Rsponse` → `Response` in section heading
- `Conten-Type` → `Content-Type` 
- `metdata` → `metadata` in best practices section

### Best Practices
- Added recommendation to use descriptive file extensions in URLs to leverage automatic format detection

## Related Issues
- Implements documentation for feature added in [#5300](https://github.com/tenzir/tenzir/pull/5300)

## Testing
- Verified markdown formatting with `pnpm lint:markdown:fix`
- Checked code style with `pnpm lint:prettier:fix`
