### PR TITLE
Fix SVG inlining for Markdoc files

### DIFF
--- a/astro-inline-svgs.mjs
+++ b/astro-inline-svgs.mjs
@@ -118,9 +118,9 @@ function inlineSVGsInHTML(html) {
  */
 function extractBaseFilename(svgPath) {
   const base = path.basename(svgPath);
-  // Match everything before the Astro hash (which starts with a capital letter)
+  // Match everything before the Astro hash
   // This handles filenames with multiple dots like "delay.excalidraw.svg"
-  const match = base.match(/^(.+?)\.([A-Z][A-Za-z0-9_-]+)\.svg$/);
+  const match = base.match(/^(.+?)\.([A-Za-z0-9_-]+)\.svg$/);
   return match ? match[1] + ".svg" : base;
 }
 


### PR DESCRIPTION
## Summary

Fixes SVG inlining for Markdoc (`.mdoc`) files.

## Problem

The regex pattern in `astro-inline-svgs.mjs` only matched Astro hashes starting with uppercase letters, but Astro generates hashes that can start with lowercase letters or hyphens:
- `charts.yAPl35Lg.svg` 
- `platform-services.-sBCic5A.svg`

## Solution

Updated the regex to accept hashes starting with `[a-zA-Z0-9-]` instead of just `[A-Z]`.

## Test

All SVGs from `.mdoc` files now inline correctly. Verified with `pnpm build`.