### PR TITLE
Document Feather compression options

### DIFF
--- a/src/content/docs/reference/operators/read_feather.mdx
+++ b/src/content/docs/reference/operators/read_feather.mdx
@@ -25,7 +25,7 @@ Transforms the input [Feather] (a thin wrapper around
 ```tql
 load_file "logs.feather"
 read_feather
-pulish "log"
+publish "log"
 ```
 
 ## See Also

--- a/src/content/docs/reference/operators/write_feather.mdx
+++ b/src/content/docs/reference/operators/write_feather.mdx
@@ -27,8 +27,9 @@ Defaults to the compression type's default compression level.
 
 ### `compression_type = str (optional)`
 
-Supported options are `zstd` for [Zstandard][zstd-docs] compression
-and `lz4` for [LZ4 Frame][lz4-docs] compression.
+Supported options are `uncompressed` to disable compression, `zstd` for
+[Zstandard][zstd-docs] compression, and `lz4` for [LZ4 Frame][lz4-docs]
+compression.
 
 [zstd-docs]: http://facebook.github.io/zstd/
 [lz4-docs]: https://android.googlesource.com/platform/external/lz4/+/HEAD/doc/lz4_Frame_format.md


### PR DESCRIPTION
## 🔍 Problem

- The Feather operator docs did not list `compression_type="uncompressed"`.
- The `read_feather` example had a typo.

## 🛠️ Solution

- Document `uncompressed` as a valid `compression_type` for `write_feather`.
- Fix the `publish` example in `read_feather`.

## 💬 Review

- Confirm that the documented options match the current operator behavior.

<sub>
🔗 Code PR: https://github.com/tenzir/tenzir/pull/6045
</sub>
