### PR TITLE
Document test scratch space

### DIFF
--- a/src/content/docs/guides/testing/add-custom-runners.mdx
+++ b/src/content/docs/guides/testing/add-custom-runners.mdx
@@ -100,6 +100,10 @@ runners.register(XxdRunner())
 - The runner writes or compares a `.txt` baseline next to each `.xxd` file.
 - Helper functions from `tenzir_test.runners._utils` integrate cleanly with the
   harness log output.
+- Every run hands the process a dedicated scratch directory through
+  `TENZIR_TMP_DIR`; use it for temporary artefacts your runner needs. Combine it
+  with the CLI `--keep` flag when you want to inspect the intermediate files
+  after the harness exits.
 
 ## Step 3: Add a hexdump test
 

--- a/src/content/docs/guides/testing/create-fixtures.mdx
+++ b/src/content/docs/guides/testing/create-fixtures.mdx
@@ -98,6 +98,11 @@ from {x: 42, y: "foo"}
 http env("HTTP_FIXTURE_URL"), body=this
 ```
 
+Fixtures receive the same per-test scratch directory as the scenario itself via
+`TENZIR_TMP_DIR`. Use it to stage temporary files or logs that should disappear
+after the run. Launch the harness with `--keep` when you want to retain those
+artefacts for debugging.
+
 ## Step 4: Capture the reference output
 
 Run the harness in update mode so it records the HTTP response next to the test.

--- a/src/content/docs/guides/testing/write-tests.mdx
+++ b/src/content/docs/guides/testing/write-tests.mdx
@@ -3,9 +3,9 @@ title: Write tests
 ---
 
 This guide walks you through creating a standalone repository for integration
-tests, wiring it up to [`tenzir-test`](/reference/test), and running your first
-scenarios end to end. You will create a minimal project structure, add a
-pipeline test, record reference output, and rerun the harness to make sure
+tests, wiring it up to [`tenzir-test`](/reference/test-framework), and running
+your first scenarios end to end. You will create a minimal project structure,
+add a pipeline test, record reference output, and rerun the harness to make sure
 everything passes.
 
 ## Prerequisites

--- a/src/content/docs/guides/testing/write-tests.mdx
+++ b/src/content/docs/guides/testing/write-tests.mdx
@@ -64,6 +64,11 @@ project id, message
 sort id
 ```
 
+The harness also injects a unique scratch directory into `TENZIR_TMP_DIR` while
+each test executes. Use it for transient files you do not want under version
+control; pass `--keep` when you run `tenzir-test` if you need to inspect the
+generated artefacts afterwards.
+
 ## Step 5: Capture the reference output
 
 Run the harness once in update mode to execute the pipeline and write the

--- a/src/content/docs/reference/test-framework/index.mdx
+++ b/src/content/docs/reference/test-framework/index.mdx
@@ -33,6 +33,8 @@ uvx tenzir-test --help
 - **Fixture** – Reusable environment provider registered under `fixtures/` and
   requested via frontmatter.
 - **Input** – Data accessed with `TENZIR_INPUTS` (usually under `inputs/`).
+- **Scratch directory** – Ephemeral workspace exposed as `TENZIR_TMP_DIR` during
+  each test run.
 - **Artifact / Baseline** – Runner output persisted next to the test; regenerate
   with `--update`.
 - **Configuration sources** – Frontmatter plus inherited `test.yaml` files;
@@ -105,6 +107,8 @@ Useful options:
   runs.
 - `--jobs N`: Control concurrency (`4 * CPU cores` by default).
 - `--coverage` and `--coverage-source-dir`: Enable LLVM coverage.
+- `-k`, `--keep`: Preserve per-test scratch directories instead of deleting
+  them (same as setting `TENZIR_KEEP_TMP_DIRS=1`).
 - `--log-comparisons`: Log comparison targets (also via
   `TENZIR_TEST_LOG_COMPARISONS=1`).
 
@@ -241,10 +245,18 @@ server that exposes `HTTP_FIXTURE_URL` and tears down cleanly.
 - `TENZIR_TEST_ROOT` – Default test root when `--root` is omitted.
 - `TENZIR_BINARY` / `TENZIR_NODE_BINARY` – Override binary discovery.
 - `TENZIR_INPUTS` – Preferred data directory (overridden in package mode).
+- `TENZIR_KEEP_TMP_DIRS` – Keep per-test scratch directories (equivalent to
+  `--keep`).
 - `TENZIR_TEST_LOG_COMPARISONS` – Enable comparison logging.
 
 Fixtures often publish additional variables (for example
 `TENZIR_NODE_CLIENT_*`, `HTTP_FIXTURE_URL`).
+
+During execution the harness also adds transient variables such as
+`TENZIR_TMP_DIR` so tests and fixtures can create temporary artefacts without
+polluting the repository. Combine it with `--keep` (or
+`TENZIR_KEEP_TMP_DIRS=1`) when you need to inspect the generated files after a
+run.
 
 ## Baselines and artifacts
 


### PR DESCRIPTION
This PR documents the new `TENZIR_TMP_DIR` env variable that tests can use.
