### PR TITLE
Document hostname resolution for accept_tcp

### DIFF
--- a/src/content/docs/guides/collecting/get-data-from-the-network.mdx
+++ b/src/content/docs/guides/collecting/get-data-from-the-network.mdx
@@ -23,7 +23,9 @@ accept_tcp "0.0.0.0:9000" {
 ```
 
 This listens on all interfaces (`0.0.0.0`) on port 9000. Specify a parsing
-pipeline to convert incoming bytes to events.
+pipeline to convert incoming bytes to events. Inside the nested pipeline,
+`$peer.ip` and `$peer.port` identify the connecting client. Set
+`resolve_hostnames=true` to also expose `$peer.hostname` from reverse DNS.
 
 ### Connect to a remote server
 

--- a/src/content/docs/integrations/tcp.mdx
+++ b/src/content/docs/integrations/tcp.mdx
@@ -26,7 +26,9 @@ operators reconnect automatically with exponential backoff on connection failure
 
 Use <Op>accept_tcp</Op> to listen on a local endpoint and accept incoming TCP
 connections. Each connection spawns a nested pipeline that processes the
-incoming byte stream independently.
+incoming byte stream independently. Inside that pipeline, `$peer.ip` and
+`$peer.port` describe the connected client. Set `resolve_hostnames=true` to
+also expose `$peer.hostname` from reverse DNS.
 
 ## Serving data to clients
 

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -335,6 +335,10 @@ operators:
     description: 'Shows a snapshot of open sockets.'
     example: 'sockets'
     path: 'reference/operators/sockets'
+  - name: 'accept_tcp'
+    description: 'Accepts incoming TCP or TLS connections and yields events.'
+    example: 'accept_tcp "0.0.0.0:8090" { read_json }'
+    path: 'reference/operators/accept_tcp'
   - name: 'from'
     description: 'Obtains events from an URI, inferring the source, compression and format.'
     example: 'from "data.json"'
@@ -2154,6 +2158,14 @@ load_zmq
 ### Events
 
 <CardGrid>
+
+<ReferenceCard title="accept_tcp" description="Accepts incoming TCP or TLS connections and yields events." href="/reference/operators/accept_tcp">
+
+```tql
+accept_tcp "0.0.0.0:8090" { read_json }
+```
+
+</ReferenceCard>
 
 <ReferenceCard title="from" description="Obtains events from an URI, inferring the source, compression and format." href="/reference/operators/from">
 

--- a/src/content/docs/reference/operators/accept_tcp.mdx
+++ b/src/content/docs/reference/operators/accept_tcp.mdx
@@ -10,7 +10,8 @@ import Integration from '@components/see-also/Integration.astro';
 Listens for incoming TCP or TLS connections and receives events.
 
 ```tql
-accept_tcp endpoint:string, [max_connections=int, tls=record, { … }]
+accept_tcp endpoint:string, [max_connections=int, resolve_hostnames=bool,
+                           tls=record, { … }]
 ```
 
 ## Description
@@ -35,6 +36,16 @@ connections beyond this limit are rejected.
 
 Defaults to `128`.
 
+### `resolve_hostnames = bool (optional)`
+
+Perform reverse DNS lookups for accepted peers and expose the result as
+`$peer.hostname` inside the nested pipeline.
+
+When enabled, the `hostname` field exists on `$peer` and is `null` if no PTR
+record is available. When disabled, the `hostname` field is omitted.
+
+Defaults to `false`.
+
 ### `{ … } (optional)`
 
 The pipeline to run for each individual TCP connection. If none is specified, no
@@ -46,10 +57,11 @@ pipeline that parses the individual connection streams into events, for instance
 Inside the pipeline, the `$peer` variable is available as a record with the
 following fields:
 
-| Field  | Type    | Description                           |
-| :----- | :------ | :------------------------------------ |
-| `ip`   | `ip`    | The IP address of the connected peer  |
-| `port` | `int64` | The port number of the connected peer |
+| Field      | Type    | Description                                                                                                                    |
+| :--------- | :------ | :----------------------------------------------------------------------------------------------------------------------------- |
+| `ip`       | `ip`    | The IP address of the connected peer.                                                                                          |
+| `port`     | `int64` | The port number of the connected peer.                                                                                         |
+| `hostname` | `string` | The reverse-DNS hostname of the connected peer. This field exists only when `resolve_hostnames=true` and is `null` when no hostname is available. |
 
 ## Examples
 
@@ -66,6 +78,15 @@ accept_tcp "0.0.0.0:8090" {
 ```tql
 accept_tcp "0.0.0.0:514" {
   read_syslog
+}
+```
+
+### Enrich events with peer hostnames
+
+```tql
+accept_tcp "0.0.0.0:514", resolve_hostnames=true {
+  read_syslog
+  collector = $peer
 }
 ```
 

--- a/src/content/docs/reference/operators/accept_tcp.mdx
+++ b/src/content/docs/reference/operators/accept_tcp.mdx
@@ -61,7 +61,7 @@ following fields:
 | :--------- | :------ | :----------------------------------------------------------------------------------------------------------------------------- |
 | `ip`       | `ip`    | The IP address of the connected peer.                                                                                          |
 | `port`     | `int64` | The port number of the connected peer.                                                                                         |
-| `hostname` | `string` | The reverse-DNS hostname of the connected peer. This field exists only when `resolve_hostnames=true` and is `null` when no hostname is available. |
+| `hostname` | `string` | The reverse-DNS hostname of the connected peer. |
 
 ## Examples
 

--- a/src/content/docs/reference/operators/accept_tcp.mdx
+++ b/src/content/docs/reference/operators/accept_tcp.mdx
@@ -11,7 +11,7 @@ Listens for incoming TCP or TLS connections and receives events.
 
 ```tql
 accept_tcp endpoint:string, [max_connections=int, resolve_hostnames=bool,
-                           tls=record, { … }]
+                           tls=record { … }]
 ```
 
 ## Description


### PR DESCRIPTION
## 🔍 Problem

- The `accept_tcp` docs did not mention the new peer hostname enrichment.

## 🛠️ Solution

- Document `resolve_hostnames` on `accept_tcp`.
- Describe `$peer.hostname` and the typed `$peer.ip` field.
- Update the TCP integration overview and network collection guide.

## 💬 Review

- Focus on whether the peer metadata semantics are clear and discoverable.

## Functional PRs

- https://github.com/tenzir/tenzir/pull/6017
