### PR TITLE
Enable Claude tools in GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -69,7 +69,11 @@ jobs:
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
 
           # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+          allowed_tools: |
+            Bash(pnpm install),
+            Bash(pnpm build),
+            Bash(pnpm test:*),
+            Bash(pnpm lint:*)
 
           # Optional: Skip review for certain conditions
           # if: |

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -50,7 +50,16 @@ jobs:
           # assignee_trigger: "claude-bot"
 
           # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          allowed_tools: |
+            Bash(pnpm install),
+            Bash(pnpm build),
+            Bash(pnpm test:*),
+            Bash(pnpm lint:*),
+            Bash(git status),
+            Bash(git diff),
+            Bash(git add),
+            Bash(git commit),
+            Bash(git push)
 
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |


### PR DESCRIPTION
## Summary
- Enables Claude to use bash commands and git operations in GitHub Actions
- Addresses the permission restrictions encountered in PR #74

## Changes
- Uncommented and configured `allowed_tools` in both Claude workflow files
- Added permissions for:
  - pnpm commands (install, build, test, lint)
  - git commands (status, diff, add, commit, push)
- Formatted tool lists for better readability (one tool per line)

## Context
In PR #74, Claude was unable to run linting commands (`pnpm lint:markdown:fix` and `pnpm lint:prettier:fix`) due to permission restrictions. This PR fixes that by explicitly allowing these tools in the workflow configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)