### PR TITLE
Document each operator

### DIFF
--- a/src/content/docs/guides/routing/fan-out-with-subpipelines.mdx
+++ b/src/content/docs/guides/routing/fan-out-with-subpipelines.mdx
@@ -1,0 +1,153 @@
+---
+title: Fan out with subpipelines
+---
+
+This guide shows you how to fan out an event stream into subpipelines with
+<Op>each</Op> and <Op>group</Op>. You'll learn when to spawn one subpipeline per
+event, when to keep one subpipeline per key, and how these operators differ
+from fixed fan-out operators like <Op>fork</Op>, <Op>parallel</Op>, and
+<Op>load_balance</Op>.
+
+## Choose a fan-out pattern
+
+Tenzir has several operators that send events into subpipelines. Choose the
+operator based on how many subpipelines you need and how events should flow into
+them:
+
+| Operator              | Subpipelines                          | Event flow                                                         | Use case                                                      |
+| --------------------- | ------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------- |
+| <Op>fork</Op>         | One fixed side branch                 | Every event goes to the main pipeline and the side branch          | Archive or publish a copy while continuing processing         |
+| <Op>parallel</Op>     | A fixed number of workers             | Each event goes to one worker running the same subpipeline         | Speed up CPU-heavy or I/O-heavy work                          |
+| <Op>load_balance</Op> | One branch per configured target      | Each event goes to one target                                      | Distribute load across equivalent sinks                       |
+| <Op>each</Op>         | One fresh subpipeline per input event | The input event is available as `$this`; it is not passed as input | Run a per-event job, such as a lookup or export               |
+| <Op>group</Op>        | One subpipeline per key               | Matching events are passed to the same keyed subpipeline           | Keep per-tenant, per-host, or per-session processing isolated |
+
+Use regular transformations when every event can flow through the same linear
+pipeline. Use subpipeline fan-out when the pipeline structure itself depends on
+each event or key.
+
+## Run one subpipeline per event
+
+Use <Op>each</Op> when every input event describes a job to run. The nested
+pipeline must start with a source because `each` does not pass the input event
+into the subpipeline. Instead, it binds the current event record to `$this`.
+
+The following pipeline treats incoming cases as lookup requests. Each case
+queries the same historical dataset for matching source IPs and annotates the
+matches with the case ID:
+
+```tql
+from {case_id: "C-1", ip: "10.0.0.5"},
+     {case_id: "C-2", ip: "10.0.0.7"}
+each parallel=4 {
+  from {ts: 2024-01-01T10:00:00, src_ip: "10.0.0.5", action: "login"},
+       {ts: 2024-01-01T10:02:00, src_ip: "10.0.0.8", action: "scan"},
+       {ts: 2024-01-01T10:05:00, src_ip: "10.0.0.7", action: "download"}
+  where src_ip == $this.ip
+  case_id = $this.case_id
+}
+sort case_id, ts
+```
+
+```tql
+{
+  ts: 2024-01-01T10:00:00.000000,
+  src_ip: "10.0.0.5",
+  action: "login",
+  case_id: "C-1",
+}
+{
+  ts: 2024-01-01T10:05:00.000000,
+  src_ip: "10.0.0.7",
+  action: "download",
+  case_id: "C-2",
+}
+```
+
+The `parallel` option limits how many per-event jobs run at the same time. When
+more events arrive, `each` queues them and applies back pressure upstream until
+a running subpipeline finishes. Keep this value bounded for external APIs,
+expensive exports, or destinations with rate limits.
+
+## Keep one subpipeline per key
+
+Use <Op>group</Op> when events with the same key must go through the same
+subpipeline. Unlike `each`, the nested pipeline receives input: Tenzir sends all
+matching events for a key to that key's subpipeline. The key is available as
+`$group` inside the subpipeline.
+
+The following pipeline keeps tenant streams separate and computes a summary per
+tenant:
+
+```tql
+from {tenant: "alpha", bytes: 120},
+     {tenant: "beta", bytes: 90},
+     {tenant: "alpha", bytes: 80}
+group tenant {
+  summarize events=count(), bytes=sum(bytes)
+  tenant = $group
+}
+sort tenant
+```
+
+```tql
+{
+  events: 2,
+  bytes: 200,
+  tenant: "alpha",
+}
+{
+  events: 1,
+  bytes: 90,
+  tenant: "beta",
+}
+```
+
+For a pure aggregation, <Op>summarize</Op> is usually shorter. Use `group` when
+the per-key subpipeline does more than aggregate, such as keeping state,
+applying a keyed transformation, or writing to a key-specific sink.
+
+## Write separate outputs per key
+
+A common `group` pattern is to write each tenant, host, or sensor to its own
+file. The subpipeline ends with a sink, so `group` itself becomes a sink:
+
+```tql
+from {tenant: "alpha", message: "login"},
+     {tenant: "beta", message: "scan"},
+     {tenant: "alpha", message: "logout"}
+group tenant {
+  to_file f"/tmp/tenzir/{$group}.json" {
+    write_ndjson
+  }
+}
+```
+
+This creates one subpipeline per tenant and writes matching events to that
+subpipeline's file.
+
+## Avoid common mistakes
+
+- Don't use `each` for ordinary per-event transformations. Use regular TQL
+  statements or <Op>parallel</Op> when every event follows the same processing
+  steps.
+- Don't use `group` only to calculate grouped totals. Use <Op>summarize</Op>
+  unless you need a full subpipeline per key.
+- Don't leave `each` unbounded for external systems. Set `parallel` to match
+  the concurrency that the downstream service can handle.
+- Remember that `each` subpipelines must start with a source, while `group`
+  subpipelines receive the grouped input stream.
+- Neither `each` nor `group` can use subpipelines that produce bytes as output.
+
+## See Also
+
+- <Op>each</Op>
+- <Op>group</Op>
+- <Op>fork</Op>
+- <Op>parallel</Op>
+- <Op>load_balance</Op>
+- <Op>publish</Op>
+- <Op>subscribe</Op>
+- <Op>summarize</Op>
+- <Guide>routing/split-and-merge-streams</Guide>
+- <Guide>routing/load-balance-pipelines</Guide>

--- a/src/content/docs/guides/routing/split-and-merge-streams.mdx
+++ b/src/content/docs/guides/routing/split-and-merge-streams.mdx
@@ -164,6 +164,7 @@ blocking production pipelines.
 ## See also
 
 - <Guide>routing/send-to-destinations</Guide>
+- <Guide>routing/fan-out-with-subpipelines</Guide>
 - <Guide>routing/load-balance-pipelines</Guide>
 - <Op>publish</Op>
 - <Op>subscribe</Op>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -207,6 +207,10 @@ operators:
     description: 'Discards all incoming events.'
     example: 'discard'
     path: 'reference/operators/discard'
+  - name: 'each'
+    description: 'Spawns a subpipeline for every incoming event, with the event bound to `$this`.'
+    example: 'each { from $this }'
+    path: 'reference/operators/each'
   - name: 'every'
     description: 'Runs a pipeline periodically at a fixed interval.'
     example: 'every 10s { summarize sum(amount) }'
@@ -1354,6 +1358,14 @@ delay ts, speed=2.5
 
 ```tql
 discard
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="each" description="Spawns a subpipeline for every incoming event, with the event bound to `$this`." href="/reference/operators/each">
+
+```tql
+each { from $this }
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -219,6 +219,10 @@ operators:
     description: 'Executes a subpipeline with a copy of the input.'
     example: 'fork { to "copy.json" }'
     path: 'reference/operators/fork'
+  - name: 'group'
+    description: 'Routes events with the same key through the same subpipeline.'
+    example: 'group tenant { summarize count() }'
+    path: 'reference/operators/group'
   - name: 'load_balance'
     description: 'Routes the data to one of multiple subpipelines.'
     example: 'load_balance $over { publish $over }'
@@ -1382,6 +1386,14 @@ every 10s { summarize sum(amount) }
 
 ```tql
 fork { to "copy.json" }
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="group" description="Routes events with the same key through the same subpipeline." href="/reference/operators/group">
+
+```tql
+group tenant { summarize count() }
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators/cron.mdx
+++ b/src/content/docs/reference/operators/cron.mdx
@@ -66,4 +66,5 @@ publish "api"
 
 ## See Also
 
+- <Op>each</Op>
 - <Op>every</Op>

--- a/src/content/docs/reference/operators/each.mdx
+++ b/src/content/docs/reference/operators/each.mdx
@@ -1,0 +1,104 @@
+---
+title: each
+category: Flow Control
+example: 'each { from $this }'
+---
+
+Spawns a subpipeline for every incoming event, with the event bound to `$this`.
+
+```tql
+each [parallel=int] { … }
+```
+
+## Description
+
+The `each` operator runs a fresh subpipeline for every incoming event. The
+record of the current event is bound to `$this` inside the subpipeline, so the
+subpipeline can parametrize its behavior on a per-event basis.
+
+The subpipeline must be a source: it takes no input from `each` and instead
+produces its own events (or sinks them itself). Outputs of all running
+subpipelines are merged into the operator's output stream and may interleave.
+
+Up to `parallel` subpipelines run concurrently. Excess events queue and start
+as soon as a slot frees.
+
+### `parallel = int (optional)`
+
+The maximum number of subpipelines that may run concurrently. Must be at least
+`1`.
+
+Defaults to `10`.
+
+### `{ … }`
+
+The subpipeline to spawn for each event. Must be a source. The subpipeline may
+either produce events—which are forwarded as the operator's output—or end with
+a sink, in which case `each` itself becomes a sink.
+
+The subpipeline must not produce bytes.
+
+Inside the subpipeline, `$this` refers to the record of the current input
+event.
+
+## Examples
+
+### Re-emit each input event
+
+Use `from $this` to convert each incoming event into a one-event subpipeline:
+
+```tql
+from {name: "alice"}, {name: "bob"}
+each {
+  from $this
+}
+```
+
+### Parametrize a subpipeline with the event
+
+Filter a fixed dataset using a threshold from the input event:
+
+```tql
+from {threshold: 3}, {threshold: 7}
+each {
+  from {x: 1}, {x: 5}, {x: 10}
+  where x > $this.threshold
+}
+```
+
+```tql
+{x: 5}
+{x: 10}
+{x: 10}
+```
+
+### Limit concurrency
+
+Run at most four subpipelines at the same time:
+
+```tql
+subscribe "jobs"
+each parallel=4 {
+  load_http $this.url
+  read_json
+}
+```
+
+### Sink output inside the subpipeline
+
+When the subpipeline ends with a sink, `each` itself becomes a sink:
+
+```tql
+from {x: 1}, {x: 2}, {x: 3}
+each {
+  from $this
+  discard
+}
+```
+
+## See Also
+
+- <Op>cron</Op>
+- <Op>every</Op>
+- <Op>fork</Op>
+- <Op>parallel</Op>

--- a/src/content/docs/reference/operators/each.mdx
+++ b/src/content/docs/reference/operators/each.mdx
@@ -56,14 +56,17 @@ each {
 
 ### Run a per-event sink
 
-When the subpipeline ends with a sink, `each` itself becomes a sink. Write a
-separate file for each tenant referenced in the input:
+When the subpipeline ends with a sink, `each` itself becomes a sink. Use this
+to write a separate output file per tenant in the input:
 
 ```tql
 from {tenant: "alpha"}, {tenant: "beta"}
 each {
-  subscribe f"events.{$this.tenant}"
-  to f"out/{$this.tenant}.json"
+  from {tenant: $this.tenant, status: "ok"},
+       {tenant: $this.tenant, status: "fail"}
+  to_file f"out/{$this.tenant}.json" {
+    write_ndjson
+  }
 }
 ```
 

--- a/src/content/docs/reference/operators/each.mdx
+++ b/src/content/docs/reference/operators/each.mdx
@@ -20,6 +20,10 @@ The subpipeline takes no input from `each`. It either emits events—which are
 forwarded as the operator's output—or ends with a sink, in which case `each`
 itself becomes a sink. The subpipeline must not produce bytes.
 
+Use `each` for per-event jobs, such as running a lookup, export, or sink whose
+source depends on the incoming event. For keyed streams that should keep one
+subpipeline alive per key, use <Op>group</Op> instead.
+
 ### `parallel = int (optional)`
 
 The maximum number of subpipelines that may run concurrently. Must be at least
@@ -36,22 +40,38 @@ event.
 
 ## Examples
 
-### Parametrize a subpipeline with the event
+### Run a lookup per event
 
-Filter a fixed dataset using a threshold taken from the input event:
+Use fields from the input event to parametrize a source subpipeline. This
+example treats the input as investigation cases and searches a historical event
+set for matching source IPs:
 
 ```tql
-from {threshold: 3}, {threshold: 7}
-each {
-  from {x: 1}, {x: 5}, {x: 10}
-  where x > $this.threshold
+from {case_id: "C-1", ip: "10.0.0.5"},
+     {case_id: "C-2", ip: "10.0.0.7"}
+each parallel=4 {
+  from {ts: 2024-01-01T10:00:00, src_ip: "10.0.0.5", action: "login"},
+       {ts: 2024-01-01T10:02:00, src_ip: "10.0.0.8", action: "scan"},
+       {ts: 2024-01-01T10:05:00, src_ip: "10.0.0.7", action: "download"}
+  where src_ip == $this.ip
+  case_id = $this.case_id
 }
+sort case_id, ts
 ```
 
 ```tql
-{x: 5}
-{x: 10}
-{x: 10}
+{
+  ts: 2024-01-01T10:00:00.000000,
+  src_ip: "10.0.0.5",
+  action: "login",
+  case_id: "C-1",
+}
+{
+  ts: 2024-01-01T10:05:00.000000,
+  src_ip: "10.0.0.7",
+  action: "download",
+  case_id: "C-2",
+}
 ```
 
 ### Run a per-event sink
@@ -64,7 +84,7 @@ from {tenant: "alpha"}, {tenant: "beta"}
 each {
   from {tenant: $this.tenant, status: "ok"},
        {tenant: $this.tenant, status: "fail"}
-  to_file f"out/{$this.tenant}.json" {
+  to_file f"/tmp/tenzir/{$this.tenant}.json" {
     write_ndjson
   }
 }
@@ -75,4 +95,6 @@ each {
 - <Op>cron</Op>
 - <Op>every</Op>
 - <Op>fork</Op>
+- <Op>group</Op>
 - <Op>parallel</Op>
+- <Guide>routing/fan-out-with-subpipelines</Guide>

--- a/src/content/docs/reference/operators/each.mdx
+++ b/src/content/docs/reference/operators/each.mdx
@@ -16,47 +16,29 @@ The `each` operator runs a fresh subpipeline for every incoming event. The
 record of the current event is bound to `$this` inside the subpipeline, so the
 subpipeline can parametrize its behavior on a per-event basis.
 
-The subpipeline must be a source: it takes no input from `each` and instead
-produces its own events (or sinks them itself). Outputs of all running
-subpipelines are merged into the operator's output stream and may interleave.
-
-Up to `parallel` subpipelines run concurrently. Excess events queue and start
-as soon as a slot frees.
+The subpipeline takes no input from `each`. It either emits events—which are
+forwarded as the operator's output—or ends with a sink, in which case `each`
+itself becomes a sink. The subpipeline must not produce bytes.
 
 ### `parallel = int (optional)`
 
 The maximum number of subpipelines that may run concurrently. Must be at least
-`1`.
+`1`. Excess events queue and start as soon as a slot frees.
 
 Defaults to `10`.
 
 ### `{ … }`
 
-The subpipeline to spawn for each event. Must be a source. The subpipeline may
-either produce events—which are forwarded as the operator's output—or end with
-a sink, in which case `each` itself becomes a sink.
-
-The subpipeline must not produce bytes.
+The subpipeline to spawn for each event. Must start with a source.
 
 Inside the subpipeline, `$this` refers to the record of the current input
 event.
 
 ## Examples
 
-### Re-emit each input event
-
-Use `from $this` to convert each incoming event into a one-event subpipeline:
-
-```tql
-from {name: "alice"}, {name: "bob"}
-each {
-  from $this
-}
-```
-
 ### Parametrize a subpipeline with the event
 
-Filter a fixed dataset using a threshold from the input event:
+Filter a fixed dataset using a threshold taken from the input event:
 
 ```tql
 from {threshold: 3}, {threshold: 7}
@@ -72,27 +54,16 @@ each {
 {x: 10}
 ```
 
-### Limit concurrency
+### Run a per-event sink
 
-Run at most four subpipelines at the same time:
-
-```tql
-subscribe "jobs"
-each parallel=4 {
-  load_http $this.url
-  read_json
-}
-```
-
-### Sink output inside the subpipeline
-
-When the subpipeline ends with a sink, `each` itself becomes a sink:
+When the subpipeline ends with a sink, `each` itself becomes a sink. Write a
+separate file for each tenant referenced in the input:
 
 ```tql
-from {x: 1}, {x: 2}, {x: 3}
+from {tenant: "alpha"}, {tenant: "beta"}
 each {
-  from $this
-  discard
+  subscribe f"events.{$this.tenant}"
+  to f"out/{$this.tenant}.json"
 }
 ```
 

--- a/src/content/docs/reference/operators/every.mdx
+++ b/src/content/docs/reference/operators/every.mdx
@@ -51,6 +51,7 @@ publish "threat-feed"
 ## See Also
 
 - <Op>cron</Op>
+- <Op>each</Op>
 - <Guide>transformation/work-with-time</Guide>
 - <Guide>enrichment/work-with-lookup-tables</Guide>
 - <Tutorial>write-a-package</Tutorial>

--- a/src/content/docs/reference/operators/group.mdx
+++ b/src/content/docs/reference/operators/group.mdx
@@ -1,0 +1,87 @@
+---
+title: group
+category: Flow Control
+example: 'group tenant { summarize count() }'
+---
+
+Routes events with the same key through the same subpipeline.
+
+```tql
+group over:expr { … }
+```
+
+## Description
+
+The `group` operator evaluates `over` for every incoming event and creates one
+subpipeline for every distinct key. Events with the same key are sent to the
+same subpipeline. Inside the subpipeline, `$group` refers to the key for that
+subpipeline.
+
+The subpipeline receives grouped events as input. It either emits events—which
+are forwarded as the operator's output—or ends with a sink, in which case
+`group` itself becomes a sink. The subpipeline must not produce bytes.
+
+Use `group` when you need a full keyed subpipeline, such as a per-tenant sink or
+a per-session stateful transformation. For grouped aggregations only, use
+<Op>summarize</Op> instead.
+
+### `over: expr`
+
+The expression that computes the group key for every incoming event.
+
+### `{ … }`
+
+The subpipeline to run for every distinct key. The subpipeline receives the
+matching events as input.
+
+Inside the subpipeline, `$group` refers to the current key.
+
+## Examples
+
+### Summarize each tenant independently
+
+```tql
+from {tenant: "alpha", bytes: 120},
+     {tenant: "beta", bytes: 90},
+     {tenant: "alpha", bytes: 80}
+group tenant {
+  summarize events=count(), bytes=sum(bytes)
+  tenant = $group
+}
+sort tenant
+```
+
+```tql
+{
+  events: 2,
+  bytes: 200,
+  tenant: "alpha",
+}
+{
+  events: 1,
+  bytes: 90,
+  tenant: "beta",
+}
+```
+
+### Write a file per tenant
+
+```tql
+from {tenant: "alpha", message: "login"},
+     {tenant: "beta", message: "scan"},
+     {tenant: "alpha", message: "logout"}
+group tenant {
+  to_file f"/tmp/tenzir/{$group}.json" {
+    write_ndjson
+  }
+}
+```
+
+## See Also
+
+- <Op>each</Op>
+- <Op>fork</Op>
+- <Op>load_balance</Op>
+- <Op>parallel</Op>
+- <Op>summarize</Op>
+- <Guide>routing/fan-out-with-subpipelines</Guide>

--- a/src/content/docs/reference/operators/load_balance.mdx
+++ b/src/content/docs/reference/operators/load_balance.mdx
@@ -74,5 +74,7 @@ load_balance $cfg {
 ## See Also
 
 - <Op>fork</Op>
+- <Op>group</Op>
 - <Op>publish</Op>
+- <Guide>routing/fan-out-with-subpipelines</Guide>
 - <Guide>routing/load-balance-pipelines</Guide>

--- a/src/content/docs/reference/operators/parallel.mdx
+++ b/src/content/docs/reference/operators/parallel.mdx
@@ -102,4 +102,5 @@ parallel 4 {
 
 ## See Also
 
+- <Op>each</Op>
 - <Op>load_balance</Op>

--- a/src/content/docs/reference/operators/parallel.mdx
+++ b/src/content/docs/reference/operators/parallel.mdx
@@ -103,4 +103,6 @@ parallel 4 {
 ## See Also
 
 - <Op>each</Op>
+- <Op>group</Op>
 - <Op>load_balance</Op>
+- <Guide>routing/fan-out-with-subpipelines</Guide>

--- a/src/content/docs/reference/operators/summarize.mdx
+++ b/src/content/docs/reference/operators/summarize.mdx
@@ -171,6 +171,7 @@ summarize count(this), severity, options={frequency: 10s, mode: "update"}
 
 ## See Also
 
+- <Op>group</Op>
 - <Op>rare</Op>
 - <Op>top</Op>
 - <Fn>sum</Fn>

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -153,6 +153,7 @@ export const guides = [
           "guides/routing/send-to-destinations",
           "guides/routing/expose-data-as-server",
           "guides/routing/split-and-merge-streams",
+          "guides/routing/fan-out-with-subpipelines",
           "guides/routing/load-balance-pipelines",
         ],
       },


### PR DESCRIPTION
## Summary

- Add reference pages for the new `each` and `group` operators.
- Add a routing guide for dynamic fan-out with subpipelines, covering when to use `each`, `group`, `fork`, `parallel`, and `load_balance`.
- Add reciprocal See Also links and update the operator index and sidebar.

<sub>
⚙️ Code PR: tenzir/tenzir#5981
</sub>
