### PR TITLE
Document files permission handling

### DIFF
--- a/src/content/docs/reference/operators/files.mdx
+++ b/src/content/docs/reference/operators/files.mdx
@@ -25,13 +25,19 @@ Defaults to the current working directory.
 
 Recursively list files in subdirectories.
 
+When recursive traversal reaches a child directory that can't be opened because
+of file permissions, `files` emits a warning, skips that directory's children,
+and continues with the remaining directories. The initial `dir` must still be
+readable.
+
 ### `follow_symlinks = bool (optional)`
 
 Follow directory symlinks.
 
 ### `skip_permission_denied = bool (optional)`
 
-Skip directories that would otherwise result in permission denied errors.
+Skip the initial directory if it can't be opened because of file permissions.
+Recursive traversal skips unreadable child directories by default.
 
 ## Schemas
 
@@ -94,7 +100,7 @@ summarize total_size=sum(file_size)
 ### Find all named pipes in `/tmp`
 
 ```tql
-files "/tmp", recurse=true, skip_permission_denied=true
+files "/tmp", recurse=true
 where type == "fifo"
 ```
 

--- a/src/content/docs/reference/operators/files.mdx
+++ b/src/content/docs/reference/operators/files.mdx
@@ -27,8 +27,8 @@ Recursively list files in subdirectories.
 
 When recursive traversal reaches a child directory that can't be opened because
 of file permissions, `files` emits a warning, skips that directory's children,
-and continues with the remaining directories. The initial `dir` must still be
-readable.
+and continues with the remaining directories. Set `skip_permission_denied=true`
+to suppress these warnings.
 
 ### `follow_symlinks = bool (optional)`
 
@@ -36,8 +36,10 @@ Follow directory symlinks.
 
 ### `skip_permission_denied = bool (optional)`
 
-Skip the initial directory if it can't be opened because of file permissions.
-Recursive traversal skips unreadable child directories by default.
+Ignore permission-denied paths. If the initial directory can't be opened because
+of file permissions, `files` produces no events instead of an error. During
+recursive traversal, this also suppresses warnings for skipped child
+directories.
 
 ## Schemas
 


### PR DESCRIPTION
## 🔍 Problem

The `files` reference did not distinguish the initial directory from unreadable child directories during recursive traversal.

## 🛠️ Solution

- Document that recursive traversal warns and skips unreadable child directories by default.
- Clarify that `skip_permission_denied=true` turns an unreadable initial directory into an empty result and suppresses recursive child-directory warnings.
- Update the `/tmp` named pipe example accordingly.

## 💬 Review

Please check that the wording makes the initial-directory vs child-directory behavior clear.

<sub>
🛠️ Code PR: tenzir/tenzir#6073<br>
🎫 References TNZ-516, TNZ-520
</sub>