### PR TITLE
Improve node deployment token documentation

### DIFF
--- a/src/content/docs/guides/node-setup/deploy-a-node/index.mdx
+++ b/src/content/docs/guides/node-setup/deploy-a-node/index.mdx
@@ -222,9 +222,9 @@ This guide walks through manual setup of a single Tenzir node, but you can
 deploy as many nodes as you need.
 
 :::note[Prerequisites]
-Before you begin, you'll need a valid `TENZIR_TOKEN`. You can obtain this by
-[provisioning a node](/guides/node-setup/provision-a-node) and downloading
-the Docker Compose configuration file.
+Before you begin, you'll need a valid `TENZIR_TOKEN` for your node. Obtain one by
+[provisioning a node](/guides/node-setup/provision-a-node), select the
+_other_ tab, and click on the text box to copy the shown token.
 :::
 
 <Steps>
@@ -275,7 +275,7 @@ the Docker Compose configuration file.
    ![Create a Cluster](./aws/06-run-task.png)
 
    In the _Container overrides_ section, add the `TENZIR_TOKEN` environment
-   variable with the token value from the prerequisites.
+   variable with the token value corresponding to your node.
 
    ![Container Overrides](./aws/07-container-overrides.png)
 
@@ -292,11 +292,15 @@ To run a node in Azure, we recommend using [Azure Container Instances
 (ACI)](https://azure.microsoft.com/en-us/products/container-instances), which
 allows you to run Docker containers without having to setup VMs.
 
+:::note[Prerequisites]
+Before you begin, you'll need a valid `TENZIR_TOKEN` for your node. Obtain one by
+[provisioning a node](/guides/node-setup/provision-a-node), select the
+_other_ tab, and click on the text box to copy the shown token.
+:::
+
 ### Azure Container Instances (ACI)
 
-Prior to getting started, you need a valid `TENZIR_TOKEN` that you can obtain
-after [provisioning a node](/guides/node-setup/provision-a-node) and downloading the Docker
-Compose configuration file.
+The following steps guide you through deploying a Tenzir Node using ACI.
 
 #### Create a new container instance
 

--- a/src/content/docs/guides/node-setup/provision-a-node/index.mdx
+++ b/src/content/docs/guides/node-setup/provision-a-node/index.mdx
@@ -46,8 +46,9 @@ Provision a self-hosted node by following these steps:
 
 </Steps>
 
-🚢 Your node is ready to be deployed. The easiest way to continue is by spinning
-up a node with [Docker](/guides/node-setup/deploy-a-node#docker).
+🚢 Your node is ready to be [deployed](/guides/node-setup/deploy-a-node). The
+easiest way to continue is by spinning up a node with
+[Docker](/guides/node-setup/deploy-a-node#docker).
 
 :::tip[Ephemeral Nodes]
 Instead of provisioning a node as a above, with a dedicated authentication


### PR DESCRIPTION
## Summary

- Improve clarity in node deployment documentation regarding `TENZIR_TOKEN` acquisition
- Add explicit prerequisites sections where missing
- Clarify that tokens are obtained from the provisioning page's "other" tab

## Changes

This PR updates the node deployment documentation to make it clearer how to obtain the `TENZIR_TOKEN` needed for deployment:

1. **AWS deployment section**: Added a note directing users to the "other" tab on the provisioning page to copy the token
2. **Azure deployment section**: Added a proper prerequisites section matching the AWS format
3. **Provision page**: Added a direct link to the deployment guide for better navigation flow

These changes address potential confusion about where to find the authentication token after provisioning a node.

🤖 Generated with [Claude Code](https://claude.ai/code)