### PR TITLE
Document `yara` whole-stream semantics

### DIFF
--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -713,7 +713,7 @@ operators:
     path: 'reference/operators/sigma'
   - name: 'yara'
     description: 'Executes YARA rules on byte streams.'
-    example: 'yara "/path/to/rules", blockwise=true'
+    example: 'yara "/path/to/rules"'
     path: 'reference/operators/yara'
   - name: 'to'
     description: 'Saves to an URI, inferring the destination, compression and format.'
@@ -1073,7 +1073,7 @@ sigma "/tmp/rules/"
 <ReferenceCard title="yara" description="Executes YARA rules on byte streams." href="/reference/operators/yara">
 
 ```tql
-yara "/path/to/rules", blockwise=true
+yara "/path/to/rules"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators/yara.md
+++ b/src/content/docs/reference/operators/yara.md
@@ -52,14 +52,16 @@ Enable fast matching mode.
 
 ## Examples
 
-The example below shows how you can apply YARA rules to a finite byte stream.
+The example below shows how you can scan a file with YARA rules.
 
-### Scan a finite byte stream
+### Scan a file
 
-Scan a byte stream with a set of YARA rules:
+Scan a file with a set of YARA rules:
 
 ```tql
-yara "rule.yara"
+from_file "evil.exe" {
+  yara "rule.yara"
+}
 ```
 
 :::note[Chunking and copies]

--- a/src/content/docs/reference/operators/yara.md
+++ b/src/content/docs/reference/operators/yara.md
@@ -8,7 +8,7 @@ This reference documents the `yara` operator. You'll learn how to apply YARA
 rules to a byte stream and what match records it emits.
 
 ```tql
-yara rule:list<string>, [compiled_rules=bool, fast_scan=bool]
+yara rule:string|list<string>, [compiled_rules=bool, fast_scan=bool]
 ```
 
 ## Description
@@ -33,11 +33,11 @@ It buffers the full input in memory and runs the YARA scan when the input ends.
 This lets matches span chunk boundaries, but it also means the operator is only
 suitable for finite byte streams.
 
-### `rule: list<string>`
+### `rule: string | list<string>`
 
-The path to the YARA rule or rules.
+The path to one YARA rule or a list of rule paths.
 
-If the path is a directory, the operator attempts to recursively add all
+If a path is a directory, the operator attempts to recursively add all
 contained files as YARA rules.
 
 ### `compiled_rules = bool (optional)`

--- a/src/content/docs/reference/operators/yara.md
+++ b/src/content/docs/reference/operators/yara.md
@@ -4,8 +4,7 @@ category: Detection
 example: 'yara "/path/to/rules"'
 ---
 
-This reference documents the `yara` operator. You'll learn how to apply YARA
-rules to a byte stream and what match records it emits.
+Executes YARA rules on byte streams.
 
 ```tql
 yara rule:string|list<string>, [compiled_rules=bool, fast_scan=bool]

--- a/src/content/docs/reference/operators/yara.md
+++ b/src/content/docs/reference/operators/yara.md
@@ -59,15 +59,16 @@ The example below shows how you can scan a file with YARA rules.
 Scan a file with a set of YARA rules:
 
 ```tql
-from_file "evil.exe" {
+from_file "evil.exe", mmap=true {
   yara "rule.yara"
 }
 ```
 
-:::note[Chunking and copies]
-If the upstream delivers one contiguous chunk of bytes, `yara` can scan it
-without an extra copy. If the upstream splits the data across multiple chunks,
-`yara` buffers and joins them before scanning.
+:::note[Memory mapping optimization]
+When reading from a local file, `from_file ..., mmap=true` uses `mmap(2)` so
+`yara` can scan one contiguous chunk without an extra copy. Without
+`mmap=true`, `from_file` may deliver multiple chunks; `yara` still works
+because it buffers and joins the full input before scanning.
 :::
 
 :::caution[Finite inputs only]

--- a/src/content/docs/reference/operators/yara.md
+++ b/src/content/docs/reference/operators/yara.md
@@ -52,25 +52,20 @@ Enable fast matching mode.
 
 ## Examples
 
-The examples below show how you can scan a single file and how you can create a
-simple rule scanning service.
+The example below shows how you can apply YARA rules to a finite byte stream.
 
-### Perform one-shot scanning of files
+### Scan a finite byte stream
 
-Scan a file with a set of YARA rules:
+Scan a byte stream with a set of YARA rules:
 
 ```tql
-load_file "evil.exe", mmap=true
 yara "rule.yara"
 ```
 
-:::note[Memory mapping optimization]
-The `mmap` flag is an optimization that constructs a single chunk of bytes
-instead of a stream of byte chunks. Without `mmap=true`,
-[`load_file`](/reference/operators/load_file) produces multiple byte chunks and
-feeds them to the `yara` operator. This still works because `yara` buffers the
-full input in memory before scanning, but `mmap=true` avoids the extra copy and
-usually performs better.
+:::note[Chunking and copies]
+If the upstream delivers one contiguous chunk of bytes, `yara` can scan it
+without an extra copy. If the upstream splits the data across multiple chunks,
+`yara` buffers and joins them before scanning.
 :::
 
 :::caution[Finite inputs only]

--- a/src/content/docs/reference/operators/yara.md
+++ b/src/content/docs/reference/operators/yara.md
@@ -1,60 +1,51 @@
 ---
 title: yara
 category: Detection
-example: 'yara "/path/to/rules", blockwise=true'
+example: 'yara "/path/to/rules"'
 ---
 
-Executes YARA rules on byte streams.
+This reference documents the `yara` operator. You'll learn how to apply YARA
+rules to a byte stream and what match records it emits.
 
 ```tql
-yara rule:list<string>, [blockwise=bool, compiled_rules=bool, fast_scan=bool]
+yara rule:list<string>, [compiled_rules=bool, fast_scan=bool]
 ```
 
 ## Description
 
 The `yara` operator applies [YARA](https://virustotal.github.io/yara/) rules to
-an input of bytes, emitting rule context upon a match.
+an input of bytes and emits rule context for each match.
 
 ![YARA Operator](yara-operator.svg)
 
 We modeled the operator after the official [`yara` command-line
 utility](https://yara.readthedocs.io/en/stable/commandline.html) to enable a
-familiar experience for the command users. Similar to the official `yara`
-command, the operator compiles the rules by default, unless you provide the
-option `compiled_rules=true`. To quote from the above link:
+familiar experience for command-line users. Similar to the official `yara`
+command, the operator compiles the rules by default unless you provide the
+`compiled_rules=true` option. To quote from the above link:
 
 > This is a security measure to prevent users from inadvertently using compiled
 > rules coming from a third-party. Using compiled rules from untrusted sources
 > can lead to the execution of malicious code in your computer.
 
-The operator uses a YARA _scanner_ under the hood that buffers blocks of bytes
-incrementally. Even though the input arrives in non-contiguous blocks of
-memories, the YARA scanner engine support matching across block boundaries. For
-continuously running pipelines, use the `blockwise=true` option that considers each
-block as a separate unit. Otherwise the scanner engine would simply accumulate
-blocks but never trigger a scan.
+The operator scans the entire logical input as one contiguous byte sequence.
+It buffers the full input in memory and runs the YARA scan when the input ends.
+This lets matches span chunk boundaries, but it also means the operator is only
+suitable for finite byte streams.
 
 ### `rule: list<string>`
 
-The path to the YARA rule(s).
+The path to the YARA rule or rules.
 
 If the path is a directory, the operator attempts to recursively add all
 contained files as YARA rules.
-
-### `blockwise = bool (optional)`
-
-Whether to match on every byte chunk instead of triggering a scan when the input
-exhausted.
-
-This option makes sense for never-ending dataflows where each chunk of bytes
-constitutes a self-contained unit, such as a single file.
 
 ### `compiled_rules = bool (optional)`
 
 Whether to interpret the rules as compiled.
 
-When providing this flag, you must exactly provide one rule path as positional
-argument.
+When you provide this flag, you must provide exactly one rule path as the
+positional argument.
 
 ### `fast_scan = bool (optional)`
 
@@ -74,12 +65,18 @@ load_file "evil.exe", mmap=true
 yara "rule.yara"
 ```
 
-:::note[Memory Mapping Optimization]
-The `mmap` flag is merely an optimization that constructs a single chunk of
-bytes instead of a contiguous stream. Without `mmap=true`,
-[`load_file`](/reference/operators/load_file) generates a stream of byte chunks and feeds them
-incrementally to the `yara` operator. This also works, but performance is better
-due to memory locality when using `mmap`.
+:::note[Memory mapping optimization]
+The `mmap` flag is an optimization that constructs a single chunk of bytes
+instead of a stream of byte chunks. Without `mmap=true`,
+[`load_file`](/reference/operators/load_file) produces multiple byte chunks and
+feeds them to the `yara` operator. This still works because `yara` buffers the
+full input in memory before scanning, but `mmap=true` avoids the extra copy and
+usually performs better.
+:::
+
+:::caution[Finite inputs only]
+`yara` waits for the end of input before it emits any matches. Don't use it on
+never-ending byte streams.
 :::
 
 Let's unpack a concrete example:
@@ -142,5 +139,5 @@ You will get one `yara.match` per matching rule:
 }
 ```
 
-Each match has a `rule` field describing the rule and a `matches` record
+Each match has a `rule` field that describes the rule and a `matches` record
 indexed by string identifier to report a list of matches per rule string.


### PR DESCRIPTION
## 🔍 Problem

- The `yara` docs still documented `blockwise=true`.
- The reference page did not explain that `yara` buffers the full input and scans at end of input.
- The argument reference did not say that `yara` accepts either one rule path or a list of rule paths.

## 🛠️ Solution

- Remove `blockwise` from the operator reference and index examples.
- Document whole-stream semantics, in-memory buffering, and the finite-input limitation.
- Document `rule:string|list<string>`.
- Refresh the `load_file` note to match the new behavior.

## 💬 Review

- Focus on whether the page clearly sets expectations for accepted rule argument forms, chunk boundaries, memory use, and end-of-input behavior.

## Functional PRs

- https://github.com/tenzir/tenzir/pull/6035
