### PR TITLE
Set a search ranking for page titles

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,7 @@ import {
 } from "./src/sidebar-shared-groups.ts";
 import { generateRedirects } from "./src/utils/redirects.mjs";
 import { rehypeBaseLinks } from "./src/utils/rehype-base-links";
+import { rehypeHeadingWeights } from "./src/utils/rehype-heading-weights";
 import { remarkExcalidrawLinks } from "./src/utils/remark-excalidraw-links";
 import { remarkInlinePartials } from "./src/utils/remark-inline-partials";
 import { remarkSeeAlsoLinks } from "./src/utils/remark-see-also-links";
@@ -156,9 +157,9 @@ export default defineConfig({
         // always.
         ranking: {
           pageLength: 0.1, // default: 0.1
-          termFrequency: 0.1, // default: 0.1
-          termSaturation: 0.1, // default: 2
-          termSimilarity: 9, // default: 9
+          termFrequency: 0, // default: 0.1
+          termSaturation: 2, // default: 2
+          termSimilarity: 0, // default: 9
         },
       },
       plugins: [
@@ -254,6 +255,7 @@ export default defineConfig({
       remarkSeeAlsoLinks,
     ],
     rehypePlugins: [
+      rehypeHeadingWeights,
       [rehypeBaseLinks, { base }],
       [
         rehypeExternalLinks,

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -25,14 +25,18 @@ const weightConfig = getSearchWeight(starlightRoute.id);
 const pagefindType = weightConfig?.metadata?.type;
 const pagefindWeight = weightConfig?.weight;
 
-// Build h1 attributes
+// Build h1 attributes.
+// Always set a weight so title matches outrank body text across all pages.
+// Operator pages get 100, guides 50, uncategorized pages get the base of 10.
+const BASE_H1_WEIGHT = 10;
 const h1Attrs: Record<string, any> = {
   id: PAGE_TITLE_ID,
   "data-pagefind-meta": "title",
+  "data-pagefind-weight":
+    pagefindWeight !== undefined
+      ? pagefindWeight * BASE_H1_WEIGHT
+      : BASE_H1_WEIGHT,
 };
-if (pagefindWeight !== undefined) {
-  h1Attrs["data-pagefind-weight"] = pagefindWeight * 100000;
-}
 
 // Build custom crumbs array with page titles
 interface BreadcrumbItem {

--- a/src/utils/rehype-heading-weights.ts
+++ b/src/utils/rehype-heading-weights.ts
@@ -1,0 +1,31 @@
+import type { Element, Root } from "hast";
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+const HEADING_WEIGHTS: Record<string, number> = {
+  h2: 5,
+  h3: 3,
+  h4: 2,
+};
+
+/**
+ * Rehype plugin that adds data-pagefind-weight to markdown headings so that
+ * keyword matches in headings rank above plain body text in Pagefind search.
+ *
+ * Weight hierarchy (body text defaults to 1):
+ *   h2 → 5, h3 → 3, h4 → 2
+ *
+ * The h1 (page title) is handled separately in PageTitle.astro.
+ */
+export const rehypeHeadingWeights: Plugin<[], Root> = () => {
+  return (tree) => {
+    visit(tree, "element", (node: Element) => {
+      const weight = HEADING_WEIGHTS[node.tagName];
+      if (weight !== undefined) {
+        node.properties["data-pagefind-weight"] = weight;
+      }
+    });
+  };
+};
+
+export default rehypeHeadingWeights;


### PR DESCRIPTION
As an example, consider the search text "measure", which would previously
produce the operator docs for "metrics" as the top result before the
"measure" opertor itself.
