### PR TITLE
Clarify BITZ operator docs

### DIFF
--- a/src/content/docs/guides/parsing/parse-binary-data.mdx
+++ b/src/content/docs/guides/parsing/parse-binary-data.mdx
@@ -4,7 +4,7 @@ title: Parse binary data
 
 This guide shows you how to parse binary data formats into structured events.
 You'll learn to work with columnar formats like Parquet and Feather, packet
-captures in PCAP format, Tenzir's native Bitz format, and compressed data.
+captures in PCAP format, Tenzir's native BITZ format, and compressed data.
 
 The examples use <Op>from_file</Op> with a
 [parsing subpipeline](/reference/programs#parsing-subpipelines) to illustrate
@@ -66,9 +66,9 @@ from_file "capture.pcap" {
 {linktype: 1, timestamp: 2024-01-15T10:30:45.123456Z, captured_packet_length: 74, original_packet_length: 74, data: "ABY88f1tZJ7zvttmCABFAAA8..."}
 ```
 
-Use `from_nic` to parse directly from a live interface. TQL furhter comes with light-weight packet processing functions. For
-example, you can extract protocol headers from raw packet data using the
-<Fn>decapsulate</Fn> function:
+Use <Op>from_nic</Op> to parse directly from a live interface. TQL also
+includes lightweight packet processing functions. For example, you can extract
+protocol headers from raw packet data using the <Fn>decapsulate</Fn> function:
 
 ```tql
 from_file "capture.pcap" {
@@ -81,10 +81,12 @@ packet = decapsulate(this)
 {packet: {ether: {src: "64-9E-F3-BE-DB-66", dst: "00-16-3C-F1-FD-6D", type: 2048}, ip: {src: "192.168.1.100", dst: "10.0.0.1", type: 6}, tcp: {src_port: 54321, dst_port: 443}, community_id: "1:YXWfTYEyYLKVv5Ge4WqijUnKTrM="}}
 ```
 
-## Bitz
+## BITZ
 
-Bitz is Tenzir's native columnar format, optimized for schema-rich security
-data. Use <Op>read_bitz</Op> to parse it:
+BITZ, short for **Bi**nary **T**en**z**ir, is Tenzir's native columnar format,
+optimized for schema-rich security data. Use <Op>read_bitz</Op> to parse it.
+Use <Op>write_bitz</Op> to serialize events into the same format for later
+reuse:
 
 ```tql
 from_file "archive.bitz" {

--- a/src/content/docs/reference/operators/read_bitz.mdx
+++ b/src/content/docs/reference/operators/read_bitz.mdx
@@ -24,9 +24,12 @@ write-once-read-many use cases.
 Internally, BITZ uses Arrow's IPC format for serialization and deserialization,
 but prefixes each message with a 64 bit size prefix to support changing schemas
 between batches—something that Arrow's IPC format does not support on its own.
+Use <Op>write_bitz</Op> to create `.bitz` files that you can later load again
+with <Op>read_bitz</Op>.
 
 ## See Also
 
 - <Op>read_feather</Op>
 - <Op>read_parquet</Op>
 - <Op>write_bitz</Op>
+- <Guide>parsing/parse-binary-data</Guide>

--- a/src/content/docs/reference/operators/write_bitz.mdx
+++ b/src/content/docs/reference/operators/write_bitz.mdx
@@ -24,6 +24,8 @@ write-once-read-many use cases.
 Internally, BITZ uses Arrow's IPC format for serialization and deserialization,
 but prefixes each message with a 64 bit size prefix to support changing schemas
 between batches—something that Arrow's IPC format does not support on its own.
+Use <Op>write_bitz</Op> when you want to persist events in a compact columnar
+format and later load them again with <Op>read_bitz</Op>.
 
 ## See Also
 
@@ -31,3 +33,4 @@ between batches—something that Arrow's IPC format does not support on its own.
 - <Op>to_hive</Op>
 - <Op>write_feather</Op>
 - <Op>write_parquet</Op>
+- <Guide>parsing/parse-binary-data</Guide>


### PR DESCRIPTION
## 🔍 Problem

- The BITZ acronym was not defined in the binary parsing guide.
- The `read_bitz` and `write_bitz` reference pages did not point clearly to each other or back to the guide.

## 🛠️ Solution

- Define BITZ as **Bi**nary **T**en**z**ir in the guide and normalize the capitalization there.
- Add paired guidance between `read_bitz` and `write_bitz`.
- Link both operator reference pages back to the binary parsing guide.
- Replace the naked `from_nic` mention in nearby prose with a semantic operator link.

## 💬 Review

- Please focus on whether the acronym definition and reciprocal cross-links are in the right places.
- I ran `bun run lint:markdown`.

<sub>
🛠️ Code PR: tenzir/tenzir#6050
</sub>
