### PR TITLE
Document SentinelOne sink TLS

### DIFF
--- a/src/content/docs/reference/operators/to_sentinelone_data_lake.mdx
+++ b/src/content/docs/reference/operators/to_sentinelone_data_lake.mdx
@@ -8,7 +8,7 @@ Sends security events to SentinelOne Singularity Data Lake via REST API.
 
 ```tql
 to_sentinelone_data_lake url:string, token=string,
-                        [session_info=record, timeout=duration]
+                         [session_info=record, timeout=duration, tls=record]
 ```
 
 ## Description
@@ -41,6 +41,8 @@ according to this table:
 
 The ingest URL for the Data Lake.
 
+The URL must start with `https://`.
+
 :::info
 Please note that using the wrong ingestion endpoint, such as an incorrect region,
 may silently fail, as the SentinelOne API responds with 200 OK, even for some
@@ -67,6 +69,14 @@ The delay after which events are sent, even if this results in fewer events
 sent per message.
 
 Defaults to `1min`.
+
+### `tls = record (optional)`
+
+The TLS settings for the HTTPS connection.
+
+Use `tls={cacert: "/path/to/ca.pem"}` when your SentinelOne endpoint uses a
+private CA. For all supported TLS options, see [Configure
+TLS](/guides/node-setup/configure-tls/#available-options).
 
 ## Examples
 

--- a/src/content/docs/reference/operators/to_sentinelone_data_lake.mdx
+++ b/src/content/docs/reference/operators/to_sentinelone_data_lake.mdx
@@ -70,13 +70,12 @@ sent per message.
 
 Defaults to `1min`.
 
-### `tls = record (optional)`
+import TLSOptions from '@partials/operators/TLSOptions.mdx';
 
-The TLS settings for the HTTPS connection.
+<TLSOptions tls_default="true"/>
 
-Use `tls={cacert: "/path/to/ca.pem"}` when your SentinelOne endpoint uses a
-private CA. For all supported TLS options, see [Configure
-TLS](/guides/node-setup/configure-tls/#available-options).
+For SentinelOne endpoints that use a private CA, set
+`tls={cacert: "/path/to/ca.pem"}`.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Document that `to_sentinelone_data_lake` requires an HTTPS ingest URL.
- Use the shared operator TLS options list for `tls={...}` and call out private CA configuration.

## Checks

- `bun x markdownlint src/content/docs/reference/operators/to_sentinelone_data_lake.mdx`
- `bun x prettier --check src/content/docs/reference/operators/to_sentinelone_data_lake.mdx`

<sub>
⚙️ Code PR: tenzir/tenzir#6081<br>
🧩 Plugin PR: tenzir/tenzir-plugins#521<br>
🎫 References TNZ-74
</sub>