### PR TITLE
Integrate link checking into primary build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -44,6 +44,8 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build with Astro
+        env:
+          RUN_LINK_CHECK: true
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             pnpm astro build \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -72,29 +72,3 @@ jobs:
 
       - name: Run Prettier
         run: pnpm lint:prettier
-
-  linkcheck:
-    name: Link Check
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: recursive
-
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - name: Setup Node.js and pnpm
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run link check
-        run: pnpm run lint:linkcheck


### PR DESCRIPTION
## Summary

- Integrates link checking directly into the primary build process
- Removes redundant separate link check job from lint workflow
- Ensures consistent link validation across all builds (PRs and main branch)

## Changes

1. **Added `RUN_LINK_CHECK=true` environment variable** to the build step in `.github/workflows/docs.yaml`
2. **Removed the separate `linkcheck` job** from `.github/workflows/lint.yaml`

This simplification means link checking now happens as part of every build, eliminating the need for a separate CI job while maintaining the same validation coverage.

🤖 Generated with [Claude Code](https://claude.ai/code)