### PR TITLE
Document per-test fixture-unavailable skips

### DIFF
--- a/src/content/docs/guides/testing/create-fixtures.mdx
+++ b/src/content/docs/guides/testing/create-fixtures.mdx
@@ -122,8 +122,8 @@ def mysql():
     # ...
 ```
 
-By default this causes a test failure. To convert it into a skip, add a
-structured `skip` entry to the suite's `test.yaml`:
+By default this causes a test failure. To convert a suite fixture failure into a
+skip, add a structured `skip` entry to the suite's `test.yaml`:
 
 ```yaml
 suite: mysql-integration
@@ -136,6 +136,20 @@ The harness marks every test in the suite as skipped and includes the exception
 message in the output. This opt-in design keeps suites failing loudly by
 default — you only suppress the failure for environments where the missing
 dependency is expected.
+
+If one test selects the fixture directly, put the same skip mapping in that
+test's frontmatter instead:
+
+```yaml
+---
+fixtures: [mysql]
+skip:
+  on: fixture-unavailable
+---
+```
+
+An unavailable fixture then skips only that test. Frontmatter does not control
+suite fixture setup because suite fixtures start before any member test runs.
 
 ## Use container runtime helpers
 

--- a/src/content/docs/reference/test-framework/index.mdx
+++ b/src/content/docs/reference/test-framework/index.mdx
@@ -649,8 +649,8 @@ skip: "pending upstream fix"
 ```
 
 **Structured form** conditionally skips tests when a runtime condition occurs.
-Use this when the suite depends on an external resource that may not be
-available in every environment:
+Use this when a fixture or suite capability depends on an external resource that
+may not be available in every environment:
 
 ```yaml
 skip:
@@ -663,7 +663,15 @@ The `on` field accepts the following values:
   during initialization. See [Fixture unavailability](#fixture-unavailability).
 - `capability-unavailable` — skip when a required capability (declared via
   [`requires`](#capability-requirements)) is missing from the runtime
-  environment.
+  environment. This value is only valid in directory-level `test.yaml` files.
+
+`fixture-unavailable` follows fixture activation scope. If a fixture is selected
+by one test, put `skip: {on: fixture-unavailable}` in that test's frontmatter or
+inherit it from a directory-level `test.yaml`; only that test is skipped when
+the fixture is unavailable. If a suite fixture is selected in `test.yaml`, put
+the skip opt-in in the suite's directory-level configuration; suite setup
+happens before any member test runs, so member frontmatter cannot control a
+suite fixture failure.
 
 You can combine multiple conditions by passing a list:
 
@@ -674,10 +682,10 @@ skip:
     - capability-unavailable
 ```
 
-When the triggering condition occurs and the suite carries the matching `on`
-value, all tests in the suite are marked as skipped with exit code 0. Without
-the opt-in configuration the exception propagates normally and causes a test
-failure.
+When the triggering condition occurs and the active scope carries the matching
+`on` value, the affected test or suite is marked as skipped with exit code 0.
+Without the opt-in configuration the exception propagates normally and causes a
+test failure.
 
 The optional `reason` field provides additional context that is combined with
 the condition message in the skip output.
@@ -999,8 +1007,9 @@ def mysql():
     # ... start container, yield env, cleanup ...
 ```
 
-By default the exception propagates and causes a test failure. To convert it
-into a skip, add a structured `skip` entry to the suite's `test.yaml`:
+By default the exception propagates and causes a test failure. To convert a
+suite fixture failure into a skip, add a structured `skip` entry to the suite's
+`test.yaml`:
 
 ```yaml
 # tests/mysql/test.yaml
@@ -1017,6 +1026,21 @@ code 0) and logs the combined reason. Without the opt-in configuration the
 exception surfaces as a regular failure. See
 [skip configuration](#skip-configuration) for the full syntax of the `skip`
 key.
+
+For fixtures that are selected by individual tests, use the same skip mapping in
+test frontmatter:
+
+```yaml
+---
+fixtures: [mysql]
+skip:
+  on: fixture-unavailable
+  reason: "needs container runtime"
+---
+```
+
+In this form, an unavailable fixture skips only that test. Suite fixture skips
+remain controlled by directory-level configuration.
 
 ### Container runtime helpers
 
@@ -1126,10 +1150,10 @@ uvx tenzir-test --update
 - **Unexpected exits** – Set `error: true` in frontmatter when a non-zero exit is
   expected.
 - **Skipped tests** – Use `skip: reason` to document temporary skips; baseline
-  files can stay empty. For fixture-dependent suites, use
-  `skip: {on: fixture-unavailable}` so tests skip gracefully when a required
-  tool is missing. For capability-dependent suites, combine `requires` with
-  `skip: {on: capability-unavailable}`.
+  files can stay empty. For fixture-dependent suites, put
+  `skip: {on: fixture-unavailable}` in `test.yaml`. For fixtures selected by
+  one test, use the same mapping in frontmatter. For capability-dependent
+  suites, combine `requires` with `skip: {on: capability-unavailable}`.
 - **Noisy output** – Use `--jobs 1` to serialize worker logs, and enable
   `--debug` (or set `TENZIR_TEST_DEBUG=1`) when you need to trace comparisons
   and fixture activity. Note that `--debug` automatically enables verbose


### PR DESCRIPTION
## 🔍 Problem

- The test framework docs only described `fixture-unavailable` skips as a suite-level `test.yaml` pattern.
- The code behavior now distinguishes per-test fixture activation from suite fixture activation.

## 🛠️ Solution

- Document that `fixture-unavailable` follows fixture activation scope.
- Show frontmatter opt-in for fixtures selected by one test.
- Clarify that suite fixture failures remain controlled by directory-level `test.yaml`.

## 💬 Review

- Focus on whether the scope distinction is clear in the reference and fixture guide.
- The code PR has the behavioral change and regression tests.

<sub>
🛠️ Code PR: tenzir/test#35<br>
📎 Related: https://github.com/tenzir/tenzir/pull/5999
</sub>
