### PR TITLE
Document Tenzir Gateway CORS and TLS certificate configuration

### DIFF
--- a/src/content/docs/guides/platform-setup/configure-internal-services.mdx
+++ b/src/content/docs/guides/platform-setup/configure-internal-services.mdx
@@ -152,4 +152,22 @@ in the identity provider configuration guide.
 
 ## Tenzir Gateway
 
-The Tenzir Gateway doesn't offer any user-controlled settings at the moment.
+### CORS
+
+When the Tenzir UI frontend connects directly to the Tenzir Gateway from the
+browser—the default when `TENZIR_PLATFORM_USE_INTERNAL_WS_PROXY` is `false`—
+and the UI and gateway are served from different origins (for example, on
+different ports or domains), the browser enforces Cross-Origin Resource Sharing
+(CORS) restrictions. You must explicitly allow the UI's origin by setting
+`CORS_ALLOWED_ORIGINS` on the `websocket-gateway` service in your
+`docker-compose.yaml`:
+
+```yaml
+services:
+  websocket-gateway:
+    environment:
+      - CORS_ALLOWED_ORIGINS=https://app.platform.example:3000
+```
+
+Specify the full origin including scheme and port. Separate multiple allowed
+origins with commas.

--- a/src/content/docs/guides/platform-setup/configure-reverse-proxy.mdx
+++ b/src/content/docs/guides/platform-setup/configure-reverse-proxy.mdx
@@ -157,6 +157,25 @@ services:
       - ./ssl/ca.pem:/ssl/ca.pem
 ```
 
+:::caution[Browser certificate trust for direct gateway connections]
+When the browser connects directly to the gateway (the default when
+`TENZIR_PLATFORM_USE_INTERNAL_WS_PROXY` is `false`) and the gateway uses a
+self-signed certificate, the browser must explicitly trust that certificate.
+Because users do not navigate to the gateway port directly, the browser never
+shows its usual untrusted-certificate warning page. The only visible symptom is
+a vague message such as "Unable to fetch pipelines." The actual cause appears
+only in the browser developer console, where it shows a failed connection to the
+gateway URL.
+
+To resolve this, open the gateway URL directly in your browser (for example,
+`https://nodes.platform.example`) and accept the security exception. After
+accepting the certificate, reload the platform UI.
+
+Alternatively, set `TENZIR_PLATFORM_USE_INTERNAL_WS_PROXY=true` to route
+gateway traffic through the UI backend. The browser then only needs to trust
+the UI certificate, not the gateway certificate.
+:::
+
 #### Platform API
 
 To enable TLS serving for the Platform API, mount the certificate into the


### PR DESCRIPTION
## Summary
This PR adds documentation for two important Tenzir Gateway configuration scenarios that users may encounter when setting up the platform with direct browser-to-gateway connections.

## Key Changes
- **CORS Configuration Guide**: Added documentation for the `CORS_ALLOWED_ORIGINS` environment variable on the `websocket-gateway` service. This explains when CORS restrictions apply (when the UI and gateway are on different origins) and how to properly configure allowed origins with full scheme and port information.

- **TLS Certificate Trust Guide**: Added a caution section explaining the browser certificate trust issue that occurs when using self-signed certificates with direct gateway connections. Includes:
  - Explanation of why the browser doesn't show the typical untrusted certificate warning
  - How to identify the actual problem in browser developer console
  - Two resolution approaches: manually accepting the certificate or using the internal proxy mode

## Notable Details
- Both additions are context-aware, referencing the `TENZIR_PLATFORM_USE_INTERNAL_WS_PROXY` configuration flag to explain when these issues apply
- The CORS documentation includes a concrete YAML example showing proper configuration syntax
- The TLS documentation provides practical troubleshooting steps and alternative solutions

https://claude.ai/code/session_01GgSV84jmGtMoBNGDnYzWse