### PR TITLE
Document serve_http operator

### DIFF
--- a/src/content/docs/guides/routing/expose-data-as-server.mdx
+++ b/src/content/docs/guides/routing/expose-data-as-server.mdx
@@ -5,17 +5,20 @@ title: Expose data as a server
 import Op from '@components/see-also/Op.astro';
 
 This guide shows you how to make pipeline data available to external consumers
-by spinning up servers. You'll learn to stream events over HTTP and configure
-server endpoints for different use cases.
+by starting an HTTP server. You'll learn how to stream serialized pipeline
+output to HTTP clients, pick a wire format, and configure connection limits and
+TLS.
 
 ## Spin up an HTTP server
 
-Use [`serve_http`](/reference/operators/serve_http) at the end of a pipeline to
-start an HTTP server that streams events as NDJSON to connected clients:
+Use <Op>serve_http</Op> at the end of a pipeline to start an HTTP server. The
+nested pipeline chooses how to serialize your events:
 
 ```tql
 from_file "example.yaml"
-serve_http "0.0.0.0:8080"
+serve_http "0.0.0.0:8080" {
+  write_ndjson
+}
 ```
 
 Any HTTP client connecting to `http://host:8080/` receives a continuous NDJSON
@@ -30,38 +33,38 @@ curl http://localhost:8080/
 {"timestamp":"2025-01-15T10:30:01Z","src_ip":"10.0.0.50","event":"file_access"}
 ```
 
-Multiple clients can connect simultaneously — each receives a copy of every
-event.
+Multiple clients can connect simultaneously. Each connected client receives a
+copy of the bytes produced after it connects.
 
-### Custom path and method
+### Choose a wire format
 
-By default, clients connect with a GET request to `/`. Customize both:
+Use the nested pipeline to control the response body format and content type.
+For example, use <Op>write_lines</Op> to stream plain text instead of NDJSON:
+
+```tql
+from_file "alerts.txt"
+serve_http "0.0.0.0:8080" {
+  write_lines
+}
+```
+
+You can also add filters or transforms before the printer:
 
 ```tql
 from_file "alerts.json"
-serve_http "0.0.0.0:9090", path="/alerts", method="post"
+where severity == "high"
+serve_http "0.0.0.0:8080" {
+  write_ndjson
+}
 ```
 
-Clients must now POST to `/alerts` to receive the stream. Requests to other
-paths return a `404` response.
+### Understand delivery semantics
 
-### Health check endpoints
+`serve_http` does not buffer output for future clients. A client only receives
+bytes produced after it connects.
 
-Production deployments often need health check endpoints for load balancers
-or monitoring. Use the `responses` option to serve static content alongside
-the event stream:
-
-```tql
-subscribe "my-topic"
-serve_http "0.0.0.0:8080",
-  responses={
-    "/health": {code: 200, content_type: "text/plain", body: "ok"},
-    "/ready": {code: 200, content_type: "application/json", body: "{\"status\":\"ready\"}"},
-  }
-```
-
-Clients hitting `/health` or `/ready` get the static response immediately.
-Clients connecting to `/` (the default stream path) receive the event stream.
+If a client cannot keep up with the producer, Tenzir may disconnect it to keep
+memory usage bounded.
 
 ### Connection limits
 
@@ -69,10 +72,12 @@ Control the maximum number of simultaneous client connections:
 
 ```tql
 from_file "data.csv"
-serve_http "0.0.0.0:8080", max_connections=10
+serve_http "0.0.0.0:8080", max_connections=10 {
+  write_ndjson
+}
 ```
 
-Connections beyond the limit are rejected with a `503` response.
+Additional clients wait until a connection slot becomes available.
 
 ### TLS encryption
 
@@ -84,10 +89,13 @@ serve_http "0.0.0.0:8443",
   tls={
     certfile: "/path/to/cert.pem",
     keyfile: "/path/to/key.pem",
-  }
+  } {
+  write_ndjson
+}
 ```
 
 ## See Also
 
 - <Op>serve_http</Op>
+- <Op>serve_tcp</Op>
 - <Op>to_http</Op>

--- a/src/content/docs/integrations/http.mdx
+++ b/src/content/docs/integrations/http.mdx
@@ -6,8 +6,8 @@ sidebar:
 
 [HTTP](https://en.wikipedia.org/wiki/HTTP) is the foundation of data exchange
 on the web. Tenzir provides operators for all sides of an HTTP conversation:
-fetching data from APIs, sending events to webhooks, streaming data to clients,
-and accepting incoming requests.
+fetching data from APIs, sending events to webhooks, streaming pipeline output
+to clients, and accepting incoming requests.
 
 ## Fetching data from APIs
 
@@ -37,13 +37,13 @@ event.
 
 ## Streaming data to HTTP clients
 
-Use [`serve_http`](/reference/operators/serve_http) to start an HTTP server that
-streams pipeline events as NDJSON to connected clients. Each client receives a
-copy of every event. This is useful when external systems need to pull data from
-your pipeline over HTTP.
+Use <Op>serve_http</Op> to start an HTTP server that streams the bytes produced
+by a nested pipeline to connected clients. For example, use
+<Op>write_ndjson</Op> when you want NDJSON over HTTP or <Op>write_lines</Op>
+when you want plain text.
 
-See the [Expose data as a server](/guides/routing/expose-data-as-server) guide
-for practical examples covering health checks, connection limits, and TLS.
+See the <Guide>routing/expose-data-as-server</Guide> guide for practical
+examples covering serialization, connection limits, and TLS.
 
 ## Accepting incoming requests
 

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -711,6 +711,14 @@ operators:
     description: 'Sends bytes as ZeroMQ messages.'
     example: 'save_zmq'
     path: 'reference/operators/save_zmq'
+  - name: 'serve_http'
+    description: 'Starts an HTTP server and streams bytes produced by a nested pipeline to connected clients.'
+    example: 'serve_http "0.0.0.0:8080" { write_ndjson }'
+    path: 'reference/operators/serve_http'
+  - name: 'serve_tcp'
+    description: 'Listens for incoming TCP connections and sends events to all connected clients.'
+    example: 'serve_tcp "0.0.0.0:8090" { write_json }'
+    path: 'reference/operators/serve_tcp'
   - name: 'sigma'
     description: 'Filter the input with Sigma rules and output matching events.'
     example: 'sigma "/tmp/rules/"'
@@ -2546,6 +2554,22 @@ save_zmq
 ### Events
 
 <CardGrid>
+
+<ReferenceCard title="serve_http" description="Starts an HTTP server and streams bytes produced by a nested pipeline to connected clients." href="/reference/operators/serve_http">
+
+```tql
+serve_http "0.0.0.0:8080" { write_ndjson }
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="serve_tcp" description="Listens for incoming TCP connections and sends events to all connected clients." href="/reference/operators/serve_tcp">
+
+```tql
+serve_tcp "0.0.0.0:8090" { write_json }
+```
+
+</ReferenceCard>
 
 <ReferenceCard title="to" description="Saves to an URI, inferring the destination, compression and format." href="/reference/operators/to">
 

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -763,6 +763,10 @@ operators:
     description: 'Writes events to a URI using hive partitioning.'
     example: 'to_hive "s3://…", partition_by=[x]'
     path: 'reference/operators/to_hive'
+  - name: 'to_http'
+    description: 'Sends events as HTTP requests to a webhook or API endpoint.'
+    example: 'to_http "https://example.com/webhook"'
+    path: 'reference/operators/to_http'
   - name: 'to_kafka'
     description: 'Sends messages to an Apache Kafka topic.'
     example: 'to_kafka "topic", message=this.print_json()'
@@ -783,6 +787,10 @@ operators:
     description: 'Sends events to a Splunk HTTP Event Collector (HEC).'
     example: 'to_splunk "localhost:8088", …'
     path: 'reference/operators/to_splunk'
+  - name: 'to_tcp'
+    description: 'Connects to a remote TCP or TLS endpoint and sends events.'
+    example: 'to_tcp "collector.example.com:5044" { write_json }'
+    path: 'reference/operators/to_tcp'
   - name: 'write_bitz'
     description: 'Writes events in *BITZ* format.'
     example: 'write_bitz'
@@ -2643,6 +2651,14 @@ to_hive "s3://…", partition_by=[x]
 
 </ReferenceCard>
 
+<ReferenceCard title="to_http" description="Sends events as HTTP requests to a webhook or API endpoint." href="/reference/operators/to_http">
+
+```tql
+to_http "https://example.com/webhook"
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="to_kafka" description="Sends messages to an Apache Kafka topic." href="/reference/operators/to_kafka">
 
 ```tql
@@ -2679,6 +2695,14 @@ to_snowflake account_identifier="…
 
 ```tql
 to_splunk "localhost:8088", …
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="to_tcp" description="Connects to a remote TCP or TLS endpoint and sends events." href="/reference/operators/to_tcp">
+
+```tql
+to_tcp "collector.example.com:5044" { write_json }
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators/serve_http.mdx
+++ b/src/content/docs/reference/operators/serve_http.mdx
@@ -1,72 +1,47 @@
 ---
 title: serve_http
 category: Outputs/Events
-example: 'serve_http "0.0.0.0:8080"'
+example: 'serve_http "0.0.0.0:8080" { write_ndjson }'
 ---
 
 import Op from '@components/see-also/Op.astro';
 import Guide from '@components/see-also/Guide.astro';
 import Integration from '@components/see-also/Integration.astro';
 
-Starts an HTTP server that streams events as NDJSON to connected clients.
+Starts an HTTP server and streams bytes produced by a nested pipeline to connected clients.
 
 ```tql
-serve_http url:string, [path=string, method=string, responses=record,
-           max_connections=int, tls=record]
+serve_http endpoint:string, [max_connections=int, tls=record] { … }
 ```
 
 ## Description
 
-The `serve_http` operator starts an HTTP server and streams pipeline events as
-[NDJSON](https://github.com/ndjson/ndjson-spec) to any HTTP client that
-connects. Each connected client receives a copy of every event.
+The `serve_http` operator starts an HTTP server and broadcasts the bytes from a
+nested pipeline to all connected clients. Input events flow through the nested
+pipeline, which must produce bytes such as NDJSON, JSON, or plain text.
 
-The operator waits for at least one client to connect before delivering data.
-When the pipeline finishes, the server shuts down and all client connections are
-closed.
+Clients connect with a `GET` request and receive a continuous HTTP response
+body. Each client only receives bytes produced after it connects. The operator
+does not buffer output for future clients.
 
-Clients that connect to a path other than the stream path, or use the wrong HTTP
-method, receive a `404` or `405` response respectively. Use the `responses`
-option to serve static content on additional paths, such as health checks.
+Use the nested pipeline to choose the wire format. For example,
+<Op>write_ndjson</Op> emits `application/x-ndjson`, and <Op>write_lines</Op>
+emits `text/plain`. If the nested pipeline does not set a content type,
+`serve_http` falls back to `application/octet-stream`.
 
-### `url: string`
+Slow clients may be disconnected when they cannot keep up with the producer.
+When the input pipeline finishes, the server closes all active responses and
+stops accepting new connections.
 
-The endpoint to listen on. Must have the form `<host>:<port>`. Use `0.0.0.0` to
-accept connections on all interfaces.
+### `endpoint: string`
 
-### `path = string (optional)`
-
-The URL path that clients connect to for the event stream.
-
-Defaults to `"/"`.
-
-### `method = string (optional)`
-
-The HTTP method that clients must use to connect to the stream.
-
-Defaults to `"GET"`.
-
-### `responses = record (optional)`
-
-Serve fixed responses on auxiliary paths that are separate from the event stream.
-This is useful for health checks or status endpoints. For example:
-
-```tql
-responses={
-  "/health": {code: 200, content_type: "text/plain", body: "ok"},
-}
-```
-
-Clients hitting `/health` receive the static `body` defined here, while clients
-connecting to the stream path receive the live NDJSON event stream from the
-pipeline.
-
-Each route must be a record with `code`, `content_type`, and `body` fields. The
-stream path itself cannot appear in `responses`.
+The endpoint to listen on. Use `host:port`, `[host]:port`, `http://host:port`,
+or `https://host:port`. Use `0.0.0.0` to accept connections on all interfaces.
 
 ### `max_connections = int (optional)`
 
-The maximum number of simultaneous client connections to accept.
+The maximum number of simultaneous client connections to accept. Additional
+connections wait until a slot becomes available.
 
 Defaults to `128`.
 
@@ -74,16 +49,21 @@ import TLSOptions from '@partials/operators/TLSOptions.mdx';
 
 <TLSOptions tls_default="false"/>
 
+### `{ … }`
+
+The nested pipeline that serializes input events into bytes. It must produce
+bytes as output, for example `{ write_ndjson }`, `{ write_json }`, or
+`{ write_lines }`.
+
 ## Examples
 
-### Stream events to HTTP clients
-
-Serve events on port 8080. Any HTTP client connecting to `http://host:8080/`
-receives the events as NDJSON:
+### Stream NDJSON over HTTP
 
 ```tql
 export
-serve_http "0.0.0.0:8080"
+serve_http "0.0.0.0:8080" {
+  write_ndjson
+}
 ```
 
 Connect with `curl`:
@@ -92,25 +72,13 @@ Connect with `curl`:
 curl http://localhost:8080/
 ```
 
-### Serve on a custom path and method
-
-Require clients to POST to `/events`:
+### Stream plain text lines
 
 ```tql
 export
-serve_http "0.0.0.0:8080", path="/events", method="post"
-```
-
-### Add a health check endpoint
-
-Expose a health endpoint alongside the event stream:
-
-```tql
-export
-serve_http "0.0.0.0:8080",
-  responses={
-    "/health": {code: 200, content_type: "text/plain", body: "ok"},
-  }
+serve_http "0.0.0.0:8080" {
+  write_lines
+}
 ```
 
 ### Serve over HTTPS
@@ -121,12 +89,15 @@ serve_http "0.0.0.0:8443",
   tls={
     certfile: "/path/to/cert.pem",
     keyfile: "/path/to/key.pem",
-  }
+  } {
+  write_ndjson
+}
 ```
 
 ## See Also
 
 - <Op>accept_http</Op>
+- <Op>serve_tcp</Op>
 - <Op>to_http</Op>
 - <Guide>routing/expose-data-as-server</Guide>
 - <Integration>http</Integration>


### PR DESCRIPTION
Updates does for `serve_http` operator, which were half-assed when I merged docs for `from_http` and `accept_http`.
