### PR TITLE
Document from_nic, read_pcap, and write_pcap

### DIFF
--- a/src/content/docs/guides/collecting/get-data-from-the-network.mdx
+++ b/src/content/docs/guides/collecting/get-data-from-the-network.mdx
@@ -166,16 +166,12 @@ The `community_id` field provides a
 [Community ID](https://github.com/corelight/community-id-spec) hash for
 correlating network flows across different tools.
 
-### Filter captured packets
+### Filter by BPF expression
 
-Filter captured traffic after parsing:
+Use a Berkeley Packet Filter (BPF) expression to drop unwanted traffic before Tenzir parses packets:
 
 ```tql
-from_nic "eth0" {
-  read_pcap
-}
-packet = decapsulate(this)
-where packet.tcp.dst_port? == 443
+from_nic "eth0", filter="tcp port 443"
 ```
 
 ### Read PCAP files

--- a/src/content/docs/guides/collecting/get-data-from-the-network.mdx
+++ b/src/content/docs/guides/collecting/get-data-from-the-network.mdx
@@ -166,15 +166,16 @@ The `community_id` field provides a
 [Community ID](https://github.com/corelight/community-id-spec) hash for
 correlating network flows across different tools.
 
-### Filter by BPF expression
+### Filter captured packets
 
-Apply Berkeley Packet Filter (BPF) expressions to capture only specific
-traffic:
+Filter captured traffic after parsing:
 
 ```tql
-from_nic filter="tcp port 443", "eth0" {
+from_nic "eth0" {
   read_pcap
 }
+packet = decapsulate(this)
+where packet.tcp.dst_port? == 443
 ```
 
 ### Read PCAP files

--- a/src/content/docs/integrations/nic.mdx
+++ b/src/content/docs/integrations/nic.mdx
@@ -8,8 +8,7 @@ Use <Op>from_nic</Op> to capture live packets as events:
 
 ![Packet pipeline](nic.svg)
 
-`from_nic` defaults to <Op>read_pcap</Op>, so live capture works directly in neo
-pipelines without an extra parsing step.
+`from_nic` uses <Op>read_pcap</Op> by default.
 
 ## Examples
 

--- a/src/content/docs/integrations/nic.mdx
+++ b/src/content/docs/integrations/nic.mdx
@@ -2,18 +2,14 @@
 title: Network Interface
 ---
 
-Tenzir supports reading packets from a network interface card (NIC).
+Tenzir supports capturing packets from a network interface card (NIC).
 
-The <Op>load_nic</Op> produces a stream of bytes
-in PCAP file format:
+Use <Op>from_nic</Op> to capture live packets as events:
 
 ![Packet pipeline](nic.svg)
 
-We designed `load_nic` such that it produces a byte stream in the form of a PCAP
-file. That is, when the pipeline starts, it first produces a file header,
-followed by chunks of packets. This creates a byte stream that is
-wire-compatible with the PCAP format, allowing you to exchange `load_nic`
-with <Op>load_file</Op> and It Just Works™.
+`from_nic` defaults to <Op>read_pcap</Op>, so live capture works directly in neo
+pipelines without an extra parsing step.
 
 ## Examples
 
@@ -57,11 +53,10 @@ where up
 
 ### Read packets from a network interface
 
-Load packets from `eth0` and parse them as PCAP:
+Capture packets from `eth0`:
 
 ```tql
-load_nic "eth0"
-read_pcap
+from_nic "eth0"
 head 3
 ```
 
@@ -96,8 +91,7 @@ After you have structured data in the form of PCAP events, you can use the
 binary `data`:
 
 ```tql
-load_nic "eth0"
-read_pcap
+from_nic "eth0"
 select packet = decapsulate(this)
 head 1
 ```

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -379,6 +379,10 @@ operators:
     description: 'Reads events from a MySQL database.'
     example: 'from_mysql table="users", host="db.example.com", database="mydb"'
     path: 'reference/operators/from_mysql'
+  - name: 'from_nic'
+    description: 'Captures packets from a network interface and outputs events.'
+    example: 'from_nic "eth0"'
+    path: 'reference/operators/from_nic'
   - name: 'from_opensearch'
     description: 'Receives events via Opensearch Bulk API.'
     example: 'from_opensearch'
@@ -2245,6 +2249,13 @@ from_mysql table="users", host="db.example.com", database="mydb"
 
 </ReferenceCard>
 
+<ReferenceCard title="from_nic" description="Captures packets from a network interface and outputs events." href="/reference/operators/from_nic">
+
+```tql
+from_nic "eth0"
+```
+
+</ReferenceCard>
 <ReferenceCard title="from_opensearch" description="Receives events via Opensearch Bulk API." href="/reference/operators/from_opensearch">
 
 ```tql

--- a/src/content/docs/reference/operators/from_nic.mdx
+++ b/src/content/docs/reference/operators/from_nic.mdx
@@ -14,8 +14,9 @@ from_nic iface:string, [snaplen=int] { … }
 
 The `from_nic` operator captures packets with libpcap and forwards them as events.
 
-If you omit the optional pipeline, `from_nic` uses <Op>read_pcap</Op> by default.
-Provide a pipeline when you want to change how the captured PCAP byte stream is parsed. The pipeline must accept bytes and return events.
+If you omit the optional pipeline, `from_nic` uses <Op>read_pcap</Op> by default. Provide a pipeline when you want to change how the captured PCAP byte stream is parsed. The pipeline must accept bytes and return events.
+
+To narrow the traffic, filter the resulting packet events in TQL after parsing. `from_nic` does not currently expose a BPF filter argument.
 
 ### `iface: string`
 
@@ -55,6 +56,14 @@ from_nic "en1"
 from_nic "en1" {
   read_pcap emit_file_headers=true
 }
+```
+
+### Filter HTTPS traffic after parsing
+
+```tql
+from_nic "en1"
+packet = decapsulate(this)
+where packet.tcp.dst_port? == 443
 ```
 
 ### Write a live capture to a PCAP file

--- a/src/content/docs/reference/operators/from_nic.mdx
+++ b/src/content/docs/reference/operators/from_nic.mdx
@@ -81,7 +81,6 @@ save_file "trace.pcap"
 ## See Also
 
 - <Op>nics</Op>
-- <Op>load_nic</Op>
 - <Op>read_pcap</Op>
 - <Op>write_pcap</Op>
 - <Integration>nic</Integration>

--- a/src/content/docs/reference/operators/from_nic.mdx
+++ b/src/content/docs/reference/operators/from_nic.mdx
@@ -1,0 +1,74 @@
+---
+title: from_nic
+category: Inputs/Events
+example: 'from_nic "eth0"'
+---
+
+This reference documents the `from_nic` operator. You'll learn how to capture live packets from a network interface in neo pipelines and how to customize packet parsing.
+
+```tql
+from_nic iface:string, [snaplen=int] { … }
+```
+
+## Description
+
+The `from_nic` operator captures packets with libpcap and forwards them as events.
+
+If you omit the optional pipeline, `from_nic` uses <Op>read_pcap</Op> by default.
+Provide a pipeline when you want to change how the captured PCAP byte stream is parsed. The pipeline must accept bytes and return events.
+
+### `iface: string`
+
+The interface to capture packets from.
+
+### `snaplen = int (optional)`
+
+Sets the snapshot length of captured packets.
+
+This value is an upper bound on the packet size. Packets larger than this size get truncated to `snaplen` bytes.
+
+Defaults to `262144`.
+
+### `{ … } (optional)`
+
+An optional parsing pipeline for the captured PCAP byte stream.
+
+When omitted, `from_nic` defaults to:
+
+```tql
+{ read_pcap }
+```
+
+Provide a custom pipeline when you want to adjust parsing behavior, for example to re-emit PCAP file headers.
+
+## Examples
+
+### Capture packets from `en1`
+
+```tql
+from_nic "en1"
+```
+
+### Capture packets and re-emit file headers
+
+```tql
+from_nic "en1" {
+  read_pcap emit_file_headers=true
+}
+```
+
+### Write a live capture to a PCAP file
+
+```tql
+from_nic "en1"
+write_pcap
+save_file "trace.pcap"
+```
+
+## See Also
+
+- <Op>nics</Op>
+- <Op>load_nic</Op>
+- <Op>read_pcap</Op>
+- <Op>write_pcap</Op>
+- <Integration>nic</Integration>

--- a/src/content/docs/reference/operators/from_nic.mdx
+++ b/src/content/docs/reference/operators/from_nic.mdx
@@ -7,7 +7,7 @@ example: 'from_nic "eth0"'
 This reference documents the `from_nic` operator. You'll learn how to capture live packets from a network interface in neo pipelines and how to customize packet parsing.
 
 ```tql
-from_nic iface:string, [snaplen=int] { … }
+from_nic iface:string, [snaplen=int, filter=string] { … }
 ```
 
 ## Description
@@ -16,7 +16,7 @@ The `from_nic` operator captures packets with libpcap and forwards them as event
 
 If you omit the optional pipeline, `from_nic` uses <Op>read_pcap</Op> by default. Provide a pipeline when you want to change how the captured PCAP byte stream is parsed. The pipeline must accept bytes and return events.
 
-To narrow the traffic, filter the resulting packet events in TQL after parsing. `from_nic` does not currently expose a BPF filter argument.
+Use `filter` to apply a Berkeley Packet Filter (BPF) expression before Tenzir parses packets. This lets libpcap drop unwanted traffic early.
 
 ### `iface: string`
 
@@ -29,6 +29,12 @@ Sets the snapshot length of captured packets.
 This value is an upper bound on the packet size. Packets larger than this size get truncated to `snaplen` bytes.
 
 Defaults to `262144`.
+
+### `filter = string (optional)`
+
+Applies a Berkeley Packet Filter (BPF) expression to the capture.
+
+The filter runs in libpcap before Tenzir parses packets. Use the same filter syntax as `tcpdump`, for example `tcp port 443` or `host 10.0.0.1`.
 
 ### `{ … } (optional)`
 
@@ -58,12 +64,10 @@ from_nic "en1" {
 }
 ```
 
-### Filter HTTPS traffic after parsing
+### Capture only HTTPS traffic
 
 ```tql
-from_nic "en1"
-packet = decapsulate(this)
-where packet.tcp.dst_port? == 443
+from_nic "en1", filter="tcp port 443"
 ```
 
 ### Write a live capture to a PCAP file

--- a/src/content/docs/reference/operators/from_nic.mdx
+++ b/src/content/docs/reference/operators/from_nic.mdx
@@ -4,7 +4,7 @@ category: Inputs/Events
 example: 'from_nic "eth0"'
 ---
 
-This reference documents the `from_nic` operator. You'll learn how to capture live packets from a network interface in neo pipelines and how to customize packet parsing.
+Captures packets from a network interface and outputs events.
 
 ```tql
 from_nic iface:string, [snaplen=int, filter=string] { … }

--- a/src/content/docs/reference/operators/load_nic.mdx
+++ b/src/content/docs/reference/operators/load_nic.mdx
@@ -4,7 +4,7 @@ category: Inputs/Bytes
 example: 'load_nic "eth0"'
 ---
 
-This reference documents the `load_nic` operator. You'll learn how to capture raw PCAP bytes from a network interface and when to use <Op>from_nic</Op> instead.
+Captures raw PCAP bytes from a network interface.
 
 [pcap-rfc]: https://datatracker.ietf.org/doc/id/draft-gharris-opsawg-pcap-00.html
 
@@ -18,7 +18,7 @@ The `load_nic` operator uses libpcap to acquire packets from a network interface
 
 The first captured packet also triggers emission of a PCAP file header so downstream operators can treat the packet stream as a valid PCAP capture file.
 
-In neo pipelines, prefer <Op>from_nic</Op> when you want packet events directly. It defaults to <Op>read_pcap</Op> and removes the extra parsing step from the pipeline.
+Use <Op>read_pcap</Op> to parse the emitted PCAP byte stream into packet events.
 
 ### `iface: str`
 

--- a/src/content/docs/reference/operators/load_nic.mdx
+++ b/src/content/docs/reference/operators/load_nic.mdx
@@ -4,7 +4,7 @@ category: Inputs/Bytes
 example: 'load_nic "eth0"'
 ---
 
-Loads bytes from a network interface card (NIC).
+This reference documents the `load_nic` operator. You'll learn how to capture raw PCAP bytes from a network interface and when to use <Op>from_nic</Op> instead.
 
 [pcap-rfc]: https://datatracker.ietf.org/doc/id/draft-gharris-opsawg-pcap-00.html
 
@@ -14,11 +14,11 @@ load_nic iface:str, [snaplen=int, emit_file_headers=bool]
 
 ## Description
 
-The `load_nic` operator uses libpcap to acquire packets from a network interface and
-packs them into blocks of bytes that represent PCAP packet records.
+The `load_nic` operator uses libpcap to acquire packets from a network interface and packs them into blocks of bytes that represent PCAP packet records.
 
-The received first packet triggers also emission of PCAP file header such that
-downstream operators can treat the packet stream as valid PCAP capture file.
+The first captured packet also triggers emission of a PCAP file header so downstream operators can treat the packet stream as a valid PCAP capture file.
+
+In neo pipelines, prefer <Op>from_nic</Op> when you want packet events directly. It defaults to <Op>read_pcap</Op> and removes the extra parsing step from the pipeline.
 
 ### `iface: str`
 
@@ -28,8 +28,7 @@ The interface to load bytes from.
 
 Sets the snapshot length of the captured packets.
 
-This value is an upper bound on the packet size. Packets larger than this size
-get truncated to `snaplen` bytes.
+This value is an upper bound on the packet size. Packets larger than this size get truncated to `snaplen` bytes.
 
 Defaults to `262144`.
 
@@ -37,17 +36,19 @@ Defaults to `262144`.
 
 Creates PCAP file headers for every flushed batch.
 
-The operator emits chunk of bytes that represent a stream of packets.
-When setting `emit_file_headers` every chunk gets its own PCAP file header, as
-opposed to just the very first. This yields a continuous stream of concatenated
-PCAP files.
+The operator emits chunks of bytes that represent a stream of packets. When setting `emit_file_headers`, every chunk gets its own PCAP file header instead of only the very first one. This yields a continuous stream of concatenated PCAP files.
 
-Our <Op>read_pcap</Op> operator can handle such concatenated traces, and
-optionally re-emit thes file headers as separate events.
+Our <Op>read_pcap</Op> operator can handle such concatenated traces and optionally re-emit those file headers as separate events.
 
 ## Examples
 
-### Read PCAP packets from `eth0`
+### Load raw PCAP bytes from `eth0`
+
+```tql
+load_nic "eth0"
+```
+
+### Parse packets from `eth0`
 
 ```tql
 load_nic "eth0"
@@ -58,13 +59,12 @@ read_pcap
 
 ```tql
 load_nic "en0"
-read_pcap
-write_pcap
 save_file "trace.pcap"
 ```
 
 ## See Also
 
+- <Op>from_nic</Op>
 - <Op>nics</Op>
 - <Op>read_pcap</Op>
 - <Op>write_pcap</Op>

--- a/src/content/docs/reference/operators/nics.mdx
+++ b/src/content/docs/reference/operators/nics.mdx
@@ -53,4 +53,4 @@ where status.connected
 
 ## See Also
 
-- <Op>load_nic</Op>
+- <Op>from_nic</Op>

--- a/src/content/docs/reference/operators/read_pcap.mdx
+++ b/src/content/docs/reference/operators/read_pcap.mdx
@@ -4,7 +4,7 @@ category: Parsing
 example: 'read_pcap'
 ---
 
-This reference documents the `read_pcap` operator. You'll learn how to parse PCAP byte streams into packet events and how to preserve file headers for round-tripping.
+Parses PCAP byte streams into packet events.
 
 [pcap-rfc]: https://datatracker.ietf.org/doc/id/draft-gharris-opsawg-pcap-00.html
 

--- a/src/content/docs/reference/operators/read_pcap.mdx
+++ b/src/content/docs/reference/operators/read_pcap.mdx
@@ -83,6 +83,5 @@ from_nic "en1" {
 ## See Also
 
 - <Op>from_nic</Op>
-- <Op>load_nic</Op>
 - <Op>write_pcap</Op>
 - <Fn>decapsulate</Fn>

--- a/src/content/docs/reference/operators/read_pcap.mdx
+++ b/src/content/docs/reference/operators/read_pcap.mdx
@@ -4,7 +4,7 @@ category: Parsing
 example: 'read_pcap'
 ---
 
-Reads raw network packets in PCAP file format.
+This reference documents the `read_pcap` operator. You'll learn how to parse PCAP byte streams into packet events and how to preserve file headers for round-tripping.
 
 [pcap-rfc]: https://datatracker.ietf.org/doc/id/draft-gharris-opsawg-pcap-00.html
 
@@ -14,8 +14,7 @@ read_pcap [emit_file_headers=bool]
 
 ## Description
 
-The `read_pcap` operator converts raw bytes representing a [PCAP][pcap-rfc] file into
-events.
+The `read_pcap` operator converts raw bytes representing a [PCAP][pcap-rfc] file into events.
 
 [pcapng-rfc]: https://www.ietf.org/archive/id/draft-tuexen-opsawg-pcapng-05.html
 
@@ -25,55 +24,65 @@ The current implementation does _not_ support [PCAPNG][pcapng-rfc].
 
 ### `emit_file_headers = bool (optional)`
 
-Emit a `pcap.file_header` event that represents the PCAP file header. If
-present, the parser injects this additional event before the subsequent stream
-of packets.
+Emit a `pcap.file_header` event that represents the PCAP file header. If present, the parser injects this additional event before the subsequent stream of packets.
 
-Emitting this extra event makes it possible to seed the
-<Op>write_pcap</Op> operator with a file header from the input. This
-allows for controlling the timestamp formatting (microseconds vs. nanosecond
-granularity) and byte order in the packet headers.
+Emitting this extra event makes it possible to seed <Op>write_pcap</Op> with a file header from the input. This allows you to preserve timestamp formatting (microseconds vs. nanoseconds) and byte order in packet headers.
 
-When the PCAP parser processes a concatenated stream of PCAP files, specifying
-`emit_file_headers` will also re-emit every intermediate file header as
-separate event.
+When the parser processes a concatenated stream of PCAP files, `emit_file_headers=true` also re-emits every intermediate file header as a separate event.
 
-Use this option when you would like to reproduce the identical trace file layout
-of the PCAP input.
+Use this option when you want to reproduce the original trace layout.
 
 ## Schemas
 
-The operator emits events with the following schema.
+The operator emits events with the following schemas.
+
+### `pcap.file_header`
+
+Contains the global header for one PCAP trace.
+
+| Field           | Type     | Description                                 |
+| :-------------- | :------- | :------------------------------------------ |
+| `magic_number`  | `uint64` | The PCAP magic number.                      |
+| `major_version` | `uint64` | The major PCAP format version.              |
+| `minor_version` | `uint64` | The minor PCAP format version.              |
+| `reserved1`     | `uint64` | Reserved header field.                      |
+| `reserved2`     | `uint64` | Reserved header field.                      |
+| `snaplen`       | `uint64` | The maximum captured packet size.           |
+| `linktype`      | `uint64` | The link-layer type for subsequent packets. |
 
 ### `pcap.packet`
 
-Contains information about all accessed API endpoints, emitted once per second.
+Contains one captured packet from the trace.
 
 | Field                    | Type     | Description                           |
 | :----------------------- | :------- | :------------------------------------ |
-| `timestamp`              | `time`   | The time of capturing the packet.     |
-| `linktype`               | `uint64` | The linktype of the captured packet.  |
+| `timestamp`              | `time`   | The time when the packet was captured. |
+| `linktype`               | `uint64` | The link-layer type of the packet.    |
 | `original_packet_length` | `uint64` | The length of the original packet.    |
 | `captured_packet_length` | `uint64` | The length of the captured packet.    |
-| `data`                   | `blob`   | The captured packet's data as a blob. |
+| `data`                   | `blob`   | The captured packet payload.          |
 
 ## Examples
 
 ### Read packets from a PCAP file
 
 ```tql
-load_file "/tmp/trace.pcap"
-read_pcap
+from_file "/tmp/trace.pcap" {
+  read_pcap
+}
 ```
 
-### Read packets from the [network interface](/reference/operators/load_nic) `eth0`
+### Capture packets from `en1` and preserve file headers
 
 ```tql
-load_nic "eth0"
-read_pcap
+from_nic "en1" {
+  read_pcap emit_file_headers=true
+}
 ```
 
 ## See Also
 
+- <Op>from_nic</Op>
 - <Op>load_nic</Op>
 - <Op>write_pcap</Op>
+- <Fn>decapsulate</Fn>

--- a/src/content/docs/reference/operators/write_pcap.mdx
+++ b/src/content/docs/reference/operators/write_pcap.mdx
@@ -4,7 +4,7 @@ category: Printing
 example: 'write_pcap'
 ---
 
-This reference documents the `write_pcap` operator. You'll learn how to serialize packet events as a PCAP byte stream and how to preserve headers from an existing capture.
+Serializes packet events as a PCAP byte stream.
 
 ```tql
 write_pcap

--- a/src/content/docs/reference/operators/write_pcap.mdx
+++ b/src/content/docs/reference/operators/write_pcap.mdx
@@ -60,5 +60,4 @@ save_file "/tmp/trace-copy.pcap"
 ## See Also
 
 - <Op>from_nic</Op>
-- <Op>load_nic</Op>
 - <Op>read_pcap</Op>

--- a/src/content/docs/reference/operators/write_pcap.mdx
+++ b/src/content/docs/reference/operators/write_pcap.mdx
@@ -4,7 +4,7 @@ category: Printing
 example: 'write_pcap'
 ---
 
-Transforms event stream to PCAP byte stream.
+This reference documents the `write_pcap` operator. You'll learn how to serialize packet events as a PCAP byte stream and how to preserve headers from an existing capture.
 
 ```tql
 write_pcap
@@ -12,9 +12,14 @@ write_pcap
 
 ## Description
 
-Transforms event stream to [PCAP][pcap-rfc] byte stream.
+The `write_pcap` operator transforms packet events into a [PCAP][pcap-rfc] byte stream.
 
 [pcap-rfc]: https://datatracker.ietf.org/doc/id/draft-gharris-opsawg-pcap-00.html
+[pcapng-rfc]: https://www.ietf.org/archive/id/draft-tuexen-opsawg-pcapng-05.html
+
+The operator accepts `pcap.packet` events. When present, it also uses `pcap.file_header` events emitted by <Op>read_pcap</Op> to preserve the original timestamp precision and byte order.
+
+If no `pcap.file_header` event is present, `write_pcap` generates a file header from the first packet's `linktype` and writes timestamps with nanosecond precision.
 
 The structured representation of packets has the `pcap.packet` schema:
 
@@ -22,30 +27,38 @@ The structured representation of packets has the `pcap.packet` schema:
 pcap.packet:
   record:
     - linktype: uint64
-    - time:
-        timestamp: time
+    - timestamp: time
     - captured_packet_length: uint64
     - original_packet_length: uint64
-    - data: string
+    - data: blob
 ```
 
 :::note[PCAPNG]
 The current implementation does _not_ support [PCAPNG][pcapng-rfc].
 :::
 
-[pcapng-rfc]: https://www.ietf.org/archive/id/draft-tuexen-opsawg-pcapng-05.html
-
 ## Examples
 
-### Write packet events as a PCAP file
+### Write a live capture to a PCAP file
 
 ```tql
-subscribe "packets"
+from_nic "en1"
 write_pcap
 save_file "/logs/packets.pcap"
 ```
 
+### Round-trip a PCAP file while preserving its file header
+
+```tql
+from_file "/tmp/trace.pcap" {
+  read_pcap emit_file_headers=true
+}
+write_pcap
+save_file "/tmp/trace-copy.pcap"
+```
+
 ## See Also
 
+- <Op>from_nic</Op>
 - <Op>load_nic</Op>
 - <Op>read_pcap</Op>


### PR DESCRIPTION
## 🔍 Problem

- The docs did not cover `from_nic`.
- Packet-capture docs and examples did not reflect the current workflow.

## 🛠️ Solution

- Add a reference page for `from_nic`.
- Update the `read_pcap`, `write_pcap`, `nics`, and NIC integration docs to center `from_nic`.
- Document BPF filtering for `from_nic` and refresh the operator index.

## 💬 Review

- Please check the operator naming, examples, and cross-links.

## Functional PRs

- https://github.com/tenzir/tenzir/pull/6022
