### PR TITLE
Document OData pagination for from_http

### DIFF
--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -271,6 +271,31 @@ from {url: "https://api.github.com/repos/tenzir/tenzir/issues?per_page=10"}
 http url, paginate="link"
 ```
 
+### [OData](https://www.oasis-open.org/standard/odata-v4-01-os/) pagination
+
+Some APIs return an OData collection envelope with records in a top-level
+`value` array and the next page URL in `@odata.nextLink`. Microsoft Graph uses
+this pagination shape for many collection endpoints. Use `paginate="odata"` with
+<Op>from_http</Op> to unpack the envelope and follow the next link
+automatically:
+
+```tql
+from_http "https://graph.microsoft.com/v1.0/users",
+  headers={
+    "Authorization": "Bearer " + secret("MICROSOFT_GRAPH_TOKEN"),
+    "ConsistencyLevel": "eventual",
+  },
+  paginate="odata" {
+  read_json
+}
+```
+
+The operator emits each object from the top-level `value` array as an event. It
+follows a top-level string `@odata.nextLink` as an opaque URL, so you do not need
+to inspect or rebuild query parameters such as `$skiptoken`. Pagination stops
+when the response omits `@odata.nextLink` or when the field is not a string.
+Follow-up requests use `GET` and reuse the configured request headers.
+
 ### Rate Limiting
 
 Control request frequency by configuring the `paginate_delay` parameter to add
@@ -366,6 +391,6 @@ Follow these practices for reliable and efficient API integration:
    performance.
 7. **Leverage automatic format inference**. Use descriptive file extensions in
    URLs when possible to enable automatic format and compression detection.
-8. **Prefer link pagination when available**. Use `paginate="link"` for APIs
-   that support RFC 8288 `Link` headers instead of writing custom lambda
-   expressions.
+8. **Prefer built-in pagination modes when available**. Use `paginate="link"`
+   for APIs that support RFC 8288 `Link` headers or `paginate="odata"` for
+   OData collection envelopes instead of writing custom lambda expressions.

--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -175,6 +175,28 @@ Many APIs (such as GitHub, GitLab, and Jira) use the `Link` header for
 pagination. The operator extracts the `rel=next` URL from the header and
 continues fetching until no more pages are available.
 
+### Paginate [OData](https://www.oasis-open.org/standard/odata-v4-01-os/) collection responses
+
+Use `paginate="odata"` for APIs that return an OData collection envelope, such
+as Microsoft Graph:
+
+```tql
+from_http "https://graph.microsoft.com/v1.0/users",
+  headers={
+    "Authorization": "Bearer " + secret("MICROSOFT_GRAPH_TOKEN"),
+    "ConsistencyLevel": "eventual",
+  },
+  paginate="odata" {
+  read_json
+}
+```
+
+The response body must be a JSON object with a top-level `value` array. The
+operator emits each object from `value`, follows a top-level string
+`@odata.nextLink` as an opaque URL, and stops when the field is absent or not a
+string. Follow-up requests use `GET` with the same headers as the initial
+request.
+
 ### Retry Failed Requests
 
 Configure retries for failed requests:

--- a/src/partials/operators/HTTPClientOptions.mdx
+++ b/src/partials/operators/HTTPClientOptions.mdx
@@ -48,6 +48,13 @@ The operator parses `Link` headers and follows the `rel=next` relation to fetch
 the next page. Pagination stops when the response no longer contains a
 `rel=next` link.
 
+**[OData](https://www.oasis-open.org/standard/odata-v4-01-os/) mode**: For
+<Op>from_http</Op>, the string `"odata"` to follow OData collection responses
+such as Microsoft Graph. The response body must be a JSON object with a
+top-level `value` array. The operator emits each object from `value`, follows a
+top-level string `@odata.nextLink` as an opaque URL, and sends follow-up
+requests as `GET` requests with the same headers.
+
 ### `paginate_delay = duration (optional)`
 
 The duration to wait between consecutive pagination requests.


### PR DESCRIPTION
## 🔍 Problem

- The HTTP API guide and `from_http` operator reference only documented lambda and Link header pagination.
- `from_http paginate="odata"` needs reference and guide coverage for OData collection envelopes such as Microsoft Graph.

## 🛠️ Solution

- Document `paginate="odata"` in the shared HTTP client options, the `from_http` reference, and the HTTP API collection guide.
- Clarify that the mode emits objects from top-level `value`, follows top-level `@odata.nextLink` as an opaque URL, and reuses configured headers for follow-up `GET` requests.
- Link the first OData mention to the OASIS OData standard.

## 💬 Review

- Check the Microsoft Graph-shaped example and the explicit `from_http` scope in the shared options partial.

<sub>
🛠️ Code PR: tenzir/tenzir#6080<br>
🎫 References TNZ-398
</sub>