### PR TITLE
Document accept_http and update HTTP operators

### DIFF
--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -7,32 +7,33 @@ This guide shows you how to fetch data from HTTP APIs using the
 <Op>http</Op> operators. You'll learn to make GET
 requests, handle authentication, and implement pagination for large result sets.
 
+## Choosing the Right Operator
+
+Tenzir has two HTTP client operators that share nearly identical options:
+
+- [`from_http`](/reference/operators/from_http) is a **source** operator that
+  starts a pipeline with an HTTP request. Use it for standalone API calls.
+- [`http`](/reference/operators/http) is a **transformation** operator that
+  enriches events flowing through a pipeline with HTTP responses. Use it when
+  you have existing data and want to make per-event API lookups.
+
+Most examples in this guide use `from_http`. Unless noted otherwise, the same
+options work with `http` as well.
+
 ## Basic API Requests
 
 Start with these fundamental patterns for making HTTP requests to APIs.
 
 ### Simple GET Requests
 
-To fetch data from an API endpoint, pass the URL as the first parameter to the
-`from_http` operator:
+To fetch data from an API endpoint, pass the URL as the first parameter:
 
 ```tql
 from_http "https://api.example.com/data"
 ```
 
 The operator makes a GET request by default and forwards the response as an
-event. The `from_http` operator is an input operator, i.e., it starts a
-pipeline. The companion operator `http` is a transformation, allowing you to
-specify the URL as a field by referencing an event field that contains the URL:
-
-```tql
-from {url: "https://api.example.com/data"}
-http url
-```
-
-This pattern is useful when processing multiple URLs or when URLs are generated
-dynamically. Most of our subsequent examples use `from_http`, as the operator
-options are very similar.
+event.
 
 ### Parsing the HTTP Response Body
 
@@ -150,17 +151,25 @@ API tokens, as in the above example.
 
 ### TLS and Security
 
-Enable TLS by setting the `tls` parameter to `true` and configure client
-certificates using the `certfile` and `keyfile` parameters:
+Configure TLS by passing a record to the `tls` parameter with certificate
+paths:
 
 ```tql
 from_http "https://secure-api.example.com/data",
-  tls=true,
-  certfile="/path/to/client.crt",
-  keyfile="/path/to/client.key"
+  tls={
+    certfile: "/path/to/client.crt",
+    keyfile: "/path/to/client.key",
+  }
 ```
 
 Use these options when APIs require client certificate authentication.
+
+To skip peer verification (e.g., for self-signed certificates in development):
+
+```tql
+from_http "https://dev-api.example.com/data",
+  tls={skip_peer_verification: true}
+```
 
 ### Timeout and Retry Configuration
 
@@ -169,8 +178,8 @@ Configure timeouts and retry behavior by setting the `connection_timeout`,
 
 ```tql
 from_http "https://api.example.com/data",
-  timeout=10s,
-  max_retries=3,
+  connection_timeout=10s,
+  max_retry_count=3,
   retry_delay=2s
 ```
 
@@ -183,62 +192,45 @@ Use HTTP requests to enrich existing data with information from external APIs.
 ### Preserving Input Context
 
 Keep original event data while adding API responses by specifying the
-`response_field` parameter to control where the response is stored:
+`response_field` parameter on the [`http`](/reference/operators/http) operator to
+control where the response is stored:
 
 ```tql
 from {
   domain: "example.com",
   severity: "HIGH",
-  api_url: "https://threat-intel.example.com/lookup",
-  response_field: "threat_data",
 }
-http f"{api_url}?domain={domain}", response_field=response_field
+http f"https://threat-intel.example.com/lookup?domain={domain}",
+  response_field=threat_data
 ```
 
 This approach preserves your original data and adds API responses in a specific
 field.
 
-### Adding Metadata
+### Accessing Response Metadata
 
-Capture HTTP response metadata by specifying the `metadata_field` parameter to
-store status codes and headers separately from the response body:
+With `from_http`, use the `$response` variable inside a parsing pipeline to
+access HTTP status codes and headers:
 
 ```tql
-from_http "https://api.example.com/status", metadata_field=http_meta
+from_http "https://api.example.com/status" {
+  read_json
+  status_code = $response.code
+  server = $response.headers.Server
+}
 ```
 
-The metadata includes status codes and response headers for debugging and
-monitoring.
+With the `http` operator, use the `metadata_field` parameter instead:
+
+```tql
+from {url: "https://api.example.com/status"}
+http url, metadata_field=http_meta
+where http_meta.code >= 200 and http_meta.code < 300
+```
 
 ## Pagination and Bulk Processing
 
 Handle APIs that return large datasets across multiple pages.
-
-### Lambda-Based Pagination
-
-Implement automatic pagination by providing a lambda function to the `paginate`
-parameter that extracts the next page URL from the response:
-
-```tql
-from_http "https://api.example.com/search?q=query",
-  paginate=(response => "next_page_url" if response.has_more)
-```
-
-The operator continues making requests as long as the pagination lambda function
-returns a valid URL.
-
-### Complex Pagination Logic
-
-Handle APIs with custom pagination schemes by building pagination URLs
-dynamically using expressions that reference response data:
-
-```tql
-let $base_url = "https://api.example.com/items"
-from_http f"{$base_url}?page=1",
-  paginate=(x => f"{$base_url}?page={x.page + 1}" if x.page < x.total_pages),
-```
-
-This example builds pagination URLs dynamically based on response data.
 
 ### Link Header Pagination
 
@@ -271,6 +263,31 @@ from {url: "https://api.github.com/repos/tenzir/tenzir/issues?per_page=10"}
 http url, paginate="link"
 ```
 
+### Lambda-Based Pagination
+
+The [`http`](/reference/operators/http) operator additionally supports
+lambda-based pagination for APIs with custom pagination schemes. Provide a
+lambda function to the `paginate` parameter that extracts the next page URL from
+the response:
+
+```tql
+from {query: "tenzir"}
+http f"https://api.example.com/search?q={query}",
+  paginate=(x => x.next_url if x.has_more)
+```
+
+The operator continues making requests as long as the pagination lambda returns
+a valid URL.
+
+You can also build pagination URLs dynamically:
+
+```tql
+let $base = "https://api.example.com/items"
+from {category: "security"}
+http f"{$base}?category={category}&page=1",
+  paginate=(x => f"{$base}?category={category}&page={x.page + 1}" if x.page < x.total_pages)
+```
+
 ### Rate Limiting
 
 Control request frequency by configuring the `paginate_delay` parameter to add
@@ -278,15 +295,11 @@ delays between requests and the `parallel` parameter to limit concurrent
 requests:
 
 ```tql
-from {
-  url: "https://api.example.com/data",
-  paginate_delay: 500ms,
-  parallel: 2
-}
-http url,
-  paginate="next_url" if has_next,
-  paginate_delay=paginate_delay,
-  parallel=parallel
+from {domain: "example.com"}
+http f"https://api.example.com/scan?q={domain}",
+  paginate=(x => x.next_url if x.has_next),
+  paginate_delay=500ms,
+  parallel=2
 ```
 
 Use `paginate_delay` and `parallel` to manage request rates appropriately.
@@ -310,17 +323,17 @@ scenarios.
 Monitor API health and response times:
 
 ```tql
-from_http "https://api.example.com/health", metadata_field=metadata
-select date=metadata.headers.Date.parse_time("%a, %d %b %Y %H:%M:%S %Z")
-latency = now() - date
+from_http "https://api.example.com/health" {
+  read_json
+  date = $response.headers.Date.parse_time("%a, %d %b %Y %H:%M:%S %Z")
+  latency = now() - date
+}
 ```
 
 The above example parses the `Date` header from the HTTP response via
 <Fn>parse_time</Fn> into a timestamp and then
 compares it to the current wallclock time using the
 <Fn>now</Fn> function.
-
-Nit: `%T` is a shortcut for `%H:%M:%S`.
 
 ## Error Handling
 
@@ -334,18 +347,28 @@ between retries:
 
 ```tql
 from_http "https://unreliable-api.example.com/data",
-  max_retries=5,
+  max_retry_count=5,
   retry_delay=2s
 ```
 
 ### Status Code Handling
 
-Check HTTP status codes by capturing metadata and filtering based on the
-`code` field to handle different response types:
+Check HTTP status codes using the `$response` variable to handle different
+response types:
 
 ```tql
-from_http "https://api.example.com/data", metadata_field=metadata
-where metadata.code >= 200 and metadata.code < 300
+from_http "https://api.example.com/data" {
+  read_json
+  where $response.code >= 200 and $response.code < 300
+}
+```
+
+With the `http` operator, use `metadata_field` instead:
+
+```tql
+from {url: "https://api.example.com/data"}
+http url, metadata_field=meta
+where meta.code >= 200 and meta.code < 300
 ```
 
 ## Best Practices
@@ -358,8 +381,9 @@ Follow these practices for reliable and efficient API integration:
    handling transient failures.
 3. **Respect rate limits**. Use `parallel` and `paginate_delay` to control
    request rates.
-4. **Handle errors gracefully**. Check status codes in metadata
-   (`metadata_field`) and implement fallback logic.
+4. **Handle errors gracefully**. Use `$response` in `from_http` parsing
+   pipelines or `metadata_field` with `http` to check status codes and implement
+   fallback logic.
 5. **Secure credentials**. Access API keys and tokens via
    [secrets](/explanations/secrets), not in code.
 6. **Monitor API usage**. Track response times and error rates for

--- a/src/content/docs/guides/routing/expose-data-as-server.mdx
+++ b/src/content/docs/guides/routing/expose-data-as-server.mdx
@@ -1,0 +1,93 @@
+---
+title: Expose data as a server
+---
+
+import Op from '@components/see-also/Op.astro';
+
+This guide shows you how to make pipeline data available to external consumers
+by spinning up servers. You'll learn to stream events over HTTP and configure
+server endpoints for different use cases.
+
+## Spin up an HTTP server
+
+Use [`serve_http`](/reference/operators/serve_http) at the end of a pipeline to
+start an HTTP server that streams events as NDJSON to connected clients:
+
+```tql
+from_file "example.yaml"
+serve_http "0.0.0.0:8080"
+```
+
+Any HTTP client connecting to `http://host:8080/` receives a continuous NDJSON
+stream. Each event is JSON-encoded on a single line, separated by newlines:
+
+```bash
+curl http://localhost:8080/
+```
+
+```json
+{"timestamp":"2025-01-15T10:30:00Z","src_ip":"192.168.1.100","event":"login"}
+{"timestamp":"2025-01-15T10:30:01Z","src_ip":"10.0.0.50","event":"file_access"}
+```
+
+Multiple clients can connect simultaneously — each receives a copy of every
+event.
+
+### Custom path and method
+
+By default, clients connect with a GET request to `/`. Customize both:
+
+```tql
+from_file "alerts.json"
+serve_http "0.0.0.0:9090", path="/alerts", method="post"
+```
+
+Clients must now POST to `/alerts` to receive the stream. Requests to other
+paths return a `404` response.
+
+### Health check endpoints
+
+Production deployments often need health check endpoints for load balancers
+or monitoring. Use the `responses` option to serve static content alongside
+the event stream:
+
+```tql
+subscribe "my-topic"
+serve_http "0.0.0.0:8080",
+  responses={
+    "/health": {code: 200, content_type: "text/plain", body: "ok"},
+    "/ready": {code: 200, content_type: "application/json", body: "{\"status\":\"ready\"}"},
+  }
+```
+
+Clients hitting `/health` or `/ready` get the static response immediately.
+Clients connecting to `/` (the default stream path) receive the event stream.
+
+### Connection limits
+
+Control the maximum number of simultaneous client connections:
+
+```tql
+from_file "data.csv"
+serve_http "0.0.0.0:8080", max_connections=10
+```
+
+Connections beyond the limit are rejected with a `503` response.
+
+### TLS encryption
+
+Serve data over HTTPS by providing TLS certificates:
+
+```tql
+from_file "secret.json"
+serve_http "0.0.0.0:8443",
+  tls={
+    certfile: "/path/to/cert.pem",
+    keyfile: "/path/to/key.pem",
+  }
+```
+
+## See Also
+
+- <Op>serve_http</Op>
+- <Op>to_http</Op>

--- a/src/content/docs/integrations/http.mdx
+++ b/src/content/docs/integrations/http.mdx
@@ -4,47 +4,55 @@ sidebar:
   label: HTTP(S)
 ---
 
-Tenzir supports HTTP and HTTPS, both as sender and receiver.
+[HTTP](https://en.wikipedia.org/wiki/HTTP) is the foundation of data exchange
+on the web. Tenzir provides operators for all sides of an HTTP conversation:
+fetching data from APIs, sending events to webhooks, streaming data to clients,
+and accepting incoming requests.
+
+## Fetching data from APIs
 
 When retrieving data from an API or website, you prepare your HTTP request and
 get back the HTTP response body as your pipeline data:
 
 ![HTTP from](http-from.svg)
 
-When sending data from a pipeline to an API or website, the events in the
-pipeline make up the HTTP request body. If the HTTP status code is not 2\*\*,
-you will get a warning.
+Use [`from_http`](/reference/operators/from_http) to issue a one-shot HTTP
+request, or [`http`](/reference/operators/http) to enrich events flowing through
+a pipeline with HTTP responses. Both operators automatically infer the response
+format from the URL extension or `Content-Type` header.
 
-![HTTP from](http-to.svg)
+See the [Fetch via HTTP and APIs](/guides/collecting/fetch-via-http-and-apis)
+guide for practical examples covering authentication, pagination, error
+handling, and data enrichment.
 
-In both cases, you can only provide static header data.
+## Sending data to webhooks and APIs
 
-Use <Op>from_http</Op> to perform HTTP requests or
-run an HTTP server. This operator automatically tries to infer the format from the
-`Content-Type` header. For sending, use
-<Op>save_http</Op> with a write operator.
+Use [`to_http`](/reference/operators/to_http) to send events as HTTP requests to
+a webhook or API endpoint. Each input event is sent as a separate request, with
+the event JSON-encoded as the body by default. This is useful for pushing alerts
+to webhooks, forwarding events to SIEMs, or calling external APIs for each
+event.
 
-## Examples
+![HTTP to](http-to.svg)
 
-### Perform a GET request with URL parameters
+## Streaming data to HTTP clients
 
-```tql
-from_http "http://example.com:8888/api?query=tenzir"
-```
+Use [`serve_http`](/reference/operators/serve_http) to start an HTTP server that
+streams pipeline events as NDJSON to connected clients. Each client receives a
+copy of every event. This is useful when external systems need to pull data from
+your pipeline over HTTP.
 
-### Perform a POST request with JSON body
+See the [Expose data as a server](/guides/routing/expose-data-as-server) guide
+for practical examples covering health checks, connection limits, and TLS.
 
-```tql
-from_http "http://example.com:8888/api", method="post", body={query: "tenzir"}
-```
+## Accepting incoming requests
 
-### Call a webhook API with pipeline data
+Use [`accept_http`](/reference/operators/accept_http) to spin up an HTTP server
+that turns incoming requests into pipeline events. This is useful for receiving
+webhooks, building custom API endpoints, or ingesting data pushed by external
+systems.
 
-```tql
-from {
-  x: 42,
-  y: "foo",
-}
-write_json
-save_http "http://example.com:8888/api", method="POST"
-```
+## SSL/TLS
+
+All HTTP operators support TLS. Pass `tls={}` to enable TLS with defaults, or
+provide a record with specific options like `certfile` and `keyfile`.

--- a/src/content/docs/reference/operators/accept_http.mdx
+++ b/src/content/docs/reference/operators/accept_http.mdx
@@ -1,0 +1,148 @@
+---
+title: accept_http
+category: Inputs/Events
+example: 'accept_http "0.0.0.0:8080" { read_json }'
+---
+
+import Op from '@components/see-also/Op.astro';
+import Guide from '@components/see-also/Guide.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+Accepts incoming HTTP requests and forwards them as events.
+
+```tql
+accept_http url:string, [responses=record, max_request_size=int,
+            max_connections=int, tls=record]
+            { … }
+```
+
+## Description
+
+The `accept_http` operator starts an HTTP/1.1 server on the given address and
+forwards incoming requests as events. Each request spawns a sub-pipeline that
+processes the request body independently.
+
+The sub-pipeline has access to a `$request` variable containing the request
+metadata.
+
+### `url: string`
+
+The endpoint to listen on. Must have the form `<host>:<port>`. Use `0.0.0.0` to
+accept connections on all interfaces.
+
+### `responses = record (optional)`
+
+Specify custom responses for endpoints on the server. For example,
+
+```tql
+responses = {
+  "/resource/create": { code: 200, content_type: "text/html", body: "Created!" },
+  "/resource/delete": { code: 401, content_type: "text/html", body: "Unauthorized!" }
+}
+```
+
+creates two special routes on the server with different responses.
+
+Each route must be a record with `code`, `content_type`, and `body` fields.
+
+Requests to an unspecified endpoint are responded with HTTP Status `200 OK`.
+
+### `max_request_size = int (optional)`
+
+The maximum size of an incoming request to accept.
+
+Defaults to `10MiB`.
+
+### `max_connections = int (optional)`
+
+The maximum number of simultaneous incoming connections to accept.
+
+Defaults to `10`.
+
+import TLSOptions from '@partials/operators/TLSOptions.mdx';
+
+<TLSOptions tls_default="false"/>
+
+### `{ … }`
+
+The pipeline to run for each incoming HTTP request. Inside the pipeline, the
+`$request` variable is available as a record with the following fields:
+
+| Field      | Type     | Description                          |
+| :--------- | :------- | :----------------------------------- |
+| `headers`  | `record` | The request headers.                 |
+| `query`    | `record` | The query parameters of the request. |
+| `path`     | `string` | The path requested.                  |
+| `fragment` | `string` | The URI fragment of the request.     |
+| `method`   | `string` | The HTTP method of the request.      |
+| `version`  | `string` | The HTTP version of the request.     |
+| `body`     | `blob`   | The raw request body.                |
+
+## Examples
+
+### Accept JSON requests on port 8080
+
+Listen on all interfaces and parse incoming request bodies as JSON:
+
+```tql
+accept_http "0.0.0.0:8080" {
+  read_json
+}
+```
+
+Send a request to the endpoint via `curl`:
+
+```bash
+echo '{"key": "value"}' | curl localhost:8080 --data-binary @- -H 'Content-Type: application/json'
+```
+
+### Filter requests by path
+
+Use the `$request` variable to filter or route requests:
+
+```tql
+accept_http "0.0.0.0:8080" {
+  read_json
+  where $request.path == "/events" and $request.method == "POST"
+}
+```
+
+### Custom responses per endpoint
+
+Return different HTTP responses based on the request path:
+
+```tql
+accept_http "0.0.0.0:8080",
+            responses={
+              "/webhook": {
+                code: 201,
+                content_type: "text/plain",
+                body: "accepted",
+              },
+            } {
+  read_json
+  where $request.path == "/webhook"
+}
+```
+
+### Accept HTTPS requests with TLS
+
+```tql
+accept_http "0.0.0.0:8443",
+            tls={
+              certfile: "/path/to/cert.pem",
+              keyfile: "/path/to/key.pem",
+            } {
+  read_json
+}
+```
+
+## See Also
+
+- <Op>from_http</Op>
+- <Op>http</Op>
+- <Op>to_http</Op>
+- <Op>serve_http</Op>
+- <Op>serve</Op>
+- <Guide>collecting/fetch-via-http-and-apis</Guide>
+- <Integration>http</Integration>

--- a/src/content/docs/reference/operators/accept_http.mdx
+++ b/src/content/docs/reference/operators/accept_http.mdx
@@ -28,7 +28,7 @@ metadata.
 ### `url: string`
 
 The endpoint to listen on. Must have the form `<host>:<port>`. Use `0.0.0.0` to
-accept connections on all interfaces.
+accept connections on all interfaces. IPv6 addresses are not supported.
 
 ### `responses = record (optional)`
 
@@ -49,13 +49,15 @@ Requests to an unspecified endpoint are responded with HTTP Status `200 OK`.
 
 ### `max_request_size = int (optional)`
 
-The maximum size of an incoming request to accept.
+The maximum size of an incoming request to accept. Requests that exceed this
+limit are rejected with HTTP `413 Content Too Large`.
 
 Defaults to `10MiB`.
 
 ### `max_connections = int (optional)`
 
-The maximum number of simultaneous incoming connections to accept.
+The maximum number of simultaneous incoming connections to accept. Connections
+that exceed this limit are rejected with HTTP `503 Service Unavailable`.
 
 Defaults to `10`.
 
@@ -74,7 +76,7 @@ The pipeline to run for each incoming HTTP request. Inside the pipeline, the
 | `query`    | `record` | The query parameters of the request. |
 | `path`     | `string` | The path requested.                  |
 | `fragment` | `string` | The URI fragment of the request.     |
-| `method`   | `string` | The HTTP method of the request.      |
+| `method`   | `string` | The HTTP method of the request (lowercase, e.g. `"post"`). |
 | `version`  | `string` | The HTTP version of the request.     |
 | `body`     | `blob`   | The raw request body.                |
 
@@ -103,7 +105,7 @@ Use the `$request` variable to filter or route requests:
 ```tql
 accept_http "0.0.0.0:8080" {
   read_json
-  where $request.path == "/events" and $request.method == "POST"
+  where $request.path == "/events" and $request.method == "post"
 }
 ```
 

--- a/src/content/docs/reference/operators/accept_http.mdx
+++ b/src/content/docs/reference/operators/accept_http.mdx
@@ -137,6 +137,15 @@ accept_http "0.0.0.0:8443",
 }
 ```
 
+### Capture all request metadata
+
+```tql
+accept_http "0.0.0.0:8443" {
+  read_json
+  metadata = $request
+}
+```
+
 ## See Also
 
 - <Op>from_http</Op>

--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -34,7 +34,11 @@ If neither the URL nor the HTTP headers provide enough information, you can expl
 
 ### `url: string`
 
-URL to connect to.
+URL to connect to. Both `http://` and `https://` schemes are supported. If the
+scheme is omitted, `https://` is assumed.
+
+The URL is resolved as a [secret](/explanations/secrets), so you can pass a
+secret name to avoid hardcoding sensitive URLs.
 
 import HTTPClientOptions from '@partials/operators/HTTPClientOptions.mdx';
 
@@ -51,6 +55,11 @@ skipped and an error is emitted.
 import TLSOptions from '@partials/operators/TLSOptions.mdx';
 
 <TLSOptions tls_default="false"/>
+
+### Migration from `server=true`
+
+The `server=true` flag is no longer supported. Use <Op>accept_http</Op> to
+listen for incoming HTTP requests.
 
 ### `{ … } (optional)`
 

--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -1,25 +1,27 @@
 ---
 title: from_http
 category: Inputs/Events
-example: 'from_http "0.0.0.0:8080"'
+example: 'from_http "https://example.com/api"'
 ---
 
-Sends and receives HTTP/1.1 requests.
+import Op from '@components/see-also/Op.astro';
+import Guide from '@components/see-also/Guide.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+Sends an HTTP/1.1 request and returns the response as events.
 
 ```tql
 from_http url:string, [method=string, body=record|string|blob, encode=string,
-          headers=record, metadata_field=field, error_field=field,
-          paginate=record->string|string, paginate_delay=duration,
-          connection_timeout=duration, max_retry_count=int,
-          retry_delay=duration, tls=record]
-from_http url:string, server=true, [metadata_field=field, responses=record,
-          max_request_size=int, max_connections=int, tls=record]
+          headers=record, error_field=field, paginate=string,
+          paginate_delay=duration, connection_timeout=duration,
+          max_retry_count=int, retry_delay=duration, tls=record]
+          { … }
 ```
 
 ## Description
 
-The `from_http` operator issues HTTP requests or spins up an HTTP/1.1 server on
-a given address and forwards received requests as events.
+The `from_http` operator issues an HTTP request and returns the response as
+events.
 
 :::tip[Format and Compression Inference]
 
@@ -32,76 +34,19 @@ If neither the URL nor the HTTP headers provide enough information, you can expl
 
 ### `url: string`
 
-URL to listen on or to connect to.
-
-Must have the form `<host>:<port>` when `server=true`.
+URL to connect to.
 
 import HTTPClientOptions from '@partials/operators/HTTPClientOptions.mdx';
 
 <HTTPClientOptions />
-
-### `metadata_field = field (optional)`
-
-Field to insert metadata into when using the parsing pipeline.
-
-The response metadata (when using the client mode) has the following schema:
-
-| Field     | Type     | Description                           |
-| :-------- | :------- | :------------------------------------ |
-| `code`    | `uint64` | The HTTP status code of the response. |
-| `headers` | `record` | The response headers.                 |
-
-The request metadata (when using the server mode) has the following schema:
-
-| Field      | Type     | Description                          |
-| :--------- | :------- | :----------------------------------- |
-| `headers`  | `record` | The request headers.                 |
-| `query`    | `record` | The query parameters of the request. |
-| `path`     | `string` | The path requested.                  |
-| `fragment` | `string` | The URI fragment of the request.     |
-| `method`   | `string` | The HTTP method of the request.      |
-| `version`  | `string` | The HTTP version of the request.     |
 
 ### `error_field = field (optional)`
 
 Field to insert the response body for HTTP error responses (status codes not in the 2xx or 3xx range).
 
 When set, any HTTP response with a status code outside the 200–399 range will
-have its body stored in this field as a `blob`. Otherwise, error responses,
-alongside the original event, are skipped and an error is emitted.
-
-### `server = bool (optional)`
-
-Whether to spin up an HTTP server or act as an HTTP client.
-
-Defaults to `false`, i.e., the HTTP client.
-
-### `responses = record (optional)`
-
-Specify custom responses for endpoints on the server. For example,
-
-```tql
-responses = {
-  "/resource/create": { code: 200, content_type: "text/html", body: "Created!" },
-  "/resource/delete": { code: 401, content_type: "text/html", body: "Unauthorized!" }
-}
-```
-
-creates two special routes on the server with different responses.
-
-Requests to an unspecified endpoint are responded with HTTP Status `200 OK`.
-
-### `max_request_size = int (optional)`
-
-The maximum size of an incoming request to accept.
-
-Defaults to `10MiB`.
-
-### `max_connections = int (optional)`
-
-The maximum number of simultaneous incoming connections to accept.
-
-Defaults to `10`.
+have its body stored in this field as a `blob`. Otherwise, error responses are
+skipped and an error is emitted.
 
 import TLSOptions from '@partials/operators/TLSOptions.mdx';
 
@@ -112,6 +57,14 @@ import TLSOptions from '@partials/operators/TLSOptions.mdx';
 A pipeline that receives the response body as bytes, allowing parsing per
 request. This is especially useful in scenarios where the response body can be
 parsed into multiple events.
+
+Inside the pipeline, the `$response` variable is available as a record with the
+following fields:
+
+| Field     | Type     | Description                           |
+| :-------- | :------- | :------------------------------------ |
+| `code`    | `uint64` | The HTTP status code of the response. |
+| `headers` | `record` | The response headers.                 |
 
 If not provided, the operator will attempt to infer the parsing operator from
 the `Content-Type` header. Should this inference fail (e.g., unsupported or
@@ -149,17 +102,26 @@ head 1
 }
 ```
 
-### Paginate with a Lambda
-
-Use the `paginate` parameter with a lambda to extract the next page URL from the
-response body:
+### Send a POST request with JSON body
 
 ```tql
-from_http "https://api.example.com/data", paginate=(x => x.next_url?)
+from_http "https://httpbin.org/post", body={key: "value"}, encode="json" {
+  read_json
+}
 ```
 
-This sends a GET request to the initial URL and evaluates the `x.next_url` field
-in the response to determine the next URL for subsequent requests.
+### Access response metadata
+
+Use the `$response` variable inside a parsing pipeline to access the HTTP
+response code and headers:
+
+```tql
+from_http "https://example.com/api", method="put" {
+  read_json
+  where $response.code == 200
+  response = $response
+}
+```
 
 ### Paginate via Link Headers
 
@@ -185,44 +147,12 @@ from_http "https://api.example.com/data", max_retry_count=3, retry_delay=2s
 
 This tries up to 3 times, waiting 2 seconds between each retry.
 
-### Listen on port 8080
-
-Spin up a server with:
-
-```tql
-from_http "0.0.0.0:8080", server=true, metadata_field=metadata
-```
-
-Send a request to the HTTP endpoint via `curl`:
-
-```sh
-echo '{"key": "value"}' | gzip | curl localhost:8080 --data-binary @- -H 'Content-Encoding: gzip' -H 'Content-Type: application/json'
-```
-
-Observe the request in the Tenzir pipeline, parsed and decompressed:
-
-```tql
-{
-  key: "value",
-  metadata: {
-    headers: {
-      Host: "localhost:8080",
-      "User-Agent": "curl/8.13.0",
-      Accept: "*/*",
-      "Content-Encoding": "gzip",
-      "Content-Length": "37",
-      "Content-Type": "application/json",
-    },
-    path: "/",
-    method: "post",
-    version: "HTTP/1.1",
-  },
-}
-```
-
 ## See Also
 
+- <Op>accept_http</Op>
 - <Op>http</Op>
+- <Op>to_http</Op>
+- <Op>serve_http</Op>
 - <Op>serve</Op>
 - <Guide>collecting/fetch-via-http-and-apis</Guide>
 - <Guide>enrichment/enrich-with-threat-intel</Guide>

--- a/src/content/docs/reference/operators/http.mdx
+++ b/src/content/docs/reference/operators/http.mdx
@@ -193,5 +193,9 @@ header with `rel=next`, such as GitHub, GitLab, and Jira.
 
 ## See Also
 
+- <Op>accept_http</Op>
 - <Op>from_http</Op>
+- <Op>to_http</Op>
+- <Op>serve_http</Op>
 - <Guide>collecting/fetch-via-http-and-apis</Guide>
+- <Guide>routing/expose-data-as-server</Guide>

--- a/src/content/docs/reference/operators/serve_http.mdx
+++ b/src/content/docs/reference/operators/serve_http.mdx
@@ -1,0 +1,132 @@
+---
+title: serve_http
+category: Outputs/Events
+example: 'serve_http "0.0.0.0:8080"'
+---
+
+import Op from '@components/see-also/Op.astro';
+import Guide from '@components/see-also/Guide.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+Starts an HTTP server that streams events as NDJSON to connected clients.
+
+```tql
+serve_http url:string, [path=string, method=string, responses=record,
+           max_connections=int, tls=record]
+```
+
+## Description
+
+The `serve_http` operator starts an HTTP server and streams pipeline events as
+[NDJSON](https://github.com/ndjson/ndjson-spec) to any HTTP client that
+connects. Each connected client receives a copy of every event.
+
+The operator waits for at least one client to connect before delivering data.
+When the pipeline finishes, the server shuts down and all client connections are
+closed.
+
+Clients that connect to a path other than the stream path, or use the wrong HTTP
+method, receive a `404` or `405` response respectively. Use the `responses`
+option to serve static content on additional paths, such as health checks.
+
+### `url: string`
+
+The endpoint to listen on. Must have the form `<host>:<port>`. Use `0.0.0.0` to
+accept connections on all interfaces.
+
+### `path = string (optional)`
+
+The URL path that clients connect to for the event stream.
+
+Defaults to `"/"`.
+
+### `method = string (optional)`
+
+The HTTP method that clients must use to connect to the stream.
+
+Defaults to `"GET"`.
+
+### `responses = record (optional)`
+
+Serve fixed responses on auxiliary paths that are separate from the event stream.
+This is useful for health checks or status endpoints. For example:
+
+```tql
+responses={
+  "/health": {code: 200, content_type: "text/plain", body: "ok"},
+}
+```
+
+Clients hitting `/health` receive the static `body` defined here, while clients
+connecting to the stream path receive the live NDJSON event stream from the
+pipeline.
+
+Each route must be a record with `code`, `content_type`, and `body` fields. The
+stream path itself cannot appear in `responses`.
+
+### `max_connections = int (optional)`
+
+The maximum number of simultaneous client connections to accept.
+
+Defaults to `128`.
+
+import TLSOptions from '@partials/operators/TLSOptions.mdx';
+
+<TLSOptions tls_default="false"/>
+
+## Examples
+
+### Stream events to HTTP clients
+
+Serve events on port 8080. Any HTTP client connecting to `http://host:8080/`
+receives the events as NDJSON:
+
+```tql
+export
+serve_http "0.0.0.0:8080"
+```
+
+Connect with `curl`:
+
+```bash
+curl http://localhost:8080/
+```
+
+### Serve on a custom path and method
+
+Require clients to POST to `/events`:
+
+```tql
+export
+serve_http "0.0.0.0:8080", path="/events", method="post"
+```
+
+### Add a health check endpoint
+
+Expose a health endpoint alongside the event stream:
+
+```tql
+export
+serve_http "0.0.0.0:8080",
+  responses={
+    "/health": {code: 200, content_type: "text/plain", body: "ok"},
+  }
+```
+
+### Serve over HTTPS
+
+```tql
+export
+serve_http "0.0.0.0:8443",
+  tls={
+    certfile: "/path/to/cert.pem",
+    keyfile: "/path/to/key.pem",
+  }
+```
+
+## See Also
+
+- <Op>accept_http</Op>
+- <Op>to_http</Op>
+- <Guide>routing/expose-data-as-server</Guide>
+- <Integration>http</Integration>

--- a/src/content/docs/reference/operators/to_http.mdx
+++ b/src/content/docs/reference/operators/to_http.mdx
@@ -1,0 +1,181 @@
+---
+title: to_http
+category: Outputs/Events
+example: 'to_http "https://example.com/webhook"'
+---
+
+import Op from '@components/see-also/Op.astro';
+import Guide from '@components/see-also/Guide.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+Sends events as HTTP requests to a webhook or API endpoint.
+
+```tql
+to_http url:string, [method=string, body=record|string|blob, encode=string,
+        headers=record, paginate=string, paginate_delay=duration,
+        parallel=int, tls=record, connection_timeout=duration,
+        max_retry_count=int, retry_delay=duration]
+```
+
+## Description
+
+The `to_http` operator sends each input event as an HTTP request to a webhook or
+API endpoint. By default, it JSON-encodes the entire event as the request body
+and sends it as a POST request.
+
+The operator is fire-and-forget: non-success HTTP status codes do not cause
+pipeline errors.
+
+### `url: string`
+
+URL to send the request to. This is an expression evaluated per event, so you
+can use field values to construct the URL dynamically.
+
+### `method = string (optional)`
+
+One of the following HTTP methods to use:
+
+- `get`
+- `head`
+- `post`
+- `put`
+- `del`
+- `connect`
+- `options`
+- `trace`
+
+Defaults to `post`.
+
+### `body = blob|record|string (optional)`
+
+Body to send with the HTTP request.
+
+If the value is a `record`, then the body is encoded according to the `encode`
+option and an appropriate `Content-Type` is set for the request.
+
+If not specified, the entire input event is JSON-encoded as the request body.
+
+### `encode = string (optional)`
+
+Specifies how to encode `record` bodies. Supported values:
+
+- `json`
+- `form`
+
+Defaults to `json`.
+
+### `headers = record (optional)`
+
+Record of headers to send with the request. This is an expression evaluated per
+event, so you can use field values.
+
+### `paginate = string (optional)`
+
+The string `"link"` to automatically follow pagination links in the HTTP `Link`
+response header per
+[RFC 8288](https://datatracker.ietf.org/doc/html/rfc8288). The operator parses
+`Link` headers and follows the `rel=next` relation to fetch the next page.
+Pagination stops when the response no longer contains a `rel=next` link or when
+a non-success status code is received.
+
+### `paginate_delay = duration (optional)`
+
+The duration to wait between consecutive pagination requests.
+
+Defaults to `0s`.
+
+### `parallel = int (optional)`
+
+Maximum number of requests that can be in progress at any time.
+
+Defaults to `1`.
+
+import TLSOptions from '@partials/operators/TLSOptions.mdx';
+
+<TLSOptions tls_default="false"/>
+
+### `connection_timeout = duration (optional)`
+
+Timeout for the connection.
+
+Defaults to `5s`.
+
+### `max_retry_count = int (optional)`
+
+The maximum times to retry a failed request. Every request has its own retry
+count.
+
+Defaults to `0`.
+
+### `retry_delay = duration (optional)`
+
+The duration to wait between each retry.
+
+Defaults to `1s`.
+
+## Examples
+
+### Send events to a webhook
+
+Send each event as a JSON POST request:
+
+```tql
+from {message: "hello", severity: "info"}
+to_http "https://example.com/webhook"
+```
+
+The entire event is JSON-encoded as the request body.
+
+### Use a custom body
+
+Override the default body with a string:
+
+```tql
+from {foo: "bar"}
+to_http "https://example.com/api", body="custom-payload"
+```
+
+### Send form-encoded data
+
+```tql
+from {user: "alice"}
+to_http "https://example.com/api",
+  body={name: "alice", role: "admin"},
+  encode="form"
+```
+
+### Set a custom method and headers
+
+```tql
+from {foo: "bar"}
+to_http "https://example.com/api",
+  method="put",
+  headers={"X-Custom": "value"}
+```
+
+### Send events with TLS
+
+```tql
+from {data: "sensitive"}
+to_http "https://secure.example.com/api",
+  tls={skip_peer_verification: true}
+```
+
+### Send requests in parallel
+
+Increase throughput by sending multiple requests concurrently:
+
+```tql
+load_file "events.json"
+read_json
+to_http "https://example.com/ingest", parallel=4
+```
+
+## See Also
+
+- <Op>from_http</Op>
+- <Op>http</Op>
+- <Op>accept_http</Op>
+- <Op>serve_http</Op>
+- <Guide>collecting/fetch-via-http-and-apis</Guide>
+- <Integration>http</Integration>

--- a/src/partials/operators/HTTPClientOptions.mdx
+++ b/src/partials/operators/HTTPClientOptions.mdx
@@ -31,7 +31,9 @@ Defaults to `json`.
 
 ### `headers = record (optional)`
 
-Record of headers to send with the request.
+Record of headers to send with the request. Each value is resolved as a
+[secret](/explanations/secrets), so you can pass secret names to avoid
+hardcoding tokens or API keys directly in the pipeline.
 
 ### `paginate = record -> string | string (optional)`
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -148,6 +148,7 @@ export const guides = [
         collapsed: true,
         items: [
           "guides/routing/send-to-destinations",
+          "guides/routing/expose-data-as-server",
           "guides/routing/split-and-merge-streams",
           "guides/routing/load-balance-pipelines",
         ],


### PR DESCRIPTION
## Summary

- Add documentation for the new `accept_http` operator (HTTP server that accepts incoming requests as events)
- Update `from_http` documentation to reflect the new client-only design with `$response` pipeline variable (replacing `metadata_field` and `server=true` mode)
- Add `accept_http` cross-reference to the `http` operator's See Also section

## Related PRs

- https://github.com/tenzir/tenzir/pull/5776

## Test plan

- [x] Verify `accept_http.mdx` renders correctly with all sections
- [x] Verify `from_http.mdx` no longer references `server=true` mode
- [x] Verify cross-references resolve between `accept_http`, `from_http`, and `http`

🤖 Generated with [Claude Code](https://claude.com/claude-code)