### PR TITLE
Document unsigned integer indexing

### DIFF
--- a/src/content/docs/reference/expressions.mdx
+++ b/src/content/docs/reference/expressions.mdx
@@ -359,8 +359,9 @@ let $ports = [80, 443, 8080]
 let $mixed = [1, 2+3, foo()]  // Can contain expressions
 ```
 
-Lists support indexing with `[]` and membership testing with `in`, with negative
-indices counting from the end of the list (`-1` refers to the last element):
+Lists support indexing with signed or unsigned integer indices and membership
+testing with `in`. Negative signed indices count from the end of the list (`-1`
+refers to the last element):
 
 ```tql
 let $items = [10, 20, 30]
@@ -594,7 +595,8 @@ Both lists and records support indexing operations to access their elements.
 
 #### List Indexing
 
-Access list elements using integral indices, starting with `0`:
+Access list elements using signed or unsigned integer indices, starting with
+`0`:
 
 ```tql
 let $my_list = ["Hello", "World"]
@@ -628,8 +630,8 @@ from {
 level = $severity_to_level[severity]  // Dynamic field access
 ```
 
-Indexing expressions (see next section below) support numeric indices for
-records:
+Indexing expressions (see next section below) support signed and unsigned
+integer indices for records:
 
 ```tql title="Accessing a field by position"
 from {

--- a/src/content/docs/reference/functions/get.mdx
+++ b/src/content/docs/reference/functions/get.mdx
@@ -4,11 +4,11 @@ category: List, Record
 example: 'xs.get(index, fallback)'
 ---
 
-Gets a field from a record or an element from a list
+Gets a field from a record or an element from a list.
 
 ```tql
 get(x:record, field:string, [fallback:any]) -> any
-get(x:record|list, index:number, [fallback:any]) -> any
+get(x:record|list, index:int|uint, [fallback:any]) -> any
 ```
 
 ## Description
@@ -22,15 +22,15 @@ returning `null`.
 
 A `record` or list you want to access.
 
-### `index: int`/`field: string`
+### `index: int|uint`/`field: string`
 
-An index or field to access. If the function's subject `xs` is a `list`, `index`
-refers to the position in the list. If the subject `xs` is a `record`, `index`
-refers to the field index. If the subject is a `record`, you can also use the
-fields name as a `string` to refer to it.
+A signed or unsigned integer index, or a field to access. If the function's
+subject `xs` is a `list`, `index` refers to the position in the list. If the
+subject `xs` is a `record`, `index` refers to the field index. If the subject is
+a `record`, you can also use the field's name as a `string` to refer to it.
 
-If the given `index` or `field` are do not exist in the subject and no `fallback`
-was provided, a warning will be raised and the function will return `null`.
+If the given `index` or `field` does not exist in the subject and no `fallback`
+was provided, the function raises a warning and returns `null`.
 
 ### `fallback: any (optional)`
 


### PR DESCRIPTION
## 🔍 Problem

- The TQL expression and `get()` references did not state that list and record indexing accepts unsigned integer indices.

## 🛠️ Solution

- Update the expression reference to describe signed and unsigned integer indexing for lists and records.
- Update the `get()` reference signature and parameter wording to include `uint` indices.

## 💬 Review

- The docs intentionally avoid showing `.uint()` as an example pattern; they only document the supported index types.

<sub>
🛠️ Code PR: tenzir/tenzir#6064
</sub>
