### PR TITLE
Document new ZeroMQ transport operators

### DIFF
--- a/src/content/docs/integrations/zeromq.mdx
+++ b/src/content/docs/integrations/zeromq.mdx
@@ -12,7 +12,7 @@ connect mode.
 
 Use the IP address `0.0.0.0` to listen on all available network interfaces.
 
-The event-oriented ZeroMQ operators are:
+The new executor provides event-oriented ZeroMQ operators:
 
 - <Op>from_zmq</Op>: Connects as a `SUB` socket and receives events.
 - <Op>accept_zmq</Op>: Binds a `SUB` socket and receives events.
@@ -31,14 +31,6 @@ operating before the subscriber. To avoid data loss due to such races, pass
 `monitor=true` on <Op>to_zmq</Op>, <Op>serve_zmq</Op>, or the legacy
 <Op>save_zmq</Op> operator to wait until at least one remote peer has connected
 on TCP transports.
-
-:::tip[URL Support]
-The URL scheme `zmq://` dispatches to
-<Op>from_zmq</Op> and
-<Op>to_zmq</Op> for URL-style use via <Op>from</Op> and <Op>to</Op>.
-Use <Op>accept_zmq</Op> and <Op>serve_zmq</Op> when Tenzir should bind the
-endpoint.
-:::
 
 ## Examples
 

--- a/src/content/docs/integrations/zeromq.mdx
+++ b/src/content/docs/integrations/zeromq.mdx
@@ -5,41 +5,69 @@ title: ZeroMQ
 [ZeroMQ](https://zeromq.org/) (0mq) is a light-weight messaging framework with
 various socket types. Tenzir supports writing to [PUB
 sockets](https://zeromq.org/socket-api/#pub-socket) and reading from [SUB
-sockets](https://zeromq.org/socket-api/#sub-socket), both in server (listening)
-and client (connect) mode.
+sockets](https://zeromq.org/socket-api/#sub-socket), both in bind mode and
+connect mode.
 
 ![ZeroMQ](zeromq.svg)
 
 Use the IP address `0.0.0.0` to listen on all available network interfaces.
 
+The event-oriented ZeroMQ operators are:
+
+- <Op>from_zmq</Op>: Connects as a `SUB` socket and receives events.
+- <Op>accept_zmq</Op>: Binds a `SUB` socket and receives events.
+- <Op>to_zmq</Op>: Connects as a `PUB` socket and sends events.
+- <Op>serve_zmq</Op>: Binds a `PUB` socket and sends events.
+
+Tenzir documents these operators for PUB/SUB-style use. ZeroMQ itself does not
+have a first-class topic abstraction. Instead, Tenzir uses an optional `prefix`
+that is prepended to outgoing messages and matched by subscribers with ZeroMQ's
+native byte-prefix filtering. Receivers strip the matched prefix before running
+their nested `read_*` pipeline unless `keep_prefix=true`.
+
 Because ZeroMQ is entirely asynchronous, publishers send messages even when no
 subscriber is present. This can lead to lost messages when the publisher begins
 operating before the subscriber. To avoid data loss due to such races, pass
-`monitor=true` to activate message buffering until at least one remote peer has
-connected.
+`monitor=true` on <Op>to_zmq</Op>, <Op>serve_zmq</Op>, or the legacy
+<Op>save_zmq</Op> operator to wait until at least one remote peer has connected
+on TCP transports.
 
 :::tip[URL Support]
 The URL scheme `zmq://` dispatches to
-<Op>load_zmq</Op> and
-<Op>save_zmq</Op> for seamless URL-style use via
-<Op>from</Op> and <Op>to</Op>.
+<Op>from_zmq</Op> and
+<Op>to_zmq</Op> for URL-style use via <Op>from</Op> and <Op>to</Op>.
+Use <Op>accept_zmq</Op> and <Op>serve_zmq</Op> when Tenzir should bind the
+endpoint.
 :::
 
 ## Examples
 
-### Accept Syslog messages over ZeroMQ
+### Connect to a remote publisher and parse JSON
 
 ```tql
-from "zmq://127.0.0.1:541" {
-  read_syslog
+from_zmq "tcp://collector.example.com:5555" {
+  read_json
 }
 ```
 
-### Send events to a ZeroMQ socket
+### Receive a prefixed stream
 
 ```tql
-from {message: "Tenzir"}
-to "zmq://1.2.3.4:8080" {
-  write_ndjson
+accept_zmq "tcp://0.0.0.0:5555", prefix="alerts/" {
+  read_ndjson
 }
+```
+
+### Publish events with a dynamic prefix
+
+```tql
+export
+serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"
+```
+
+### Connect and publish JSON
+
+```tql
+export
+to_zmq "tcp://collector.example.com:5555", encoding="json"
 ```

--- a/src/content/docs/integrations/zeromq.mdx
+++ b/src/content/docs/integrations/zeromq.mdx
@@ -12,7 +12,7 @@ connect mode.
 
 Use the IP address `0.0.0.0` to listen on all available network interfaces.
 
-The new executor provides event-oriented ZeroMQ operators:
+The event-oriented ZeroMQ operators are:
 
 - <Op>from_zmq</Op>: Connects as a `SUB` socket and receives events.
 - <Op>accept_zmq</Op>: Binds a `SUB` socket and receives events.

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -359,6 +359,10 @@ operators:
     description: 'Sends and receives HTTP/1.1 requests.'
     example: 'from_http "0.0.0.0:8080"'
     path: 'reference/operators/from_http'
+  - name: 'from_zmq'
+    description: 'Connects to a remote ZeroMQ publisher and receives events.'
+    example: 'from_zmq "tcp://collector.example.com:5555", prefix="alerts/" { read_json }'
+    path: 'reference/operators/from_zmq'
   - name: 'from_stdin'
     description: 'Reads and parses events from standard input.'
     example: 'from_stdin { read_json }'
@@ -631,6 +635,10 @@ operators:
     description: 'Parses an incoming `Zeek TSV` stream into events.'
     example: 'read_zeek_tsv'
     path: 'reference/operators/read_zeek_tsv'
+  - name: 'accept_zmq'
+    description: 'Listens on a ZeroMQ endpoint and receives events.'
+    example: 'accept_zmq "tcp://0.0.0.0:5555", prefix="alerts/" { read_json }'
+    path: 'reference/operators/accept_zmq'
   - name: 'save_amqp'
     description: 'Saves a byte stream via AMQP messages.'
     example: 'save_amqp'
@@ -711,6 +719,10 @@ operators:
     description: 'Sends events to the Microsoft Azure Logs Ingestion API.'
     example: 'to_azure_log_analytics tenant_id="...", workspace_id="..."'
     path: 'reference/operators/to_azure_log_analytics'
+  - name: 'to_zmq'
+    description: 'Connects to a remote ZeroMQ subscriber endpoint and sends events.'
+    example: 'to_zmq "tcp://collector.example.com:5555", encoding="json", prefix=kind + "/"'
+    path: 'reference/operators/to_zmq'
   - name: 'to_clickhouse'
     description: 'Sends events to a ClickHouse table.'
     example: 'to_clickhouse table="my_table"'
@@ -731,6 +743,10 @@ operators:
     description: 'Sends unstructured events to a Google SecOps Chronicle instance.'
     example: 'to_google_secops …'
     path: 'reference/operators/to_google_secops'
+  - name: 'serve_zmq'
+    description: 'Listens on a ZeroMQ endpoint and sends events.'
+    example: 'serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"'
+    path: 'reference/operators/serve_zmq'
   - name: 'to_hive'
     description: 'Writes events to a URI using hive partitioning.'
     example: 'to_hive "s3://…", partition_by=[x]'
@@ -2195,6 +2211,14 @@ from_http "0.0.0.0:8080"
 
 </ReferenceCard>
 
+<ReferenceCard title="from_zmq" description="Connects to a remote ZeroMQ publisher and receives events." href="/reference/operators/from_zmq">
+
+```tql
+from_zmq "tcp://collector.example.com:5555", prefix="alerts/" { read_json }
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="from_stdin" description="Reads and parses events from standard input." href="/reference/operators/from_stdin">
 
 ```tql
@@ -2255,6 +2279,14 @@ from_udp "0.0.0.0:8090"
 
 ```tql
 from_velociraptor subscribe="Windows"
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="accept_zmq" description="Listens on a ZeroMQ endpoint and receives events." href="/reference/operators/accept_zmq">
+
+```tql
+accept_zmq "tcp://0.0.0.0:5555", prefix="alerts/" { read_json }
 ```
 
 </ReferenceCard>
@@ -2509,6 +2541,14 @@ to_azure_log_analytics tenant_id="...", workspace_id="..."
 
 </ReferenceCard>
 
+<ReferenceCard title="to_zmq" description="Connects to a remote ZeroMQ subscriber endpoint and sends events." href="/reference/operators/to_zmq">
+
+```tql
+to_zmq "tcp://collector.example.com:5555", encoding="json", prefix=kind + "/"
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="to_clickhouse" description="Sends events to a ClickHouse table." href="/reference/operators/to_clickhouse">
 
 ```tql
@@ -2545,6 +2585,14 @@ to_google_cloud_pubsub project_id="my-project", topic_id="alerts", message=text
 
 ```tql
 to_google_secops …
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="serve_zmq" description="Listens on a ZeroMQ endpoint and sends events." href="/reference/operators/serve_zmq">
+
+```tql
+serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators/accept_zmq.mdx
+++ b/src/content/docs/reference/operators/accept_zmq.mdx
@@ -1,0 +1,82 @@
+---
+title: accept_zmq
+category: Inputs/Events
+example: 'accept_zmq "tcp://0.0.0.0:5555", prefix="alerts/" { read_json }'
+---
+
+import Op from '@components/see-also/Op.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+Listens on a ZeroMQ endpoint and receives events.
+
+```tql
+accept_zmq endpoint:string, [prefix=string, keep_prefix=bool, { … }]
+```
+
+## Description
+
+Binds a ZeroMQ `SUB` socket to the specified endpoint and receives messages that
+match the configured subscription prefix.
+
+Use `accept_zmq` when Tenzir should own the listening endpoint. This matches the
+naming used by other transport operators such as <Op>accept_tcp</Op>, even
+though ZeroMQ itself calls this binding rather than accepting.
+
+As with <Op>from_zmq</Op>, the `prefix` option uses ZeroMQ's raw subscription
+filtering. When `keep_prefix=false`, the operator strips the matched prefix
+before handing the remaining bytes to the nested pipeline.
+
+### `endpoint: string`
+
+The endpoint to listen on, for example `tcp://0.0.0.0:5555`, `ipc://path`, or
+`inproc://name`.
+
+### `prefix = string (optional)`
+
+A constant subscription prefix to install on the `SUB` socket.
+
+The expression must evaluate to a string before the operator starts receiving
+messages. It cannot depend on event fields.
+
+Defaults to the empty string, which subscribes to all messages.
+
+### `keep_prefix = bool (optional)`
+
+Whether to keep the matched prefix in the bytes that are passed to the nested
+pipeline.
+
+Defaults to `false`.
+
+### `{ … } (optional)`
+
+The pipeline to run for incoming message payloads. It receives bytes and must
+produce events, for example `{ read_json }` or `{ read_syslog }`.
+
+If you omit the nested pipeline, the operator emits one event per message with a
+single field `message` containing the message payload as a `blob`.
+
+## Examples
+
+### Listen for JSON messages
+
+```tql
+accept_zmq "tcp://0.0.0.0:5555" {
+  read_json
+}
+```
+
+### Listen with a subscription prefix
+
+```tql
+accept_zmq "tcp://0.0.0.0:5555", prefix="suricata/" {
+  read_suricata
+}
+```
+
+## See Also
+
+- <Op>from_zmq</Op>
+- <Op>to_zmq</Op>
+- <Op>serve_zmq</Op>
+- <Op>load_zmq</Op>
+- <Integration>zeromq</Integration>

--- a/src/content/docs/reference/operators/from.mdx
+++ b/src/content/docs/reference/operators/from.mdx
@@ -144,14 +144,14 @@ load_tcp "tcp://0.0.0.0:12345", parallel=10 {
 | `ftp`, `ftps`   | <Op>load_ftp</Op>                | `from "ftp://example.com/file.json"`            |
 | `gs`            | <Op>load_gcs</Op>                | `from "gs://bucket/object.json"`                |
 | `http`, `https` | <Op>load_http</Op>               | `from "http://example.com/file.json"`           |
-| `inproc`        | <Op>load_zmq</Op>                | `from "inproc://127.0.0.1:56789" { read_json }` |
+| `inproc`        | <Op>from_zmq</Op>                | `from "inproc://worker", prefix="alerts/" { read_json }` |
 | `kafka`         | <Op>load_kafka</Op>              | `from "kafka://topic" { read_json }`            |
 | `opensearch`    | <Op>from_opensearch</Op>         | `from "opensearch://1.2.3.4:9200`               |
 | `s3`            | <Op>load_s3</Op>                 | `from "s3://bucket/file.json"`                  |
 | `sqs`           | <Op>load_sqs</Op>                | `from "sqs://my-queue" { read_json }`           |
 | `tcp`           | <Op>load_tcp</Op>                | `from "tcp://127.0.0.1:13245" { read_json }`    |
 | `udp`           | <Op>load_udp</Op>                | `from "udp://127.0.0.1:56789" { read_json }`    |
-| `zmq`           | <Op>load_zmq</Op>                | `from "zmq://127.0.0.1:56789" { read_json }`    |
+| `zmq`           | <Op>from_zmq</Op>                | `from "zmq://127.0.0.1:56789", prefix="alerts/" { read_json }` |
 
 Please see the respective operator pages for details on the URI's locator format.
 

--- a/src/content/docs/reference/operators/from.mdx
+++ b/src/content/docs/reference/operators/from.mdx
@@ -144,14 +144,14 @@ load_tcp "tcp://0.0.0.0:12345", parallel=10 {
 | `ftp`, `ftps`   | <Op>load_ftp</Op>                | `from "ftp://example.com/file.json"`            |
 | `gs`            | <Op>load_gcs</Op>                | `from "gs://bucket/object.json"`                |
 | `http`, `https` | <Op>load_http</Op>               | `from "http://example.com/file.json"`           |
-| `inproc`        | <Op>from_zmq</Op>                | `from "inproc://worker", prefix="alerts/" { read_json }` |
+| `inproc`        | <Op>load_zmq</Op>                | `from "inproc://worker" { read_json }`     |
 | `kafka`         | <Op>load_kafka</Op>              | `from "kafka://topic" { read_json }`            |
 | `opensearch`    | <Op>from_opensearch</Op>         | `from "opensearch://1.2.3.4:9200`               |
 | `s3`            | <Op>load_s3</Op>                 | `from "s3://bucket/file.json"`                  |
 | `sqs`           | <Op>load_sqs</Op>                | `from "sqs://my-queue" { read_json }`           |
 | `tcp`           | <Op>load_tcp</Op>                | `from "tcp://127.0.0.1:13245" { read_json }`    |
 | `udp`           | <Op>load_udp</Op>                | `from "udp://127.0.0.1:56789" { read_json }`    |
-| `zmq`           | <Op>from_zmq</Op>                | `from "zmq://127.0.0.1:56789", prefix="alerts/" { read_json }` |
+| `zmq`           | <Op>load_zmq</Op>                | `from "zmq://127.0.0.1:56789" { read_json }` |
 
 Please see the respective operator pages for details on the URI's locator format.
 

--- a/src/content/docs/reference/operators/from_zmq.mdx
+++ b/src/content/docs/reference/operators/from_zmq.mdx
@@ -1,0 +1,93 @@
+---
+title: from_zmq
+category: Inputs/Events
+example: 'from_zmq "tcp://collector.example.com:5555", prefix="alerts/" { read_json }'
+---
+
+import Op from '@components/see-also/Op.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+Connects to a remote ZeroMQ publisher and receives events.
+
+```tql
+from_zmq endpoint:string, [prefix=string, keep_prefix=bool, { … }]
+```
+
+## Description
+
+Connects to the specified ZeroMQ endpoint as a `SUB` socket and receives
+messages that match the configured subscription prefix.
+
+Tenzir documents these operators for PUB/SUB-style use. ZeroMQ itself does not
+have a first-class notion of a topic. Instead, the `prefix` option performs a
+raw prefix match on the incoming message bytes, using ZeroMQ subscription
+filtering at the socket.
+
+When `keep_prefix=false`, the operator strips the matched prefix from the
+message before running the nested pipeline. This lets you combine prefix-based
+routing at the transport layer with regular `read_*` operators inside TQL.
+
+If the connection fails, the operator retries with exponential backoff.
+
+### `endpoint: string`
+
+The remote endpoint to connect to. This is typically a ZeroMQ endpoint such as
+`tcp://host:port`, `ipc://path`, or `inproc://name`.
+
+### `prefix = string (optional)`
+
+A constant subscription prefix to install on the `SUB` socket.
+
+The expression must evaluate to a string before the operator starts receiving
+messages. It cannot depend on event fields.
+
+Defaults to the empty string, which subscribes to all messages.
+
+### `keep_prefix = bool (optional)`
+
+Whether to keep the matched prefix in the bytes that are passed to the nested
+pipeline.
+
+Defaults to `false`.
+
+### `{ … } (optional)`
+
+The pipeline to run for incoming message payloads. It receives bytes and must
+produce events, for example `{ read_json }` or `{ read_syslog }`.
+
+If you omit the nested pipeline, the operator emits one event per message with a
+single field `message` containing the message payload as a `blob`.
+
+## Examples
+
+### Connect to a publisher and parse JSON
+
+```tql
+from_zmq "tcp://collector.example.com:5555" {
+  read_json
+}
+```
+
+### Subscribe to a prefixed stream
+
+```tql
+from_zmq "tcp://collector.example.com:5555", prefix="alerts/" {
+  read_ndjson
+}
+```
+
+### Keep the matched prefix
+
+```tql
+from_zmq "tcp://collector.example.com:5555", prefix="syslog ", keep_prefix=true {
+  read_syslog
+}
+```
+
+## See Also
+
+- <Op>accept_zmq</Op>
+- <Op>to_zmq</Op>
+- <Op>serve_zmq</Op>
+- <Op>load_zmq</Op>
+- <Integration>zeromq</Integration>

--- a/src/content/docs/reference/operators/load_zmq.mdx
+++ b/src/content/docs/reference/operators/load_zmq.mdx
@@ -7,9 +7,10 @@ example: 'load_zmq'
 import Op from '@components/see-also/Op.astro';
 import Integration from '@components/see-also/Integration.astro';
 
-:::caution[Deprecated]
-Use <Op>from_zmq</Op> for connect mode or <Op>accept_zmq</Op> for bind mode
-when you want event-oriented ZeroMQ pipelines.
+:::note[New executor]
+For the new executor, use <Op>from_zmq</Op> for connect mode or
+<Op>accept_zmq</Op> for bind mode when you want event-oriented ZeroMQ
+pipelines.
 :::
 
 Receives ZeroMQ messages.

--- a/src/content/docs/reference/operators/load_zmq.mdx
+++ b/src/content/docs/reference/operators/load_zmq.mdx
@@ -4,6 +4,14 @@ category: Inputs/Bytes
 example: 'load_zmq'
 ---
 
+import Op from '@components/see-also/Op.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+:::caution[Deprecated]
+Use <Op>from_zmq</Op> for connect mode or <Op>accept_zmq</Op> for bind mode
+when you want event-oriented ZeroMQ pipelines.
+:::
+
 Receives ZeroMQ messages.
 
 ```tql
@@ -73,5 +81,7 @@ read_json
 
 ## See Also
 
+- <Op>from_zmq</Op>
+- <Op>accept_zmq</Op>
 - <Op>save_zmq</Op>
 - <Integration>zeromq</Integration>

--- a/src/content/docs/reference/operators/load_zmq.mdx
+++ b/src/content/docs/reference/operators/load_zmq.mdx
@@ -7,8 +7,8 @@ example: 'load_zmq'
 import Op from '@components/see-also/Op.astro';
 import Integration from '@components/see-also/Integration.astro';
 
-:::note[New executor]
-For the new executor, use <Op>from_zmq</Op> for connect mode or
+:::note[Tenzir v6]
+From Tenzir v6 on, use <Op>from_zmq</Op> for connect mode or
 <Op>accept_zmq</Op> for bind mode when you want event-oriented ZeroMQ
 pipelines.
 :::

--- a/src/content/docs/reference/operators/save_zmq.mdx
+++ b/src/content/docs/reference/operators/save_zmq.mdx
@@ -7,9 +7,9 @@ example: 'save_zmq'
 import Op from '@components/see-also/Op.astro';
 import Integration from '@components/see-also/Integration.astro';
 
-:::caution[Deprecated]
-Use <Op>to_zmq</Op> for connect mode or <Op>serve_zmq</Op> for bind mode when
-you want event-oriented ZeroMQ pipelines.
+:::note[New executor]
+For the new executor, use <Op>to_zmq</Op> for connect mode or
+<Op>serve_zmq</Op> for bind mode when you want event-oriented ZeroMQ pipelines.
 :::
 
 Sends bytes as ZeroMQ messages.

--- a/src/content/docs/reference/operators/save_zmq.mdx
+++ b/src/content/docs/reference/operators/save_zmq.mdx
@@ -4,6 +4,14 @@ category: Outputs/Bytes
 example: 'save_zmq'
 ---
 
+import Op from '@components/see-also/Op.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+:::caution[Deprecated]
+Use <Op>to_zmq</Op> for connect mode or <Op>serve_zmq</Op> for bind mode when
+you want event-oriented ZeroMQ pipelines.
+:::
+
 Sends bytes as ZeroMQ messages.
 
 ```tql
@@ -59,5 +67,7 @@ save_zmq connect=true
 
 ## See Also
 
+- <Op>to_zmq</Op>
+- <Op>serve_zmq</Op>
 - <Op>load_zmq</Op>
 - <Integration>zeromq</Integration>

--- a/src/content/docs/reference/operators/save_zmq.mdx
+++ b/src/content/docs/reference/operators/save_zmq.mdx
@@ -7,8 +7,8 @@ example: 'save_zmq'
 import Op from '@components/see-also/Op.astro';
 import Integration from '@components/see-also/Integration.astro';
 
-:::note[New executor]
-For the new executor, use <Op>to_zmq</Op> for connect mode or
+:::note[Tenzir v6]
+From Tenzir v6 on, use <Op>to_zmq</Op> for connect mode or
 <Op>serve_zmq</Op> for bind mode when you want event-oriented ZeroMQ pipelines.
 :::
 

--- a/src/content/docs/reference/operators/serve_zmq.mdx
+++ b/src/content/docs/reference/operators/serve_zmq.mdx
@@ -1,0 +1,76 @@
+---
+title: serve_zmq
+category: Outputs/Events
+example: 'serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"'
+---
+
+import Op from '@components/see-also/Op.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+Listens on a ZeroMQ endpoint and sends events.
+
+```tql
+serve_zmq endpoint:string, encoding=string, [prefix=string, monitor=bool]
+```
+
+## Description
+
+Binds a ZeroMQ `PUB` socket to the specified endpoint and publishes one message
+per input event.
+
+The operator serializes each event with the selected `encoding` and optionally
+prepends a prefix to the serialized bytes before publishing the message. This
+lets subscribers use ZeroMQ's native prefix filtering while keeping the event
+payload available to a `read_*` operator on the receiving side.
+
+Use `serve_zmq` when Tenzir should own the listening endpoint. This mirrors the
+transport-oriented naming used by operators such as <Op>serve_tcp</Op>.
+
+### `endpoint: string`
+
+The endpoint to listen on, for example `tcp://0.0.0.0:5555`, `ipc://path`, or
+`inproc://name`.
+
+### `encoding = string`
+
+The encoding to use when serializing input events into ZeroMQ message payloads.
+
+Use the same format names that you would otherwise select with a `write_*`
+operator, for example `json`, `ndjson`, `csv`, or `yaml`.
+
+### `prefix = string (optional)`
+
+An expression that evaluates to the prefix to prepend to each published
+message.
+
+This expression may depend on event fields. The operator evaluates it for every
+input event.
+
+### `monitor = bool (optional)`
+
+Waits for the first peer connection before publishing messages on TCP
+transports.
+
+## Examples
+
+### Listen and publish JSON
+
+```tql
+export
+serve_zmq "tcp://0.0.0.0:5555", encoding="json"
+```
+
+### Publish with a dynamic prefix
+
+```tql
+export
+serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"
+```
+
+## See Also
+
+- <Op>to_zmq</Op>
+- <Op>from_zmq</Op>
+- <Op>accept_zmq</Op>
+- <Op>save_zmq</Op>
+- <Integration>zeromq</Integration>

--- a/src/content/docs/reference/operators/to.mdx
+++ b/src/content/docs/reference/operators/to.mdx
@@ -91,14 +91,14 @@ If no scheme is present, the connector attempts to save to the local filesystem.
 | `ftp`, `ftps`                      | <Op>save_ftp</Op>                | `to "ftp://example.com/file.json"`             |
 | `gs`                               | <Op>save_gcs</Op>                | `to "gs://bucket/object.json"`                 |
 | `http`, `https`                    | <Op>save_http</Op>               | `to "http://example.com/file.json"`            |
-| `inproc`                           | <Op>to_zmq</Op>                  | `to "inproc://worker", encoding="json", prefix="alerts/"` |
+| `inproc`                           | <Op>save_zmq</Op>                | `to "inproc://worker" { write_json }`       |
 | `kafka`                            | <Op>save_kafka</Op>              | `to "kafka://topic" { write_json }`            |
 | `opensearch`                       | <Op>to_opensearch</Op>           | `to "opensearch://…`                           |
 | `s3`                               | <Op>save_s3</Op>                 | `to "s3://bucket/file.json"`                   |
 | `sqs`                              | <Op>save_sqs</Op>                | `to "sqs://my-queue" { write_json }`           |
 | `tcp`                              | <Op>save_tcp</Op>                | `to "tcp://127.0.0.1:56789" { write_json }`    |
 | `udp`                              | <Op>save_udp</Op>                | `to "udp://127.0.0.1:56789" { write_json }`    |
-| `zmq`                              | <Op>to_zmq</Op>                  | `to "zmq://127.0.0.1:56789", encoding="json", prefix="alerts/"` |
+| `zmq`                              | <Op>save_zmq</Op>                | `to "zmq://127.0.0.1:56789" { write_json }` |
 | `smtp`, `smtps`, `mailto`, `email` | <Op>save_email</Op>              | `to "smtp://john@example.com"`                 |
 
 Please see the respective operator pages for details on the URI's locator format.

--- a/src/content/docs/reference/operators/to.mdx
+++ b/src/content/docs/reference/operators/to.mdx
@@ -91,14 +91,14 @@ If no scheme is present, the connector attempts to save to the local filesystem.
 | `ftp`, `ftps`                      | <Op>save_ftp</Op>                | `to "ftp://example.com/file.json"`             |
 | `gs`                               | <Op>save_gcs</Op>                | `to "gs://bucket/object.json"`                 |
 | `http`, `https`                    | <Op>save_http</Op>               | `to "http://example.com/file.json"`            |
-| `inproc`                           | <Op>save_zmq</Op>                | `to "inproc://127.0.0.1:56789" { write_json }` |
+| `inproc`                           | <Op>to_zmq</Op>                  | `to "inproc://worker", encoding="json", prefix="alerts/"` |
 | `kafka`                            | <Op>save_kafka</Op>              | `to "kafka://topic" { write_json }`            |
 | `opensearch`                       | <Op>to_opensearch</Op>           | `to "opensearch://…`                           |
 | `s3`                               | <Op>save_s3</Op>                 | `to "s3://bucket/file.json"`                   |
 | `sqs`                              | <Op>save_sqs</Op>                | `to "sqs://my-queue" { write_json }`           |
 | `tcp`                              | <Op>save_tcp</Op>                | `to "tcp://127.0.0.1:56789" { write_json }`    |
 | `udp`                              | <Op>save_udp</Op>                | `to "udp://127.0.0.1:56789" { write_json }`    |
-| `zmq`                              | <Op>save_zmq</Op>                | `to "zmq://127.0.0.1:56789" { write_json }`    |
+| `zmq`                              | <Op>to_zmq</Op>                  | `to "zmq://127.0.0.1:56789", encoding="json", prefix="alerts/"` |
 | `smtp`, `smtps`, `mailto`, `email` | <Op>save_email</Op>              | `to "smtp://john@example.com"`                 |
 
 Please see the respective operator pages for details on the URI's locator format.

--- a/src/content/docs/reference/operators/to_zmq.mdx
+++ b/src/content/docs/reference/operators/to_zmq.mdx
@@ -1,0 +1,75 @@
+---
+title: to_zmq
+category: Outputs/Events
+example: 'to_zmq "tcp://collector.example.com:5555", encoding="json", prefix=kind + "/"'
+---
+
+import Op from '@components/see-also/Op.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+Connects to a remote ZeroMQ subscriber endpoint and sends events.
+
+```tql
+to_zmq endpoint:string, encoding=string, [prefix=string, monitor=bool]
+```
+
+## Description
+
+Connects to the specified ZeroMQ endpoint as a `PUB` socket and publishes one
+message per input event.
+
+The operator serializes each event with the selected `encoding` and optionally
+prepends a prefix to the serialized bytes before publishing the message. This
+prefix is intended for PUB/SUB-style routing and matches the `prefix` option of
+<Op>from_zmq</Op> and <Op>accept_zmq</Op>.
+
+If the connection fails, the operator retries with exponential backoff.
+
+### `endpoint: string`
+
+The remote endpoint to connect to. This is typically a ZeroMQ endpoint such as
+`tcp://host:port`, `ipc://path`, or `inproc://name`.
+
+### `encoding = string`
+
+The encoding to use when serializing input events into ZeroMQ message payloads.
+
+Use the same format names that you would otherwise select with a `write_*`
+operator, for example `json`, `ndjson`, `csv`, or `yaml`.
+
+### `prefix = string (optional)`
+
+An expression that evaluates to the prefix to prepend to each published
+message.
+
+Unlike the read-side `prefix`, this expression may depend on event fields. The
+operator evaluates it for every input event.
+
+### `monitor = bool (optional)`
+
+Waits for the first peer connection before publishing messages on TCP
+transports.
+
+## Examples
+
+### Connect and publish JSON
+
+```tql
+export
+to_zmq "tcp://collector.example.com:5555", encoding="json"
+```
+
+### Publish per-event prefixes
+
+```tql
+export
+to_zmq "tcp://collector.example.com:5555", encoding="ndjson", prefix=source + "/"
+```
+
+## See Also
+
+- <Op>serve_zmq</Op>
+- <Op>from_zmq</Op>
+- <Op>accept_zmq</Op>
+- <Op>save_zmq</Op>
+- <Integration>zeromq</Integration>


### PR DESCRIPTION
## 🔍 Problem

- The docs only describe `load_zmq` and `save_zmq`, which models the old byte-oriented API.
- The upcoming executor work introduces event-oriented ZeroMQ operators with separate connect and bind modes.
- The old docs also overstate the role of `monitor` on the read side.

## 🛠️ Solution

- Add reference pages for `from_zmq`, `accept_zmq`, `to_zmq`, and `serve_zmq`.
- Update the ZeroMQ integration page to describe the new executor operators.
- Keep `load_zmq` and `save_zmq` documented as the legacy-executor path instead of marking them deprecated.
- Document `prefix` as the PUB/SUB routing primitive and scope `monitor` to the publishing side.

## 💬 Review

- Check whether the documented split between connect and bind matches the intended TQL surface.
- Check whether `encoding` on write and nested `read_*` pipelines on read are described precisely enough.
- Check that the rollout wording does not imply `load_zmq` and `save_zmq` are deprecated before the new executor becomes the default.

## Functional PRs

- https://github.com/tenzir/tenzir/pull/5999
