### PR TITLE
Fix preview links on reference overviews

### DIFF
--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -4,15 +4,11 @@
  * This ensures links work correctly in PR preview deployments with non-root base paths.
  */
 import { LinkButton as StarlightLinkButton } from "@astrojs/starlight/components";
-import { pathWithBase } from "../utils/base";
+import { hrefWithBase } from "../utils/base";
 
 const { href, ...rest } = Astro.props;
 
-// Apply base URL to internal links (starting with / but not //)
-const resolvedHref =
-  typeof href === "string" && href.startsWith("/") && !href.startsWith("//")
-    ? pathWithBase(href)
-    : href;
+const resolvedHref = hrefWithBase(href);
 ---
 
 <StarlightLinkButton href={resolvedHref} {...rest}>

--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -4,7 +4,7 @@ import type { StarlightIcon } from "@astrojs/starlight/components/Icons";
 import type { HTMLAttributes } from "astro/types";
 import { remark } from "remark";
 import remarkHtml from "remark-html";
-import { pathWithBase } from "../utils/base";
+import { hrefWithBase } from "../utils/base";
 
 interface Props extends Omit<HTMLAttributes<"a">, "title"> {
   title: string;
@@ -38,11 +38,7 @@ if (description) {
   renderedDescription = String(result).replace(/^<p>|<\/p>\s*$/g, "");
 }
 
-// Apply base URL to internal links (starting with / but not //)
-const resolvedHref =
-  typeof href === "string" && href.startsWith("/") && !href.startsWith("//")
-    ? pathWithBase(href)
-    : href;
+const resolvedHref = hrefWithBase(href);
 ---
 
 <div class="link-card">

--- a/src/components/ReferenceCard.astro
+++ b/src/components/ReferenceCard.astro
@@ -1,4 +1,6 @@
 ---
+import { hrefWithBase } from "../utils/base";
+
 export interface Props {
   title: string;
   description: string;
@@ -6,14 +8,21 @@ export interface Props {
 }
 
 const { title, description, href } = Astro.props;
+const resolvedHref = hrefWithBase(href);
+
+const isExternalLink = (href: string) =>
+  href.startsWith("//") || /^[a-z][a-z0-9+.-]*:/i.test(href);
 
 // Simple markdown to HTML conversion for inline elements
 function renderMarkdown(text: string): string {
   return text
-    .replace(
-      /\[([^\]]+)\]\(([^)]+)\)/g,
-      '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>',
-    )
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, href) => {
+      const resolvedDescriptionHref = hrefWithBase(href) ?? href;
+      const externalLinkAttrs = isExternalLink(href)
+        ? ' target="_blank" rel="noopener noreferrer"'
+        : "";
+      return `<a href="${resolvedDescriptionHref}"${externalLinkAttrs}>${label}</a>`;
+    })
     .replace(/`([^`]+)`/g, "<code>$1</code>")
     .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
     .replace(/\*([^*]+)\*/g, "<em>$1</em>");
@@ -24,7 +33,7 @@ const renderedDescription = renderMarkdown(description);
 
 <div class="reference-card">
   <div class="reference-card-header">
-    <a href={href} class="reference-card-title-link">
+    <a href={resolvedHref} class="reference-card-title-link">
       <h3 class="reference-card-title">{title}</h3>
     </a>
   </div>

--- a/src/utils/base.ts
+++ b/src/utils/base.ts
@@ -18,3 +18,17 @@ export function pathWithBase(path: NonNullable<string>): string {
   }
   return `${stripTrailingSlash(base)}/${path}`;
 }
+
+/**
+ * Apply Astro's configured base path to internal absolute hrefs.
+ * Leaves external, protocol-relative, anchor, and relative hrefs unchanged.
+ */
+export function hrefWithBase(href: string): string;
+export function hrefWithBase(href: undefined): undefined;
+export function hrefWithBase(href: string | undefined): string | undefined {
+  return typeof href === "string" &&
+    href.startsWith("/") &&
+    !href.startsWith("//")
+    ? pathWithBase(href)
+    : href;
+}


### PR DESCRIPTION
## 🔍 Problem

- Reference overview cards render explicit absolute `href`s.
- In preview deployments under a non-root base path like `/266`, those links ignore Astro's base URL and 404.

## 🛠️ Solution

- Add a shared `hrefWithBase()` helper for internal absolute links.
- Use it in `ReferenceCard` for both card links and inline description links.
- Reuse the same helper in `LinkCard` and `LinkButton` so custom link components resolve URLs consistently.

## 💬 Review

- Focus on whether `hrefWithBase()` handles the right internal-link cases.
- Verified with `bunx biome check` on the touched files and `bun run build -- --base /266`.
