### PR TITLE
Document subnet IP conversion

### DIFF
--- a/src/content/docs/reference/functions/subnet.mdx
+++ b/src/content/docs/reference/functions/subnet.mdx
@@ -4,23 +4,45 @@ category: Type System/Conversion
 example: 'subnet("1.2.3.4/16")'
 ---
 
-Casts an expression to a subnet value.
+Converts an expression to a subnet value.
 
 ```tql
-subnet(x:string) -> subnet
+subnet(x:string|ip|subnet) -> subnet
+subnet(x:string|ip, prefix:int) -> subnet
 ```
 
 ## Description
 
-The `subnet` function casts an expression to a subnet.
+The `subnet` function converts an expression to a subnet.
 
 ### `x: string`
 
-The string expression to cast.
+The string expression to convert. The string can be a CIDR subnet such as
+`"10.0.1.5/24"` or a plain IP address such as `"10.0.1.5"`.
+
+Plain IPv4 addresses become `/32` host subnets, and plain IPv6 addresses become
+`/128` host subnets.
+
+### `x: ip`
+
+The IP address to convert. IPv4 addresses become `/32` host subnets, and IPv6
+addresses become `/128` host subnets.
+
+### `x: subnet`
+
+The subnet to return unchanged.
+
+### `prefix: int`
+
+The CIDR prefix length for a plain IP address. IPv4 prefixes must be in the
+range `0` to `32`, and IPv6 prefixes must be in the range `0` to `128`.
+
+Use `prefix` with plain IP values. Strings that already contain CIDR notation
+return `null` when you also provide `prefix`.
 
 ## Examples
 
-### Cast a string to a subnet
+### Convert a string to a subnet
 
 ```tql
 from {x: subnet("1.2.3.4/16")}
@@ -28,6 +50,26 @@ from {x: subnet("1.2.3.4/16")}
 
 ```tql
 {x: 1.2.0.0/16}
+```
+
+### Convert an IP address to a subnet
+
+```tql
+from {x: subnet(10.10.1.124, 24)}
+```
+
+```tql
+{x: 10.10.1.0/24}
+```
+
+### Convert a plain IP string to a host subnet
+
+```tql
+from {x: subnet("2001:db8::1")}
+```
+
+```tql
+{x: 2001:db8::1/128}
 ```
 
 ## See Also

--- a/src/content/docs/reference/functions/subnet.mdx
+++ b/src/content/docs/reference/functions/subnet.mdx
@@ -8,7 +8,7 @@ Converts an expression to a subnet value.
 
 ```tql
 subnet(x:string|ip|subnet) -> subnet
-subnet(x:string|ip, prefix:int) -> subnet
+subnet(x:string|ip|subnet, prefix:int) -> subnet
 ```
 
 ## Description
@@ -34,11 +34,12 @@ The subnet to return unchanged.
 
 ### `prefix: int`
 
-The CIDR prefix length for a plain IP address. IPv4 prefixes must be in the
-range `0` to `32`, and IPv6 prefixes must be in the range `0` to `128`.
+The CIDR prefix length for a plain IP address or subnet network address. IPv4
+prefixes must be in the range `0` to `32`, and IPv6 prefixes must be in the
+range `0` to `128`.
 
-Use `prefix` with plain IP values. Strings that already contain CIDR notation
-return `null` when you also provide `prefix`.
+Use `prefix` with plain IP values or existing subnet values. Strings that
+already contain CIDR notation return `null` when you also provide `prefix`.
 
 ## Examples
 


### PR DESCRIPTION
## 🔍 Problem

The `subnet` reference page only documented CIDR-string conversion and did not describe typed IP input, host defaults, explicit prefixes, or subnet input with an explicit prefix.

## 🛠️ Solution

- Document the new `subnet(x:string|ip|subnet)` and `subnet(x:string|ip|subnet, prefix:int)` forms.
- Explain IPv4 `/32` and IPv6 `/128` host defaults.
- Add examples for typed IP input and plain IP strings.

## 💬 Review

Focus on whether the prefix wording is clear for both IPv4 and IPv6 users.

<sub>
🛠️ Code PR: tenzir/tenzir#6076<br>
🎫 References TNZ-510
</sub>