### PR TITLE
Document dns_lookup cache behavior

### DIFF
--- a/src/content/docs/reference/operators/dns_lookup.mdx
+++ b/src/content/docs/reference/operators/dns_lookup.mdx
@@ -4,7 +4,7 @@ category: Modify
 example: "dns_lookup ip_address, result=dns_info"
 ---
 
-This reference documents the `dns_lookup` operator. You'll learn how it resolves IP addresses and hostnames, how it stores results, and how cached `ttl` values behave.
+Performs DNS lookups to resolve IP addresses to hostnames or hostnames to IP addresses.
 
 ```tql
 dns_lookup field, [result=field]

--- a/src/content/docs/reference/operators/dns_lookup.mdx
+++ b/src/content/docs/reference/operators/dns_lookup.mdx
@@ -4,7 +4,7 @@ category: Modify
 example: "dns_lookup ip_address, result=dns_info"
 ---
 
-Performs DNS lookups to resolve IP addresses to hostnames or hostnames to IP addresses.
+This reference documents the `dns_lookup` operator. You'll learn how it resolves IP addresses and hostnames, how it stores results, and how cached `ttl` values behave.
 
 ```tql
 dns_lookup field, [result=field]
@@ -21,7 +21,10 @@ reverse lookup (IP to hostname) based on the field's content.
 - **Forward lookup**: When the field contains a string, the operator performs
   A and AAAA queries to find associated IP addresses.
 
-The result is stored as a record in the specified result field.
+The result is stored in the specified result field.
+
+Tenzir caches DNS results and reuses them across lookups. For forward lookups,
+the `ttl` field shows the remaining lifetime of the cached answer.
 
 ### `field: ip|string`
 
@@ -59,7 +62,9 @@ Where each record has the structure:
 }
 ```
 
-If the lookup fails or times out, the result field will be `null`.
+If an individual lookup fails or times out, the result field will be `null`.
+If Tenzir cannot initialize DNS resolution at all, the operator emits an error
+and stops instead of writing `null` results.
 
 ## Examples
 


### PR DESCRIPTION
## 🔍 Problem

- The `dns_lookup` reference does not explain cache reuse.
- The page does not say that cached forward `ttl` values show the remaining lifetime.
- It also implies that every failure becomes `null` output.

## 🛠️ Solution

- Document cache reuse for `dns_lookup`.
- Clarify the meaning of forward lookup `ttl` values.
- Distinguish per-lookup failures from resolver startup failures.

## Functional PRs

- https://github.com/tenzir/tenzir/pull/6034
