### PR TITLE
Wait for preview readiness before linking

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -78,11 +78,18 @@ jobs:
               --base "${{ steps.pages.outputs.base_path }}"
           fi
 
-      - name: Save PR number
+      - name: Save PR preview metadata
         if: github.event_name == 'pull_request'
         run: |
           mkdir -p pr
-          echo ${{ github.event.pull_request.number }} > pr/number
+          echo '${{ github.event.pull_request.number }}' > pr/number
+          echo '${{ github.sha }}' > pr/sha
+          cat > dist/__preview.json <<EOF
+          {
+            "pr": ${{ github.event.pull_request.number }},
+            "sha": "${{ github.sha }}"
+          }
+          EOF
 
       - name: Upload PR artifact
         if: github.event_name == 'pull_request'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -83,7 +83,7 @@ jobs:
         run: |
           jq -n \
             --argjson pr '${{ github.event.pull_request.number }}' \
-            --arg sha '${{ github.sha }}' \
+            --arg sha '${{ github.event.pull_request.head.sha }}' \
             '{pr: $pr, sha: $sha}' > dist/__preview.json
 
       - name: Upload PR artifact

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -78,27 +78,20 @@ jobs:
               --base "${{ steps.pages.outputs.base_path }}"
           fi
 
-      - name: Save PR preview metadata
+      - name: Write PR preview marker
         if: github.event_name == 'pull_request'
         run: |
-          mkdir -p pr
-          echo '${{ github.event.pull_request.number }}' > pr/number
-          echo '${{ github.sha }}' > pr/sha
-          cat > dist/__preview.json <<EOF
-          {
-            "pr": ${{ github.event.pull_request.number }},
-            "sha": "${{ github.sha }}"
-          }
-          EOF
+          jq -n \
+            --argjson pr '${{ github.event.pull_request.number }}' \
+            --arg sha '${{ github.sha }}' \
+            '{pr: $pr, sha: $sha}' > dist/__preview.json
 
       - name: Upload PR artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: pr-preview
-          path: |
-            dist
-            pr
+          path: dist
           retention-days: 1
 
       - name: Upload artifact

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -81,6 +81,9 @@ jobs:
       - name: Write PR preview marker
         if: github.event_name == 'pull_request'
         run: |
+          mkdir -p pr
+          printf '%s\n' '${{ github.event.pull_request.number }}' > pr/number
+          printf '%s\n' '${{ github.event.pull_request.head.sha }}' > pr/sha
           jq -n \
             --argjson pr '${{ github.event.pull_request.number }}' \
             --arg sha '${{ github.event.pull_request.head.sha }}' \
@@ -91,7 +94,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pr-preview
-          path: dist
+          path: |
+            dist
+            pr
           retention-days: 1
 
       - name: Upload artifact

--- a/.github/workflows/pr-preview-deploy.yaml
+++ b/.github/workflows/pr-preview-deploy.yaml
@@ -28,7 +28,6 @@ jobs:
           name: pr-preview
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
-          path: dist
 
       - name: Read preview metadata
         id: preview

--- a/.github/workflows/pr-preview-deploy.yaml
+++ b/.github/workflows/pr-preview-deploy.yaml
@@ -26,10 +26,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Read PR number
-        id: pr
+      - name: Read preview metadata
+        id: preview
         run: |
-          echo "number=$(cat pr/number)" >> "$GITHUB_OUTPUT"
+          number=$(cat pr/number)
+          sha=$(cat pr/sha)
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "url=https://preview.docs.tenzir.com/$number" >> "$GITHUB_OUTPUT"
+          echo "status_url=https://preview.docs.tenzir.com/$number/__preview.json" >> "$GITHUB_OUTPUT"
 
       - name: Generate app token
         id: app-token
@@ -39,32 +44,24 @@ jobs:
           private-key: ${{ secrets.TENZIR_GITHUB_APP_PRIVATE_KEY }}
           repositories: docs-previews
 
-      - name: Deploy PR Preview
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          repository-name: tenzir/docs-previews
-          folder: dist
-          target-folder: ${{ steps.pr.outputs.number }}
-          branch: gh-pages
-          clean: false
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Comment PR
+      - name: Comment PR as deploying
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.preview.outputs.number }}
         with:
           script: |
-            const url = 'https://preview.docs.tenzir.com/${{ steps.pr.outputs.number }}';
+            const prNumber = Number(process.env.PR_NUMBER);
             const comment = [
               '<!-- docs-preview -->',
-              `📦 **Preview** &nbsp;·&nbsp; [View →](${url}) &nbsp;·&nbsp; 🟢 Live`,
+              '📦 **Preview** &nbsp;·&nbsp; ⏳ Deploying',
               '',
-              '<sub>Auto-updates on push</sub>'
+              '<sub>The link appears once the preview URL serves this build.</sub>'
             ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ steps.pr.outputs.number }},
+              issue_number: prNumber,
             });
 
             const botComment = comments.find(c =>
@@ -76,13 +73,136 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: botComment.id,
-                body: comment
+                body: comment,
               });
             } else {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: ${{ steps.pr.outputs.number }},
-                body: comment
+                issue_number: prNumber,
+                body: comment,
+              });
+            }
+
+      - name: Deploy PR Preview
+        id: deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          repository-name: tenzir/docs-previews
+          folder: dist
+          target-folder: ${{ steps.preview.outputs.number }}
+          branch: gh-pages
+          clean: false
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Wait for preview readiness
+        id: readiness
+        if: steps.deploy.conclusion == 'success'
+        uses: actions/github-script@v7
+        env:
+          STATUS_URL: ${{ steps.preview.outputs.status_url }}
+          EXPECTED_SHA: ${{ steps.preview.outputs.sha }}
+          TIMEOUT_SECONDS: "180"
+          POLL_INTERVAL_SECONDS: "5"
+        with:
+          script: |
+            const statusUrl = process.env.STATUS_URL;
+            const expectedSha = process.env.EXPECTED_SHA;
+            const timeoutMs = Number(process.env.TIMEOUT_SECONDS) * 1000;
+            const intervalMs = Number(process.env.POLL_INTERVAL_SECONDS) * 1000;
+            const deadline = Date.now() + timeoutMs;
+            let lastReason = 'no response yet';
+
+            while (Date.now() < deadline) {
+              try {
+                const probeUrl = `${statusUrl}?t=${Date.now()}`;
+                const response = await fetch(probeUrl, {
+                  headers: {
+                    'cache-control': 'no-cache',
+                    pragma: 'no-cache',
+                  },
+                });
+                if (response.ok) {
+                  const payload = await response.json();
+                  if (payload?.sha === expectedSha) {
+                    core.setOutput('state', 'live');
+                    core.setOutput('reason', '');
+                    return;
+                  }
+                  lastReason = `served ${payload?.sha ?? 'unknown sha'} instead of ${expectedSha}`;
+                } else {
+                  lastReason = `HTTP ${response.status}`;
+                }
+              } catch (error) {
+                lastReason = error instanceof Error ? error.message : String(error);
+              }
+              await new Promise((resolve) => setTimeout(resolve, intervalMs));
+            }
+
+            core.setOutput('state', 'delayed');
+            core.setOutput('reason', lastReason);
+
+      - name: Comment PR with preview status
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.preview.outputs.number }}
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
+          PREVIEW_SHA: ${{ steps.preview.outputs.sha }}
+          PREVIEW_STATE: ${{ steps.deploy.conclusion == 'success' && steps.readiness.outputs.state || 'failed' }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const url = process.env.PREVIEW_URL;
+            const sha = process.env.PREVIEW_SHA.slice(0, 7);
+            const state = process.env.PREVIEW_STATE;
+
+            let comment;
+            if (state === 'live') {
+              comment = [
+                '<!-- docs-preview -->',
+                `📦 **Preview** &nbsp;·&nbsp; [View →](${url}) &nbsp;·&nbsp; 🟢 Live`,
+                '',
+                `<sub>Verified for \`${sha}\` &nbsp;·&nbsp; Auto-updates on push</sub>`
+              ].join('\n');
+            } else if (state === 'delayed') {
+              comment = [
+                '<!-- docs-preview -->',
+                '📦 **Preview** &nbsp;·&nbsp; 🟠 Still propagating',
+                '',
+                `<sub>The deploy completed, but the public URL has not served build \`${sha}\` yet. Check again in a minute.</sub>`
+              ].join('\n');
+            } else {
+              comment = [
+                '<!-- docs-preview -->',
+                '📦 **Preview** &nbsp;·&nbsp; 🔴 Deploy failed',
+                '',
+                '<sub>See the Deploy Preview workflow logs for details.</sub>'
+              ].join('\n');
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('<!-- docs-preview -->')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: comment,
               });
             }

--- a/.github/workflows/pr-preview-deploy.yaml
+++ b/.github/workflows/pr-preview-deploy.yaml
@@ -15,6 +15,9 @@ jobs:
     name: Deploy PR Preview
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    concurrency:
+      group: preview-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,13 +31,21 @@ jobs:
 
       - name: Read preview metadata
         id: preview
+        env:
+          PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          number=$(cat pr/number)
-          sha=$(cat pr/sha)
-          echo "number=$number" >> "$GITHUB_OUTPUT"
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "url=https://preview.docs.tenzir.com/$number" >> "$GITHUB_OUTPUT"
-          echo "status_url=https://preview.docs.tenzir.com/$number/__preview.json" >> "$GITHUB_OUTPUT"
+          number=$(jq -r '.[0].number // empty' <<<"$PULL_REQUESTS")
+          if [[ -z "$number" ]]; then
+            echo "No PR associated with workflow run"
+            exit 1
+          fi
+          {
+            echo "number=$number"
+            echo "sha=$HEAD_SHA"
+            echo "url=https://preview.docs.tenzir.com/$number"
+            echo "status_url=https://preview.docs.tenzir.com/$number/__preview.json"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate app token
         id: app-token
@@ -111,7 +122,7 @@ jobs:
             const timeoutMs = Number(process.env.TIMEOUT_SECONDS) * 1000;
             const intervalMs = Number(process.env.POLL_INTERVAL_SECONDS) * 1000;
             const deadline = Date.now() + timeoutMs;
-            let lastReason = 'no response yet';
+            let lastStatus = 'no response yet';
 
             while (Date.now() < deadline) {
               try {
@@ -125,25 +136,53 @@ jobs:
                 if (response.ok) {
                   const payload = await response.json();
                   if (payload?.sha === expectedSha) {
+                    core.info(`Preview is live for ${expectedSha}`);
                     core.setOutput('state', 'live');
-                    core.setOutput('reason', '');
                     return;
                   }
-                  lastReason = `served ${payload?.sha ?? 'unknown sha'} instead of ${expectedSha}`;
+                  lastStatus = `served ${payload?.sha ?? 'unknown sha'} instead of ${expectedSha}`;
                 } else {
-                  lastReason = `HTTP ${response.status}`;
+                  lastStatus = `HTTP ${response.status}`;
                 }
               } catch (error) {
-                lastReason = error instanceof Error ? error.message : String(error);
+                lastStatus = error instanceof Error ? error.message : String(error);
               }
+
+              core.info(`Preview not ready yet: ${lastStatus}`);
               await new Promise((resolve) => setTimeout(resolve, intervalMs));
             }
 
+            core.warning(`Preview did not become ready within ${timeoutMs / 1000}s: ${lastStatus}`);
             core.setOutput('state', 'delayed');
-            core.setOutput('reason', lastReason);
+
+      - name: Check if preview run is still current
+        id: current
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.preview.outputs.number }}
+          EXPECTED_SHA: ${{ steps.preview.outputs.sha }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const expectedSha = process.env.EXPECTED_SHA;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const currentSha = pr.head.sha;
+            const isCurrent = currentSha === expectedSha;
+
+            core.setOutput('is_current', isCurrent ? 'true' : 'false');
+            if (!isCurrent) {
+              core.notice(
+                `Skipping final preview status update for superseded build ${expectedSha.slice(0, 7)}; PR head is ${currentSha.slice(0, 7)}.`
+              );
+            }
 
       - name: Comment PR with preview status
-        if: always()
+        if: always() && steps.current.outputs.is_current == 'true'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.preview.outputs.number }}

--- a/.github/workflows/pr-preview-deploy.yaml
+++ b/.github/workflows/pr-preview-deploy.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     concurrency:
-      group: preview-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+      group: preview-${{ github.event.workflow_run.pull_requests[0].number || format('{0}-{1}', github.event.workflow_run.head_repository.id, github.event.workflow_run.head_branch) || github.event.workflow_run.id }}
       cancel-in-progress: true
     steps:
       - name: Checkout repository
@@ -28,21 +28,24 @@ jobs:
           name: pr-preview
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
+          path: dist
 
       - name: Read preview metadata
         id: preview
-        env:
-          PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          number=$(jq -r '.[0].number // empty' <<<"$PULL_REQUESTS")
-          if [[ -z "$number" ]]; then
-            echo "No PR associated with workflow run"
+          if [[ ! -f dist/__preview.json ]]; then
+            echo "Missing preview metadata file dist/__preview.json"
+            exit 1
+          fi
+          number=$(jq -r '.pr // empty' dist/__preview.json)
+          sha=$(jq -r '.sha // empty' dist/__preview.json)
+          if [[ -z "$number" || -z "$sha" ]]; then
+            echo "Missing preview metadata in dist/__preview.json"
             exit 1
           fi
           {
             echo "number=$number"
-            echo "sha=$HEAD_SHA"
+            echo "sha=$sha"
             echo "url=https://preview.docs.tenzir.com/$number"
             echo "status_url=https://preview.docs.tenzir.com/$number/__preview.json"
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 🔍 Problem

- The preview bot comments a public preview URL as soon as the deploy repo accepts the artifact.
- The CDN can still be propagating at that point, so the linked URL may 404 or serve an older build.

## 🛠️ Solution

- Emit PR preview metadata during the build, including a small `__preview.json` marker with the built SHA.
- Change the preview comment flow to:
  - post `⏳ Deploying` first
  - deploy the preview
  - poll the public preview URL until it serves the expected SHA
  - only then update the comment to `🟢 Live`
- Fall back to `🟠 Still propagating` or `🔴 Deploy failed` when the URL is not ready yet.

## 💬 Review

- Focus on the readiness handshake between `docs.yaml` and `pr-preview-deploy.yaml`.
- Verified by parsing both workflow YAML files and running Prettier on them.
