### PR TITLE
Upgrade worktrunk config

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -2,4 +2,4 @@
 # https://worktrunk.dev/reference/hook
 
 # Install dependencies when creating worktrees
-post-create = "bun install"
+pre-start = "bun install"


### PR DESCRIPTION
## 🔍 Problem

- The Worktrunk hook configuration still uses the old `post-create` hook name.

## 🛠️ Solution

- Switch the dependency installation hook to `pre-start`.

## 💬 Review

- Verify the hook name matches the current Worktrunk lifecycle.
