### PR TITLE
Remove explicit line width mentions from CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,6 @@ Most notably:
 
 ### Markdown Content
 
-- Break lines at 80 characters.
 - When editing Markdown, run `pnpm lint:markdown:fix` and `pnpm
 lint:prettier:fix` when you're done.
 


### PR DESCRIPTION
As discussed in https://tenzir.slack.com/archives/C7QBE8WL9/p1752595144822149 , Claude is not the best tool for adjusting line breaks, since it's bad at counting individual characters.

Instead, the existing markdownlint and prettier linters can already detect line lengths automatically and deterministically.