### PR TITLE
Document TQL match statements

### DIFF
--- a/src/content/docs/guides/normalization/map-to-ocsf.mdx
+++ b/src/content/docs/guides/normalization/map-to-ocsf.mdx
@@ -162,23 +162,32 @@ import { FileTree } from '@astrojs/starlight/components';
 ### Dispatcher operator
 
 Your package should include one dispatching operator. The dispatcher routes
-events to an event-specific mapping operator:
+events based on the event type:
 
-```tql title="paloalto/operators/ngfw/ocsf/map.tql"
-if src.type == "TRAFFIC" {
-  paloalto::ngfw::ocsf::event::network
-} else if src.type == "DNS" {
-  paloalto::ngfw::ocsf::event::dns
-} else if src.type == "THREAT" {
-  paloalto::ngfw::ocsf::event::threat
-} else {
-  // Map to base event.
-  paloalto::ngfw::ocsf::base
+```tql
+from {src: {type: "TRAFFIC"}},
+     {src: {type: "DNS"}},
+     {src: {type: "THREAT"}},
+     {src: {type: "SYSTEM"}}
+match src.type {
+  "TRAFFIC" => {
+    mapper = "network"
+  }
+  "DNS" => {
+    mapper = "dns"
+  }
+  "THREAT" => {
+    mapper = "threat"
+  }
+  _ => {
+    mapper = "base"
+  }
 }
 ```
 
 If the parser package does not set a type field, dispatch on a different field
-in the log that differentiates the event types.
+in the log that differentiates the event types. In a package, each arm can call
+an event-specific mapping operator instead of setting `mapper`.
 
 ### Test structure
 

--- a/src/content/docs/guides/packages/add-operators.mdx
+++ b/src/content/docs/guides/packages/add-operators.mdx
@@ -353,15 +353,24 @@ This hierarchy maps directly to your directory structure:
 The dispatcher operator routes events to specialized mappers, e.g., based on
 event type:
 
-```tql title="operators/ocsf/map.tql"
-if @name == "acme.dns" {
-  acme::ocsf::map::dns
-} else if @name == "acme.http" {
-  acme::ocsf::map::http
-} else if @name == "acme.auth" {
-  acme::ocsf::map::auth
-} else {
-  acme::ocsf::base
+```tql
+from {event_type: "dns"},
+     {event_type: "http"},
+     {event_type: "auth"},
+     {event_type: "other"}
+match event_type {
+  "dns" => {
+    mapper = "dns"
+  }
+  "http" => {
+    mapper = "http"
+  }
+  "auth" => {
+    mapper = "auth"
+  }
+  _ => {
+    mapper = "base"
+  }
 }
 ```
 

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -251,6 +251,81 @@ link_local3 = addr3.is_link_local()
 }
 ```
 
+## Classify values with `match`
+
+Use [`match`](/reference/statements/#match) when you need to assign different
+values for a fixed set of known inputs. A `match` statement compares a field
+against literal patterns from top to bottom and runs the first matching branch.
+
+### Normalize firewall actions
+
+Firewall and network devices often use vendor-specific action names. Normalize
+them into a shared verdict before routing or aggregating the events:
+
+```tql
+from {vendor: "fortinet", action: "accept", src_ip: 10.0.0.5},
+     {vendor: "paloalto", action: "deny", src_ip: 203.0.113.10},
+     {vendor: "checkpoint", action: "drop", src_ip: 192.168.1.20},
+     {vendor: "custom", action: "reset", src_ip: 198.51.100.7}
+match action {
+  "accept", "allow", "pass" => {
+    verdict = "allowed"
+  }
+  "deny", "drop", "block" => {
+    verdict = "blocked"
+  }
+  _ => {
+    verdict = "unknown"
+  }
+}
+```
+
+```tql
+{vendor: "fortinet", action: "accept", src_ip: 10.0.0.5, verdict: "allowed"}
+{vendor: "paloalto", action: "deny", src_ip: 203.0.113.10, verdict: "blocked"}
+{vendor: "checkpoint", action: "drop", src_ip: 192.168.1.20, verdict: "blocked"}
+{vendor: "custom", action: "reset", src_ip: 198.51.100.7, verdict: "unknown"}
+```
+
+### Group DNS record types
+
+You can list multiple patterns in one branch. This is useful for grouping DNS
+record types before you summarize, route, or inspect the records further:
+
+```tql
+from {query: "example.com", record_type: "A"},
+     {query: "example.com", record_type: "AAAA"},
+     {query: "example.com", record_type: "MX"},
+     {query: "example.com", record_type: "TXT"}
+match record_type {
+  "A", "AAAA" => {
+    record_family = "address"
+  }
+  "CNAME", "DNAME" => {
+    record_family = "alias"
+  }
+  "MX", "SRV", "SVCB", "HTTPS" => {
+    record_family = "service_discovery"
+  }
+  "TXT", "SPF", "DKIM", "DMARC" => {
+    record_family = "policy"
+  }
+  _ => {
+    record_family = "other"
+  }
+}
+```
+
+```tql
+{query: "example.com", record_type: "A", record_family: "address"}
+{query: "example.com", record_type: "AAAA", record_family: "address"}
+{query: "example.com", record_type: "MX", record_family: "service_discovery"}
+{query: "example.com", record_type: "TXT", record_family: "policy"}
+```
+
+If you omit the wildcard branch, events that don't match any branch pass
+through unchanged. Use that behavior when you only want to enrich known cases.
+
 ## Basic string operations
 
 Transform strings with simple operations to clean and standardize your data.

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -253,14 +253,16 @@ link_local3 = addr3.is_link_local()
 
 ## Classify values with `match`
 
-Use [`match`](/reference/statements/#match) when you need to assign different
-values for a fixed set of known inputs. A `match` statement compares a field
-against literal patterns from top to bottom and runs the first matching branch.
+Use [`match`](/reference/statements/#match) when a transformation depends on a
+small set of cases. A `match` statement checks patterns from top to bottom and
+runs the first matching branch. Patterns can be constants, alternatives, ranges,
+records, or bindings.
 
 ### Normalize firewall actions
 
-Firewall and network devices often use vendor-specific action names. Normalize
-them into a shared verdict before routing or aggregating the events:
+Firewall and network devices often use vendor-specific action names. Use `|` to
+put equivalent values in the same branch and normalize them into a shared
+verdict before routing or aggregating the events:
 
 ```tql
 from {vendor: "fortinet", action: "accept", src_ip: 10.0.0.5},
@@ -268,10 +270,10 @@ from {vendor: "fortinet", action: "accept", src_ip: 10.0.0.5},
      {vendor: "checkpoint", action: "drop", src_ip: 192.168.1.20},
      {vendor: "custom", action: "reset", src_ip: 198.51.100.7}
 match action {
-  "accept", "allow", "pass" => {
+  "accept" | "allow" | "pass" => {
     verdict = "allowed"
   }
-  "deny", "drop", "block" => {
+  "deny" | "drop" | "block" => {
     verdict = "blocked"
   }
   _ => {
@@ -281,50 +283,182 @@ match action {
 ```
 
 ```tql
-{vendor: "fortinet", action: "accept", src_ip: 10.0.0.5, verdict: "allowed"}
-{vendor: "paloalto", action: "deny", src_ip: 203.0.113.10, verdict: "blocked"}
-{vendor: "checkpoint", action: "drop", src_ip: 192.168.1.20, verdict: "blocked"}
-{vendor: "custom", action: "reset", src_ip: 198.51.100.7, verdict: "unknown"}
+{
+  vendor: "fortinet",
+  action: "accept",
+  src_ip: 10.0.0.5,
+  verdict: "allowed",
+}
+{
+  vendor: "paloalto",
+  action: "deny",
+  src_ip: 203.0.113.10,
+  verdict: "blocked",
+}
+{
+  vendor: "checkpoint",
+  action: "drop",
+  src_ip: 192.168.1.20,
+  verdict: "blocked",
+}
+{
+  vendor: "custom",
+  action: "reset",
+  src_ip: 198.51.100.7,
+  verdict: "unknown",
+}
 ```
 
-### Group DNS record types
+If you omit the wildcard branch, events that don't match any branch pass
+through unchanged. Use that behavior when you only want to enrich known cases.
 
-You can list multiple patterns in one branch. This is useful for grouping DNS
-record types before you summarize, route, or inspect the records further:
+### Classify numeric ranges
+
+Range patterns use `lower..upper` and include both bounds. They're useful for
+bucketizing status codes, ports, scores, or severities:
 
 ```tql
-from {query: "example.com", record_type: "A"},
-     {query: "example.com", record_type: "AAAA"},
-     {query: "example.com", record_type: "MX"},
-     {query: "example.com", record_type: "TXT"}
-match record_type {
-  "A", "AAAA" => {
-    record_family = "address"
+from {status: 200},
+     {status: 204},
+     {status: 404},
+     {status: 503}
+match status {
+  200..299 => {
+    status_class = "success"
   }
-  "CNAME", "DNAME" => {
-    record_family = "alias"
+  400..499 => {
+    status_class = "client_error"
   }
-  "MX", "SRV", "SVCB", "HTTPS" => {
-    record_family = "service_discovery"
-  }
-  "TXT", "SPF", "DKIM", "DMARC" => {
-    record_family = "policy"
+  500..599 => {
+    status_class = "server_error"
   }
   _ => {
-    record_family = "other"
+    status_class = "other"
   }
 }
 ```
 
 ```tql
-{query: "example.com", record_type: "A", record_family: "address"}
-{query: "example.com", record_type: "AAAA", record_family: "address"}
-{query: "example.com", record_type: "MX", record_family: "service_discovery"}
-{query: "example.com", record_type: "TXT", record_family: "policy"}
+{
+  status: 200,
+  status_class: "success",
+}
+{
+  status: 204,
+  status_class: "success",
+}
+{
+  status: 404,
+  status_class: "client_error",
+}
+{
+  status: 503,
+  status_class: "server_error",
+}
 ```
 
-If you omit the wildcard branch, events that don't match any branch pass
-through unchanged. Use that behavior when you only want to enrich known cases.
+### Match records structurally
+
+Record patterns let you classify complete events or nested records without
+writing a long boolean expression. Fields listed in the pattern must exist. Add
+`..` when the input may contain extra fields that you want to ignore:
+
+```tql
+from {action: "allow", dst: {port: 443}, app: "https"},
+     {action: "allow", dst: {port: 22}, app: "ssh"},
+     {action: "deny", dst: {port: 443}, app: "https"}
+match this {
+  {action: "allow", dst: {port: 80..443, ..}, ..} => {
+    policy = "web_allowed"
+  }
+  {action: "deny", dst: {port: 443, ..}, ..} => {
+    policy = "web_blocked"
+  }
+  {..} => {
+    policy = "other"
+  }
+}
+```
+
+```tql
+{
+  action: "allow",
+  dst: {
+    port: 443,
+  },
+  app: "https",
+  policy: "web_allowed",
+}
+{
+  action: "allow",
+  dst: {
+    port: 22,
+  },
+  app: "ssh",
+  policy: "other",
+}
+{
+  action: "deny",
+  dst: {
+    port: 443,
+  },
+  app: "https",
+  policy: "web_blocked",
+}
+```
+
+Without `..`, a record pattern is exact. For example, `{action: "deny"}` only
+matches a record with exactly one field named `action`.
+
+### Capture values from matching records
+
+Use an unresolved `$name` in a pattern to bind the matched value for the branch
+pipeline. This is helpful when the condition and the transformation use the same
+nested value:
+
+```tql
+from {src: {ip: 1.2.3.4, port: 12345}, dst: {port: 443}},
+     {src: {ip: 5.6.7.8, port: 54321}, dst: {port: 80}}
+match this {
+  {src: {ip: $ip, ..}, dst: {port: 443, ..}, ..} => {
+    remote_ip = $ip
+    service = "https"
+  }
+  {src: {ip: $ip, ..}, dst: {port: 80, ..}, ..} => {
+    remote_ip = $ip
+    service = "http"
+  }
+}
+```
+
+```tql
+{
+  src: {
+    ip: 1.2.3.4,
+    port: 12345,
+  },
+  dst: {
+    port: 443,
+  },
+  remote_ip: 1.2.3.4,
+  service: "https",
+}
+{
+  src: {
+    ip: 5.6.7.8,
+    port: 54321,
+  },
+  dst: {
+    port: 80,
+  },
+  remote_ip: 5.6.7.8,
+  service: "http",
+}
+```
+
+A binding name must be unique within an arm. If the same `$name` exists as an
+outer `let` binding, `match` treats it as a constant pattern instead of creating
+a new binding.
 
 ## Basic string operations
 

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -488,6 +488,12 @@ The trailing `..` lets the first event match even though it has an extra
 `"critical"` label. Without `..`, the pattern only matches lists with exactly
 the listed elements.
 
+:::tip[Summary]
+List patterns are order-sensitive. If your input uses labels as an unordered
+set, normalize the list before matching. Use <Fn>distinct</Fn> to remove
+duplicates and <Fn>sort</Fn> to make the element order deterministic.
+:::
+
 ### Match records structurally
 
 Record patterns let you classify complete events or nested records without

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -252,6 +252,81 @@ link_local3 = addr3.is_link_local()
 }
 ```
 
+## Classify values with `match`
+
+Use [`match`](/reference/statements/#match) when you need to assign different
+values for a fixed set of known inputs. A `match` statement compares a field
+against literal patterns from top to bottom and runs the first matching branch.
+
+### Normalize firewall actions
+
+Firewall and network devices often use vendor-specific action names. Normalize
+them into a shared verdict before routing or aggregating the events:
+
+```tql
+from {vendor: "fortinet", action: "accept", src_ip: 10.0.0.5},
+     {vendor: "paloalto", action: "deny", src_ip: 203.0.113.10},
+     {vendor: "checkpoint", action: "drop", src_ip: 192.168.1.20},
+     {vendor: "custom", action: "reset", src_ip: 198.51.100.7}
+match action {
+  "accept", "allow", "pass" => {
+    verdict = "allowed"
+  }
+  "deny", "drop", "block" => {
+    verdict = "blocked"
+  }
+  _ => {
+    verdict = "unknown"
+  }
+}
+```
+
+```tql
+{vendor: "fortinet", action: "accept", src_ip: 10.0.0.5, verdict: "allowed"}
+{vendor: "paloalto", action: "deny", src_ip: 203.0.113.10, verdict: "blocked"}
+{vendor: "checkpoint", action: "drop", src_ip: 192.168.1.20, verdict: "blocked"}
+{vendor: "custom", action: "reset", src_ip: 198.51.100.7, verdict: "unknown"}
+```
+
+### Group DNS record types
+
+You can list multiple patterns in one branch. This is useful for grouping DNS
+record types before you summarize, route, or inspect the records further:
+
+```tql
+from {query: "example.com", record_type: "A"},
+     {query: "example.com", record_type: "AAAA"},
+     {query: "example.com", record_type: "MX"},
+     {query: "example.com", record_type: "TXT"}
+match record_type {
+  "A", "AAAA" => {
+    record_family = "address"
+  }
+  "CNAME", "DNAME" => {
+    record_family = "alias"
+  }
+  "MX", "SRV", "SVCB", "HTTPS" => {
+    record_family = "service_discovery"
+  }
+  "TXT", "SPF", "DKIM", "DMARC" => {
+    record_family = "policy"
+  }
+  _ => {
+    record_family = "other"
+  }
+}
+```
+
+```tql
+{query: "example.com", record_type: "A", record_family: "address"}
+{query: "example.com", record_type: "AAAA", record_family: "address"}
+{query: "example.com", record_type: "MX", record_family: "service_discovery"}
+{query: "example.com", record_type: "TXT", record_family: "policy"}
+```
+
+If you omit the wildcard branch, events that don't match any branch pass
+through unchanged. Use that behavior when you only want to enrich known cases.
+
 ## Basic string operations
 
 Transform strings with simple operations to clean and standardize your data.

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -254,14 +254,16 @@ link_local3 = addr3.is_link_local()
 
 ## Classify values with `match`
 
-Use [`match`](/reference/statements/#match) when you need to assign different
-values for a fixed set of known inputs. A `match` statement compares a field
-against literal patterns from top to bottom and runs the first matching branch.
+Use [`match`](/reference/statements/#match) when a transformation depends on a
+small set of cases. A `match` statement checks patterns from top to bottom and
+runs the first matching branch. Patterns can be constants, alternatives, ranges,
+records, or bindings.
 
 ### Normalize firewall actions
 
-Firewall and network devices often use vendor-specific action names. Normalize
-them into a shared verdict before routing or aggregating the events:
+Firewall and network devices often use vendor-specific action names. Use `|` to
+put equivalent values in the same branch and normalize them into a shared
+verdict before routing or aggregating the events:
 
 ```tql
 from {vendor: "fortinet", action: "accept", src_ip: 10.0.0.5},
@@ -269,10 +271,10 @@ from {vendor: "fortinet", action: "accept", src_ip: 10.0.0.5},
      {vendor: "checkpoint", action: "drop", src_ip: 192.168.1.20},
      {vendor: "custom", action: "reset", src_ip: 198.51.100.7}
 match action {
-  "accept", "allow", "pass" => {
+  "accept" | "allow" | "pass" => {
     verdict = "allowed"
   }
-  "deny", "drop", "block" => {
+  "deny" | "drop" | "block" => {
     verdict = "blocked"
   }
   _ => {
@@ -282,50 +284,182 @@ match action {
 ```
 
 ```tql
-{vendor: "fortinet", action: "accept", src_ip: 10.0.0.5, verdict: "allowed"}
-{vendor: "paloalto", action: "deny", src_ip: 203.0.113.10, verdict: "blocked"}
-{vendor: "checkpoint", action: "drop", src_ip: 192.168.1.20, verdict: "blocked"}
-{vendor: "custom", action: "reset", src_ip: 198.51.100.7, verdict: "unknown"}
+{
+  vendor: "fortinet",
+  action: "accept",
+  src_ip: 10.0.0.5,
+  verdict: "allowed",
+}
+{
+  vendor: "paloalto",
+  action: "deny",
+  src_ip: 203.0.113.10,
+  verdict: "blocked",
+}
+{
+  vendor: "checkpoint",
+  action: "drop",
+  src_ip: 192.168.1.20,
+  verdict: "blocked",
+}
+{
+  vendor: "custom",
+  action: "reset",
+  src_ip: 198.51.100.7,
+  verdict: "unknown",
+}
 ```
 
-### Group DNS record types
+If you omit the wildcard branch, events that don't match any branch pass
+through unchanged. Use that behavior when you only want to enrich known cases.
 
-You can list multiple patterns in one branch. This is useful for grouping DNS
-record types before you summarize, route, or inspect the records further:
+### Classify numeric ranges
+
+Range patterns use `lower..upper` and include both bounds. They're useful for
+bucketizing status codes, ports, scores, or severities:
 
 ```tql
-from {query: "example.com", record_type: "A"},
-     {query: "example.com", record_type: "AAAA"},
-     {query: "example.com", record_type: "MX"},
-     {query: "example.com", record_type: "TXT"}
-match record_type {
-  "A", "AAAA" => {
-    record_family = "address"
+from {status: 200},
+     {status: 204},
+     {status: 404},
+     {status: 503}
+match status {
+  200..299 => {
+    status_class = "success"
   }
-  "CNAME", "DNAME" => {
-    record_family = "alias"
+  400..499 => {
+    status_class = "client_error"
   }
-  "MX", "SRV", "SVCB", "HTTPS" => {
-    record_family = "service_discovery"
-  }
-  "TXT", "SPF", "DKIM", "DMARC" => {
-    record_family = "policy"
+  500..599 => {
+    status_class = "server_error"
   }
   _ => {
-    record_family = "other"
+    status_class = "other"
   }
 }
 ```
 
 ```tql
-{query: "example.com", record_type: "A", record_family: "address"}
-{query: "example.com", record_type: "AAAA", record_family: "address"}
-{query: "example.com", record_type: "MX", record_family: "service_discovery"}
-{query: "example.com", record_type: "TXT", record_family: "policy"}
+{
+  status: 200,
+  status_class: "success",
+}
+{
+  status: 204,
+  status_class: "success",
+}
+{
+  status: 404,
+  status_class: "client_error",
+}
+{
+  status: 503,
+  status_class: "server_error",
+}
 ```
 
-If you omit the wildcard branch, events that don't match any branch pass
-through unchanged. Use that behavior when you only want to enrich known cases.
+### Match records structurally
+
+Record patterns let you classify complete events or nested records without
+writing a long boolean expression. Fields listed in the pattern must exist. Add
+`..` when the input may contain extra fields that you want to ignore:
+
+```tql
+from {action: "allow", dst: {port: 443}, app: "https"},
+     {action: "allow", dst: {port: 22}, app: "ssh"},
+     {action: "deny", dst: {port: 443}, app: "https"}
+match this {
+  {action: "allow", dst: {port: 80..443, ..}, ..} => {
+    policy = "web_allowed"
+  }
+  {action: "deny", dst: {port: 443, ..}, ..} => {
+    policy = "web_blocked"
+  }
+  {..} => {
+    policy = "other"
+  }
+}
+```
+
+```tql
+{
+  action: "allow",
+  dst: {
+    port: 443,
+  },
+  app: "https",
+  policy: "web_allowed",
+}
+{
+  action: "allow",
+  dst: {
+    port: 22,
+  },
+  app: "ssh",
+  policy: "other",
+}
+{
+  action: "deny",
+  dst: {
+    port: 443,
+  },
+  app: "https",
+  policy: "web_blocked",
+}
+```
+
+Without `..`, a record pattern is exact. For example, `{action: "deny"}` only
+matches a record with exactly one field named `action`.
+
+### Capture values from matching records
+
+Use an unresolved `$name` in a pattern to bind the matched value for the branch
+pipeline. This is helpful when the condition and the transformation use the same
+nested value:
+
+```tql
+from {src: {ip: 1.2.3.4, port: 12345}, dst: {port: 443}},
+     {src: {ip: 5.6.7.8, port: 54321}, dst: {port: 80}}
+match this {
+  {src: {ip: $ip, ..}, dst: {port: 443, ..}, ..} => {
+    remote_ip = $ip
+    service = "https"
+  }
+  {src: {ip: $ip, ..}, dst: {port: 80, ..}, ..} => {
+    remote_ip = $ip
+    service = "http"
+  }
+}
+```
+
+```tql
+{
+  src: {
+    ip: 1.2.3.4,
+    port: 12345,
+  },
+  dst: {
+    port: 443,
+  },
+  remote_ip: 1.2.3.4,
+  service: "https",
+}
+{
+  src: {
+    ip: 5.6.7.8,
+    port: 54321,
+  },
+  dst: {
+    port: 80,
+  },
+  remote_ip: 5.6.7.8,
+  service: "http",
+}
+```
+
+A binding name must be unique within an arm. If the same `$name` exists as an
+outer `let` binding, `match` treats it as a constant pattern instead of creating
+a new binding.
 
 ## Basic string operations
 

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -256,7 +256,7 @@ link_local3 = addr3.is_link_local()
 Use [`match`](/reference/statements/#match) when a transformation depends on a
 small set of cases. A `match` statement checks patterns from top to bottom and
 runs the first matching branch. Patterns can be constants, alternatives, ranges,
-records, lists, or bindings. Guards add boolean conditions to matching branches.
+or the wildcard `_`. Guards add boolean conditions to matching branches.
 
 ### Normalize firewall actions
 
@@ -309,12 +309,12 @@ match action {
 }
 ```
 
-If you omit the wildcard branch, events that don't match any branch pass
-through unchanged. Use that behavior when you only want to enrich known cases.
+Every `match` statement must include an unguarded final wildcard branch. Use it
+to handle all values that don't match earlier branches.
 
 ### Classify numeric ranges
 
-Range patterns use `lower..upper` and include both bounds. They're useful for
+Range patterns use `lower..upper` and exclude both bounds. They're useful for
 bucketizing status codes, ports, scores, or severities:
 
 ```tql
@@ -323,13 +323,13 @@ from {status: 200},
      {status: 404},
      {status: 503}
 match status {
-  200..299 => {
+  199..300 => {
     status_class = "success"
   }
-  400..499 => {
+  399..500 => {
     status_class = "client_error"
   }
-  500..599 => {
+  499..600 => {
     status_class = "server_error"
   }
   _ => {
@@ -370,10 +370,10 @@ from {service: "api", status: 503, attempts: 1, max_attempts: 3},
      {service: "api", status: 429, attempts: 2, max_attempts: 2},
      {service: "api", status: 404, attempts: 1, max_attempts: 3}
 match status {
-  500..599 | 429 if attempts < max_attempts => {
+  499..600 | 429 if attempts < max_attempts => {
     action = "retry"
   }
-  500..599 => {
+  499..600 => {
     action = "page"
   }
   429 => {
@@ -421,28 +421,23 @@ attempts remain. When the guard is false, the event continues to the later arms,
 so exhausted `503` errors become pages and exhausted `429` errors become
 throttling signals.
 
-### Match ordered labels
-
-Use list patterns when a field stores ordered labels or tokens. This is useful
-when the first element describes the environment and a later element contains a
-value you want to keep.
+Constants can also be lists or records. These values are compared by equality,
+so the whole value must match:
 
 ```tql
-from {id: 1, labels: ["prod", "checkout", "critical"]},
-     {id: 2, labels: ["prod", "search"]},
-     {id: 3, labels: ["dev", "checkout"]},
-     {id: 4, labels: []}
-match labels {
-  ["prod", $service, ..] => {
-    environment = "production"
-    service = $service
+from {id: 1, value: ["prod", "checkout"]},
+     {id: 2, value: ["prod"]},
+     {id: 3, value: {action: "allow", port: 443}},
+     {id: 4, value: {action: "allow"}}
+match value {
+  ["prod", "checkout"] => {
+    class = "checkout"
   }
-  ["dev", $service, ..] => {
-    environment = "development"
-    service = $service
+  {action: "allow", port: 443} => {
+    class = "allow_web"
   }
-  [] => {
-    environment = "unknown"
+  _ => {
+    class = "other"
   }
 }
 sort id
@@ -451,151 +446,35 @@ sort id
 ```tql
 {
   id: 1,
-  labels: [
+  value: [
     "prod",
     "checkout",
-    "critical",
   ],
-  environment: "production",
-  service: "checkout",
+  class: "checkout",
 }
 {
   id: 2,
-  labels: [
+  value: [
     "prod",
-    "search",
   ],
-  environment: "production",
-  service: "search",
+  class: "other",
 }
 {
   id: 3,
-  labels: [
-    "dev",
-    "checkout",
-  ],
-  environment: "development",
-  service: "checkout",
+  value: {
+    action: "allow",
+    port: 443,
+  },
+  class: "allow_web",
 }
 {
   id: 4,
-  labels: [],
-  environment: "unknown",
+  value: {
+    action: "allow",
+  },
+  class: "other",
 }
 ```
-
-The trailing `..` lets the first event match even though it has an extra
-`"critical"` label. Without `..`, the pattern only matches lists with exactly
-the listed elements.
-
-:::tip[Summary]
-List patterns are order-sensitive. If your input uses labels as an unordered
-set, normalize the list before matching. Use <Fn>distinct</Fn> to remove
-duplicates and <Fn>sort</Fn> to make the element order deterministic.
-:::
-
-### Match records structurally
-
-Record patterns let you classify complete events or nested records without
-writing a long boolean expression. Fields listed in the pattern must exist. Add
-`..` when the input may contain extra fields that you want to ignore:
-
-```tql
-from {action: "allow", dst: {port: 443}, app: "https"},
-     {action: "allow", dst: {port: 22}, app: "ssh"},
-     {action: "deny", dst: {port: 443}, app: "https"}
-match this {
-  {action: "allow", dst: {port: 80..443, ..}, ..} => {
-    policy = "web_allowed"
-  }
-  {action: "deny", dst: {port: 443, ..}, ..} => {
-    policy = "web_blocked"
-  }
-  {..} => {
-    policy = "other"
-  }
-}
-```
-
-```tql
-{
-  action: "allow",
-  dst: {
-    port: 443,
-  },
-  app: "https",
-  policy: "web_allowed",
-}
-{
-  action: "allow",
-  dst: {
-    port: 22,
-  },
-  app: "ssh",
-  policy: "other",
-}
-{
-  action: "deny",
-  dst: {
-    port: 443,
-  },
-  app: "https",
-  policy: "web_blocked",
-}
-```
-
-Without `..`, a record pattern is exact. For example, `{action: "deny"}` only
-matches a record with exactly one field named `action`.
-
-### Capture values from matching records
-
-Use an unresolved `$name` in a pattern to bind the matched value for the branch
-pipeline. This is helpful when the condition and the transformation use the same
-nested value:
-
-```tql
-from {src: {ip: 1.2.3.4, port: 12345}, dst: {port: 443}},
-     {src: {ip: 5.6.7.8, port: 54321}, dst: {port: 80}}
-match this {
-  {src: {ip: $ip, ..}, dst: {port: 443, ..}, ..} => {
-    remote_ip = $ip
-    service = "https"
-  }
-  {src: {ip: $ip, ..}, dst: {port: 80, ..}, ..} => {
-    remote_ip = $ip
-    service = "http"
-  }
-}
-```
-
-```tql
-{
-  src: {
-    ip: 1.2.3.4,
-    port: 12345,
-  },
-  dst: {
-    port: 443,
-  },
-  remote_ip: 1.2.3.4,
-  service: "https",
-}
-{
-  src: {
-    ip: 5.6.7.8,
-    port: 54321,
-  },
-  dst: {
-    port: 80,
-  },
-  remote_ip: 5.6.7.8,
-  service: "http",
-}
-```
-
-A binding name must be unique within an arm. If the same `$name` exists as an
-outer `let` binding, `match` treats it as a constant pattern instead of creating
-a new binding.
 
 ## Basic string operations
 

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -256,7 +256,7 @@ link_local3 = addr3.is_link_local()
 Use [`match`](/reference/statements/#match) when a transformation depends on a
 small set of cases. A `match` statement checks patterns from top to bottom and
 runs the first matching branch. Patterns can be constants, alternatives, ranges,
-records, or bindings.
+records, lists, or bindings. Guards add boolean conditions to matching branches.
 
 ### Normalize firewall actions
 
@@ -356,6 +356,137 @@ match status {
   status_class: "server_error",
 }
 ```
+
+### Add context with guards
+
+Use a guard when the same pattern needs different handling depending on another
+field. This is common for retry decisions: the status code tells you that a
+request failed, but the retry counter decides whether you should retry, page, or
+throttle.
+
+```tql
+from {service: "api", status: 503, attempts: 1, max_attempts: 3},
+     {service: "api", status: 503, attempts: 3, max_attempts: 3},
+     {service: "api", status: 429, attempts: 2, max_attempts: 2},
+     {service: "api", status: 404, attempts: 1, max_attempts: 3}
+match status {
+  500..599 | 429 if attempts < max_attempts => {
+    action = "retry"
+  }
+  500..599 => {
+    action = "page"
+  }
+  429 => {
+    action = "throttle"
+  }
+  _ => {
+    action = "ignore"
+  }
+}
+```
+
+```tql
+{
+  service: "api",
+  status: 503,
+  attempts: 1,
+  max_attempts: 3,
+  action: "retry",
+}
+{
+  service: "api",
+  status: 503,
+  attempts: 3,
+  max_attempts: 3,
+  action: "page",
+}
+{
+  service: "api",
+  status: 429,
+  attempts: 2,
+  max_attempts: 2,
+  action: "throttle",
+}
+{
+  service: "api",
+  status: 404,
+  attempts: 1,
+  max_attempts: 3,
+  action: "ignore",
+}
+```
+
+The guarded branch catches retryable server errors and rate limits only while
+attempts remain. When the guard is false, the event continues to the later arms,
+so exhausted `503` errors become pages and exhausted `429` errors become
+throttling signals.
+
+### Match ordered labels
+
+Use list patterns when a field stores ordered labels or tokens. This is useful
+when the first element describes the environment and a later element contains a
+value you want to keep.
+
+```tql
+from {id: 1, labels: ["prod", "checkout", "critical"]},
+     {id: 2, labels: ["prod", "search"]},
+     {id: 3, labels: ["dev", "checkout"]},
+     {id: 4, labels: []}
+match labels {
+  ["prod", $service, ..] => {
+    environment = "production"
+    service = $service
+  }
+  ["dev", $service, ..] => {
+    environment = "development"
+    service = $service
+  }
+  [] => {
+    environment = "unknown"
+  }
+}
+sort id
+```
+
+```tql
+{
+  id: 1,
+  labels: [
+    "prod",
+    "checkout",
+    "critical",
+  ],
+  environment: "production",
+  service: "checkout",
+}
+{
+  id: 2,
+  labels: [
+    "prod",
+    "search",
+  ],
+  environment: "production",
+  service: "search",
+}
+{
+  id: 3,
+  labels: [
+    "dev",
+    "checkout",
+  ],
+  environment: "development",
+  service: "checkout",
+}
+{
+  id: 4,
+  labels: [],
+  environment: "unknown",
+}
+```
+
+The trailing `..` lets the first event match even though it has an extra
+`"critical"` label. Without `..`, the pattern only matches lists with exactly
+the listed elements.
 
 ### Match records structurally
 

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -257,7 +257,7 @@ link_local3 = addr3.is_link_local()
 Use [`match`](/reference/statements/#match) when a transformation depends on a
 small set of cases. A `match` statement checks patterns from top to bottom and
 runs the first matching branch. Patterns can be constants, alternatives, ranges,
-records, or bindings.
+records, lists, or bindings. Guards add boolean conditions to matching branches.
 
 ### Normalize firewall actions
 
@@ -357,6 +357,137 @@ match status {
   status_class: "server_error",
 }
 ```
+
+### Add context with guards
+
+Use a guard when the same pattern needs different handling depending on another
+field. This is common for retry decisions: the status code tells you that a
+request failed, but the retry counter decides whether you should retry, page, or
+throttle.
+
+```tql
+from {service: "api", status: 503, attempts: 1, max_attempts: 3},
+     {service: "api", status: 503, attempts: 3, max_attempts: 3},
+     {service: "api", status: 429, attempts: 2, max_attempts: 2},
+     {service: "api", status: 404, attempts: 1, max_attempts: 3}
+match status {
+  500..599 | 429 if attempts < max_attempts => {
+    action = "retry"
+  }
+  500..599 => {
+    action = "page"
+  }
+  429 => {
+    action = "throttle"
+  }
+  _ => {
+    action = "ignore"
+  }
+}
+```
+
+```tql
+{
+  service: "api",
+  status: 503,
+  attempts: 1,
+  max_attempts: 3,
+  action: "retry",
+}
+{
+  service: "api",
+  status: 503,
+  attempts: 3,
+  max_attempts: 3,
+  action: "page",
+}
+{
+  service: "api",
+  status: 429,
+  attempts: 2,
+  max_attempts: 2,
+  action: "throttle",
+}
+{
+  service: "api",
+  status: 404,
+  attempts: 1,
+  max_attempts: 3,
+  action: "ignore",
+}
+```
+
+The guarded branch catches retryable server errors and rate limits only while
+attempts remain. When the guard is false, the event continues to the later arms,
+so exhausted `503` errors become pages and exhausted `429` errors become
+throttling signals.
+
+### Match ordered labels
+
+Use list patterns when a field stores ordered labels or tokens. This is useful
+when the first element describes the environment and a later element contains a
+value you want to keep.
+
+```tql
+from {id: 1, labels: ["prod", "checkout", "critical"]},
+     {id: 2, labels: ["prod", "search"]},
+     {id: 3, labels: ["dev", "checkout"]},
+     {id: 4, labels: []}
+match labels {
+  ["prod", $service, ..] => {
+    environment = "production"
+    service = $service
+  }
+  ["dev", $service, ..] => {
+    environment = "development"
+    service = $service
+  }
+  [] => {
+    environment = "unknown"
+  }
+}
+sort id
+```
+
+```tql
+{
+  id: 1,
+  labels: [
+    "prod",
+    "checkout",
+    "critical",
+  ],
+  environment: "production",
+  service: "checkout",
+}
+{
+  id: 2,
+  labels: [
+    "prod",
+    "search",
+  ],
+  environment: "production",
+  service: "search",
+}
+{
+  id: 3,
+  labels: [
+    "dev",
+    "checkout",
+  ],
+  environment: "development",
+  service: "checkout",
+}
+{
+  id: 4,
+  labels: [],
+  environment: "unknown",
+}
+```
+
+The trailing `..` lets the first event match even though it has an extra
+`"critical"` label. Without `..`, the pattern only matches lists with exactly
+the listed elements.
 
 ### Match records structurally
 

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -489,6 +489,12 @@ The trailing `..` lets the first event match even though it has an extra
 `"critical"` label. Without `..`, the pattern only matches lists with exactly
 the listed elements.
 
+:::tip[Summary]
+List patterns are order-sensitive. If your input uses labels as an unordered
+set, normalize the list before matching. Use <Fn>distinct</Fn> to remove
+duplicates and <Fn>sort</Fn> to make the element order deterministic.
+:::
+
 ### Match records structurally
 
 Record patterns let you classify complete events or nested records without

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -257,7 +257,7 @@ link_local3 = addr3.is_link_local()
 Use [`match`](/reference/statements/#match) when a transformation depends on a
 small set of cases. A `match` statement checks patterns from top to bottom and
 runs the first matching branch. Patterns can be constants, alternatives, ranges,
-records, lists, or bindings. Guards add boolean conditions to matching branches.
+or the wildcard `_`. Guards add boolean conditions to matching branches.
 
 ### Normalize firewall actions
 
@@ -310,12 +310,12 @@ match action {
 }
 ```
 
-If you omit the wildcard branch, events that don't match any branch pass
-through unchanged. Use that behavior when you only want to enrich known cases.
+Every `match` statement must include an unguarded final wildcard branch. Use it
+to handle all values that don't match earlier branches.
 
 ### Classify numeric ranges
 
-Range patterns use `lower..upper` and include both bounds. They're useful for
+Range patterns use `lower..upper` and exclude both bounds. They're useful for
 bucketizing status codes, ports, scores, or severities:
 
 ```tql
@@ -324,13 +324,13 @@ from {status: 200},
      {status: 404},
      {status: 503}
 match status {
-  200..299 => {
+  199..300 => {
     status_class = "success"
   }
-  400..499 => {
+  399..500 => {
     status_class = "client_error"
   }
-  500..599 => {
+  499..600 => {
     status_class = "server_error"
   }
   _ => {
@@ -371,10 +371,10 @@ from {service: "api", status: 503, attempts: 1, max_attempts: 3},
      {service: "api", status: 429, attempts: 2, max_attempts: 2},
      {service: "api", status: 404, attempts: 1, max_attempts: 3}
 match status {
-  500..599 | 429 if attempts < max_attempts => {
+  499..600 | 429 if attempts < max_attempts => {
     action = "retry"
   }
-  500..599 => {
+  499..600 => {
     action = "page"
   }
   429 => {
@@ -422,28 +422,23 @@ attempts remain. When the guard is false, the event continues to the later arms,
 so exhausted `503` errors become pages and exhausted `429` errors become
 throttling signals.
 
-### Match ordered labels
-
-Use list patterns when a field stores ordered labels or tokens. This is useful
-when the first element describes the environment and a later element contains a
-value you want to keep.
+Constants can also be lists or records. These values are compared by equality,
+so the whole value must match:
 
 ```tql
-from {id: 1, labels: ["prod", "checkout", "critical"]},
-     {id: 2, labels: ["prod", "search"]},
-     {id: 3, labels: ["dev", "checkout"]},
-     {id: 4, labels: []}
-match labels {
-  ["prod", $service, ..] => {
-    environment = "production"
-    service = $service
+from {id: 1, value: ["prod", "checkout"]},
+     {id: 2, value: ["prod"]},
+     {id: 3, value: {action: "allow", port: 443}},
+     {id: 4, value: {action: "allow"}}
+match value {
+  ["prod", "checkout"] => {
+    class = "checkout"
   }
-  ["dev", $service, ..] => {
-    environment = "development"
-    service = $service
+  {action: "allow", port: 443} => {
+    class = "allow_web"
   }
-  [] => {
-    environment = "unknown"
+  _ => {
+    class = "other"
   }
 }
 sort id
@@ -452,151 +447,35 @@ sort id
 ```tql
 {
   id: 1,
-  labels: [
+  value: [
     "prod",
     "checkout",
-    "critical",
   ],
-  environment: "production",
-  service: "checkout",
+  class: "checkout",
 }
 {
   id: 2,
-  labels: [
+  value: [
     "prod",
-    "search",
   ],
-  environment: "production",
-  service: "search",
+  class: "other",
 }
 {
   id: 3,
-  labels: [
-    "dev",
-    "checkout",
-  ],
-  environment: "development",
-  service: "checkout",
+  value: {
+    action: "allow",
+    port: 443,
+  },
+  class: "allow_web",
 }
 {
   id: 4,
-  labels: [],
-  environment: "unknown",
+  value: {
+    action: "allow",
+  },
+  class: "other",
 }
 ```
-
-The trailing `..` lets the first event match even though it has an extra
-`"critical"` label. Without `..`, the pattern only matches lists with exactly
-the listed elements.
-
-:::tip[Summary]
-List patterns are order-sensitive. If your input uses labels as an unordered
-set, normalize the list before matching. Use <Fn>distinct</Fn> to remove
-duplicates and <Fn>sort</Fn> to make the element order deterministic.
-:::
-
-### Match records structurally
-
-Record patterns let you classify complete events or nested records without
-writing a long boolean expression. Fields listed in the pattern must exist. Add
-`..` when the input may contain extra fields that you want to ignore:
-
-```tql
-from {action: "allow", dst: {port: 443}, app: "https"},
-     {action: "allow", dst: {port: 22}, app: "ssh"},
-     {action: "deny", dst: {port: 443}, app: "https"}
-match this {
-  {action: "allow", dst: {port: 80..443, ..}, ..} => {
-    policy = "web_allowed"
-  }
-  {action: "deny", dst: {port: 443, ..}, ..} => {
-    policy = "web_blocked"
-  }
-  {..} => {
-    policy = "other"
-  }
-}
-```
-
-```tql
-{
-  action: "allow",
-  dst: {
-    port: 443,
-  },
-  app: "https",
-  policy: "web_allowed",
-}
-{
-  action: "allow",
-  dst: {
-    port: 22,
-  },
-  app: "ssh",
-  policy: "other",
-}
-{
-  action: "deny",
-  dst: {
-    port: 443,
-  },
-  app: "https",
-  policy: "web_blocked",
-}
-```
-
-Without `..`, a record pattern is exact. For example, `{action: "deny"}` only
-matches a record with exactly one field named `action`.
-
-### Capture values from matching records
-
-Use an unresolved `$name` in a pattern to bind the matched value for the branch
-pipeline. This is helpful when the condition and the transformation use the same
-nested value:
-
-```tql
-from {src: {ip: 1.2.3.4, port: 12345}, dst: {port: 443}},
-     {src: {ip: 5.6.7.8, port: 54321}, dst: {port: 80}}
-match this {
-  {src: {ip: $ip, ..}, dst: {port: 443, ..}, ..} => {
-    remote_ip = $ip
-    service = "https"
-  }
-  {src: {ip: $ip, ..}, dst: {port: 80, ..}, ..} => {
-    remote_ip = $ip
-    service = "http"
-  }
-}
-```
-
-```tql
-{
-  src: {
-    ip: 1.2.3.4,
-    port: 12345,
-  },
-  dst: {
-    port: 443,
-  },
-  remote_ip: 1.2.3.4,
-  service: "https",
-}
-{
-  src: {
-    ip: 5.6.7.8,
-    port: 54321,
-  },
-  dst: {
-    port: 80,
-  },
-  remote_ip: 5.6.7.8,
-  service: "http",
-}
-```
-
-A binding name must be unique within an arm. If the same `$name` exists as an
-outer `let` binding, `match` treats it as a constant pattern instead of creating
-a new binding.
 
 ## Basic string operations
 

--- a/src/content/docs/reference/expressions.mdx
+++ b/src/content/docs/reference/expressions.mdx
@@ -876,6 +876,10 @@ The expression evaluates as `(1 - (2 * 3)) + 4`. Example: `1 + 2 * 3` evaluates 
 
 ## Conditional Expressions
 
+Use conditional expressions when one value depends on a predicate. If you need to
+route events through different statements based on literal values, use the
+[`match` statement](/reference/statements/#match).
+
 ### Python-style Conditionals
 
 TQL uses Python-style conditional expressions, i.e., `x if condition else y`

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -261,6 +261,8 @@ In this example, events with any other `record_type` continue downstream without
 a `record_family` field. Branch pipelines follow the same output type rules as
 `if` branches.
 
+### Record patterns
+
 Record patterns match record values structurally. Listed fields must exist and
 match their nested patterns. Without `..`, the pattern is exact and rejects extra
 fields. With `..`, extra fields are ignored.
@@ -279,6 +281,8 @@ match this {
 }
 ```
 
+### Range patterns
+
 Range patterns use `lower..upper` and include both bounds.
 
 ```tql
@@ -294,6 +298,8 @@ match status {
   }
 }
 ```
+
+### Bindings
 
 Bindings capture matched values for use in the arm pipeline. A binding name must
 be unique within an arm. If the same `$name` exists as an outer `let` binding,

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -216,3 +216,47 @@ if src_ip.is_private() {
   zone = "external"
 }
 ```
+
+## `match`
+
+The `match` statement routes events by comparing one expression against literal
+patterns. Tenzir evaluates the expression once for each input batch, checks the
+arms from top to bottom, and sends each event to the first matching arm.
+
+```tql
+match action {
+  "accept", "allow" => {
+    verdict = "allowed"
+  }
+  "deny", "drop" => {
+    verdict = "blocked"
+  }
+  _ => {
+    verdict = "unknown"
+  }
+}
+```
+
+Each arm contains one or more comma-separated patterns followed by a pipeline in
+braces. Patterns must be literal constants, such as strings, numbers, booleans,
+`null`, durations, times, IP addresses, or subnets. A negative numeric literal,
+such as `-1`, is also valid.
+
+Use `_` as a wildcard fallback for all remaining events. The wildcard must be
+the only pattern in its arm and must be the final arm. If you omit the wildcard,
+events that don't match any arm pass through unchanged.
+
+```tql
+match record_type {
+  "A", "AAAA" => {
+    record_family = "address"
+  }
+  "CNAME", "DNAME" => {
+    record_family = "alias"
+  }
+}
+```
+
+In this example, events with any other `record_type` continue downstream without
+a `record_family` field. Branch pipelines follow the same output type rules as
+`if` branches.

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -219,16 +219,16 @@ if src_ip.is_private() {
 
 ## `match`
 
-The `match` statement routes events by comparing one expression against literal
+The `match` statement routes events by comparing one expression against
 patterns. Tenzir evaluates the expression once for each input batch, checks the
 arms from top to bottom, and sends each event to the first matching arm.
 
 ```tql
 match action {
-  "accept", "allow" => {
+  "accept" | "allow" => {
     verdict = "allowed"
   }
-  "deny", "drop" => {
+  "deny" | "drop" => {
     verdict = "blocked"
   }
   _ => {
@@ -237,10 +237,10 @@ match action {
 }
 ```
 
-Each arm contains one or more comma-separated patterns followed by a pipeline in
-braces. Patterns must be literal constants, such as strings, numbers, booleans,
-`null`, durations, times, IP addresses, or subnets. A negative numeric literal,
-such as `-1`, is also valid.
+Use `|` to list multiple alternatives for the same arm. Each arm contains one or
+more patterns followed by a pipeline in braces. Constant patterns include
+strings, numbers, booleans, `null`, durations, times, IP addresses, and subnets.
+A negative numeric literal, such as `-1`, is also valid.
 
 Use `_` as a wildcard fallback for all remaining events. The wildcard must be
 the only pattern in its arm and must be the final arm. If you omit the wildcard,
@@ -248,10 +248,10 @@ events that don't match any arm pass through unchanged.
 
 ```tql
 match record_type {
-  "A", "AAAA" => {
+  "A" | "AAAA" => {
     record_family = "address"
   }
-  "CNAME", "DNAME" => {
+  "CNAME" | "DNAME" => {
     record_family = "alias"
   }
 }
@@ -260,3 +260,49 @@ match record_type {
 In this example, events with any other `record_type` continue downstream without
 a `record_family` field. Branch pipelines follow the same output type rules as
 `if` branches.
+
+Record patterns match record values structurally. Listed fields must exist and
+match their nested patterns. Without `..`, the pattern is exact and rejects extra
+fields. With `..`, extra fields are ignored.
+
+```tql
+match this {
+  {action: "allow", dst_port: 80..443, ..} => {
+    verdict = "web allow"
+  }
+  {action: "deny"} => {
+    verdict = "exact deny record"
+  }
+  {..} => {
+    verdict = "other record"
+  }
+}
+```
+
+Range patterns use `lower..upper` and include both bounds.
+
+```tql
+match status {
+  200..299 => {
+    class = "success"
+  }
+  400..499 => {
+    class = "client error"
+  }
+  500..599 => {
+    class = "server error"
+  }
+}
+```
+
+Bindings capture matched values for use in the arm pipeline. A binding name must
+be unique within an arm. If the same `$name` exists as an outer `let` binding,
+`match` treats it as a constant pattern instead.
+
+```tql
+match this {
+  {src: {ip: $ip, ..}, dst: {port: 443, ..}, ..} => {
+    remote_ip = $ip
+  }
+}
+```

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -237,15 +237,16 @@ match action {
 ```
 
 Use `|` to list multiple alternatives for the same arm. Each arm contains one or
-more patterns followed by a pipeline in braces. Constant patterns include
-strings, numbers, booleans, `null`, durations, times, IP addresses, and subnets.
-A negative numeric literal, such as `-1`, is also valid.
+more patterns, an optional guard, and a pipeline in braces. Constant patterns
+include strings, numbers, booleans, `null`, durations, times, IP addresses, and
+subnets. A negative numeric literal, such as `-1`, is also valid.
 
 Use `_` as a wildcard fallback for all remaining events. The wildcard must be
-the only pattern in its arm and must be the final arm. A standalone binding, such
-as `$value`, also matches all remaining events and must be in the final arm. If
-you omit a wildcard or another irrefutable final arm, events that don't match any
-arm pass through unchanged.
+the only pattern in its arm and must be the final arm, unless the arm has a
+guard. A guarded wildcard can fail and later arms can still match. An unguarded
+standalone binding, such as `$value`, also matches all remaining events and must
+be in the final arm. If you omit a wildcard or another irrefutable final arm,
+events that don't match any arm pass through unchanged.
 
 ```tql
 match record_type {
@@ -261,6 +262,94 @@ match record_type {
 In this example, events with any other `record_type` continue downstream without
 a `record_family` field. Branch pipelines follow the same output type rules as
 `if` branches.
+
+### Guards
+
+Add `if` between the pattern list and `=>` to require an additional boolean
+condition. Tenzir evaluates patterns first. If a pattern matches, Tenzir
+evaluates the guard for that event. The arm only receives events where the guard
+is `true`; events where the guard is `false` or `null` continue to later arms.
+
+```tql
+match status {
+  500..599 | 429 if retries > 0 => {
+    action = "retry"
+  }
+  500..599 => {
+    action = "page"
+  }
+  _ => {
+    action = "ignore"
+  }
+}
+```
+
+Bindings from the matched pattern are available in the guard and in the arm
+pipeline:
+
+```tql
+match this {
+  {src: {ip: $ip, ..}, ..} if $ip.is_private() => {
+    zone = "internal"
+  }
+  {src: {ip: $ip, ..}, ..} => {
+    zone = "external"
+  }
+}
+```
+
+A guard expression must evaluate to `bool`. If it evaluates to another type,
+Tenzir emits a warning and treats the arm as not matching for those events.
+
+A wildcard arm with a guard is not a fallback for every remaining event:
+
+```tql
+match status {
+  _ if status == 404 => {
+    class = "not_found"
+  }
+  _ => {
+    class = "other"
+  }
+}
+```
+
+When you combine guarded alternatives with bindings, each alternative must bind
+the same names from the same matched paths. If the alternatives need different
+bindings, split them into separate guarded arms.
+
+### List patterns
+
+List patterns match list values structurally. Elements are matched in order.
+Without `..`, the list must have exactly the listed elements. With a trailing
+`..`, the list may contain additional trailing elements.
+
+```tql
+match tags {
+  ["prod", $service, ..] => {
+    environment = "production"
+    service = $service
+  }
+  [] => {
+    environment = "unknown"
+  }
+  [..] => {
+    environment = "other"
+  }
+}
+```
+
+You can nest list patterns anywhere a pattern is accepted:
+
+```tql
+match this {
+  {labels: ["prod", $service, ..], ..} => {
+    service = $service
+  }
+}
+```
+
+The `..` rest marker is only valid as the final list item.
 
 ### Record patterns
 

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -243,8 +243,10 @@ strings, numbers, booleans, `null`, durations, times, IP addresses, and subnets.
 A negative numeric literal, such as `-1`, is also valid.
 
 Use `_` as a wildcard fallback for all remaining events. The wildcard must be
-the only pattern in its arm and must be the final arm. If you omit the wildcard,
-events that don't match any arm pass through unchanged.
+the only pattern in its arm and must be the final arm. A standalone binding, such
+as `$value`, also matches all remaining events and must be in the final arm. If
+you omit a wildcard or another irrefutable final arm, events that don't match any
+arm pass through unchanged.
 
 ```tql
 match record_type {
@@ -312,3 +314,7 @@ match this {
   }
 }
 ```
+
+Use a binding before you assign to the field it came from. Tenzir rejects arm
+pipelines that read a binding after assigning to the matched field, because that
+would make the binding depend on the mutation order inside the arm.

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -215,3 +215,47 @@ if src_ip.is_private() {
   zone = "external"
 }
 ```
+
+## `match`
+
+The `match` statement routes events by comparing one expression against literal
+patterns. Tenzir evaluates the expression once for each input batch, checks the
+arms from top to bottom, and sends each event to the first matching arm.
+
+```tql
+match action {
+  "accept", "allow" => {
+    verdict = "allowed"
+  }
+  "deny", "drop" => {
+    verdict = "blocked"
+  }
+  _ => {
+    verdict = "unknown"
+  }
+}
+```
+
+Each arm contains one or more comma-separated patterns followed by a pipeline in
+braces. Patterns must be literal constants, such as strings, numbers, booleans,
+`null`, durations, times, IP addresses, or subnets. A negative numeric literal,
+such as `-1`, is also valid.
+
+Use `_` as a wildcard fallback for all remaining events. The wildcard must be
+the only pattern in its arm and must be the final arm. If you omit the wildcard,
+events that don't match any arm pass through unchanged.
+
+```tql
+match record_type {
+  "A", "AAAA" => {
+    record_family = "address"
+  }
+  "CNAME", "DNAME" => {
+    record_family = "alias"
+  }
+}
+```
+
+In this example, events with any other `record_type` continue downstream without
+a `record_family` field. Branch pipelines follow the same output type rules as
+`if` branches.

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -260,6 +260,8 @@ In this example, events with any other `record_type` continue downstream without
 a `record_family` field. Branch pipelines follow the same output type rules as
 `if` branches.
 
+### Record patterns
+
 Record patterns match record values structurally. Listed fields must exist and
 match their nested patterns. Without `..`, the pattern is exact and rejects extra
 fields. With `..`, extra fields are ignored.
@@ -278,6 +280,8 @@ match this {
 }
 ```
 
+### Range patterns
+
 Range patterns use `lower..upper` and include both bounds.
 
 ```tql
@@ -293,6 +297,8 @@ match status {
   }
 }
 ```
+
+### Bindings
 
 Bindings capture matched values for use in the arm pipeline. A binding name must
 be unique within an arm. If the same `$name` exists as an outer `let` binding,

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -238,15 +238,16 @@ match action {
 ```
 
 Use `|` to list multiple alternatives for the same arm. Each arm contains one or
-more patterns followed by a pipeline in braces. Constant patterns include
-strings, numbers, booleans, `null`, durations, times, IP addresses, and subnets.
-A negative numeric literal, such as `-1`, is also valid.
+more patterns, an optional guard, and a pipeline in braces. Constant patterns
+include strings, numbers, booleans, `null`, durations, times, IP addresses, and
+subnets. A negative numeric literal, such as `-1`, is also valid.
 
 Use `_` as a wildcard fallback for all remaining events. The wildcard must be
-the only pattern in its arm and must be the final arm. A standalone binding, such
-as `$value`, also matches all remaining events and must be in the final arm. If
-you omit a wildcard or another irrefutable final arm, events that don't match any
-arm pass through unchanged.
+the only pattern in its arm and must be the final arm, unless the arm has a
+guard. A guarded wildcard can fail and later arms can still match. An unguarded
+standalone binding, such as `$value`, also matches all remaining events and must
+be in the final arm. If you omit a wildcard or another irrefutable final arm,
+events that don't match any arm pass through unchanged.
 
 ```tql
 match record_type {
@@ -262,6 +263,94 @@ match record_type {
 In this example, events with any other `record_type` continue downstream without
 a `record_family` field. Branch pipelines follow the same output type rules as
 `if` branches.
+
+### Guards
+
+Add `if` between the pattern list and `=>` to require an additional boolean
+condition. Tenzir evaluates patterns first. If a pattern matches, Tenzir
+evaluates the guard for that event. The arm only receives events where the guard
+is `true`; events where the guard is `false` or `null` continue to later arms.
+
+```tql
+match status {
+  500..599 | 429 if retries > 0 => {
+    action = "retry"
+  }
+  500..599 => {
+    action = "page"
+  }
+  _ => {
+    action = "ignore"
+  }
+}
+```
+
+Bindings from the matched pattern are available in the guard and in the arm
+pipeline:
+
+```tql
+match this {
+  {src: {ip: $ip, ..}, ..} if $ip.is_private() => {
+    zone = "internal"
+  }
+  {src: {ip: $ip, ..}, ..} => {
+    zone = "external"
+  }
+}
+```
+
+A guard expression must evaluate to `bool`. If it evaluates to another type,
+Tenzir emits a warning and treats the arm as not matching for those events.
+
+A wildcard arm with a guard is not a fallback for every remaining event:
+
+```tql
+match status {
+  _ if status == 404 => {
+    class = "not_found"
+  }
+  _ => {
+    class = "other"
+  }
+}
+```
+
+When you combine guarded alternatives with bindings, each alternative must bind
+the same names from the same matched paths. If the alternatives need different
+bindings, split them into separate guarded arms.
+
+### List patterns
+
+List patterns match list values structurally. Elements are matched in order.
+Without `..`, the list must have exactly the listed elements. With a trailing
+`..`, the list may contain additional trailing elements.
+
+```tql
+match tags {
+  ["prod", $service, ..] => {
+    environment = "production"
+    service = $service
+  }
+  [] => {
+    environment = "unknown"
+  }
+  [..] => {
+    environment = "other"
+  }
+}
+```
+
+You can nest list patterns anywhere a pattern is accepted:
+
+```tql
+match this {
+  {labels: ["prod", $service, ..], ..} => {
+    service = $service
+  }
+}
+```
+
+The `..` rest marker is only valid as the final list item.
 
 ### Record patterns
 

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -219,10 +219,13 @@ if src_ip.is_private() {
 ## `match`
 
 The `match` statement routes events by comparing one expression against
-patterns. Tenzir evaluates the expression once for each input batch, checks the
-arms from top to bottom, and sends each event to the first matching arm.
+patterns. Tenzir evaluates the expression for each event, checks the arms from
+top to bottom, and sends the event to the first matching arm.
 
 ```tql
+from {action: "accept"},
+     {action: "deny"},
+     {action: "reset"}
 match action {
   "accept" | "allow" => {
     verdict = "allowed"
@@ -250,6 +253,9 @@ unguarded final wildcard arm, so Tenzir can prove at compile time that the arms
 cover every possible value.
 
 ```tql
+from {record_type: "A"},
+     {record_type: "CNAME"},
+     {record_type: "TXT"}
 match record_type {
   "A" | "AAAA" => {
     record_family = "address"
@@ -273,6 +279,9 @@ evaluates the guard for that event. The arm only receives events where the guard
 is `true`; events where the guard is `false` or `null` continue to later arms.
 
 ```tql
+from {status: 503, retries: 1},
+     {status: 503, retries: 0},
+     {status: 404, retries: 0}
 match status {
   499..600 | 429 if retries > 0 => {
     action = "retry"
@@ -292,6 +301,8 @@ Tenzir emits a warning and treats the arm as not matching for those events.
 A wildcard arm with a guard is not a fallback for every remaining event:
 
 ```tql
+from {status: 404},
+     {status: 500}
 match status {
   _ if status == 404 => {
     class = "not_found"
@@ -305,6 +316,10 @@ match status {
 List and record constants are compared by equality:
 
 ```tql
+from {value: ["prod", "checkout"]},
+     {value: ["prod"]},
+     {value: {action: "allow", port: 443}},
+     {value: {action: "allow"}}
 match value {
   ["prod", "checkout"] => {
     class = "checkout"
@@ -323,6 +338,9 @@ match value {
 Range patterns use `lower..upper` and exclude both bounds.
 
 ```tql
+from {status: 200},
+     {status: 404},
+     {status: 503}
 match status {
   199..300 => {
     class = "success"

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -218,16 +218,16 @@ if src_ip.is_private() {
 
 ## `match`
 
-The `match` statement routes events by comparing one expression against literal
+The `match` statement routes events by comparing one expression against
 patterns. Tenzir evaluates the expression once for each input batch, checks the
 arms from top to bottom, and sends each event to the first matching arm.
 
 ```tql
 match action {
-  "accept", "allow" => {
+  "accept" | "allow" => {
     verdict = "allowed"
   }
-  "deny", "drop" => {
+  "deny" | "drop" => {
     verdict = "blocked"
   }
   _ => {
@@ -236,10 +236,10 @@ match action {
 }
 ```
 
-Each arm contains one or more comma-separated patterns followed by a pipeline in
-braces. Patterns must be literal constants, such as strings, numbers, booleans,
-`null`, durations, times, IP addresses, or subnets. A negative numeric literal,
-such as `-1`, is also valid.
+Use `|` to list multiple alternatives for the same arm. Each arm contains one or
+more patterns followed by a pipeline in braces. Constant patterns include
+strings, numbers, booleans, `null`, durations, times, IP addresses, and subnets.
+A negative numeric literal, such as `-1`, is also valid.
 
 Use `_` as a wildcard fallback for all remaining events. The wildcard must be
 the only pattern in its arm and must be the final arm. If you omit the wildcard,
@@ -247,10 +247,10 @@ events that don't match any arm pass through unchanged.
 
 ```tql
 match record_type {
-  "A", "AAAA" => {
+  "A" | "AAAA" => {
     record_family = "address"
   }
-  "CNAME", "DNAME" => {
+  "CNAME" | "DNAME" => {
     record_family = "alias"
   }
 }
@@ -259,3 +259,49 @@ match record_type {
 In this example, events with any other `record_type` continue downstream without
 a `record_family` field. Branch pipelines follow the same output type rules as
 `if` branches.
+
+Record patterns match record values structurally. Listed fields must exist and
+match their nested patterns. Without `..`, the pattern is exact and rejects extra
+fields. With `..`, extra fields are ignored.
+
+```tql
+match this {
+  {action: "allow", dst_port: 80..443, ..} => {
+    verdict = "web allow"
+  }
+  {action: "deny"} => {
+    verdict = "exact deny record"
+  }
+  {..} => {
+    verdict = "other record"
+  }
+}
+```
+
+Range patterns use `lower..upper` and include both bounds.
+
+```tql
+match status {
+  200..299 => {
+    class = "success"
+  }
+  400..499 => {
+    class = "client error"
+  }
+  500..599 => {
+    class = "server error"
+  }
+}
+```
+
+Bindings capture matched values for use in the arm pipeline. A binding name must
+be unique within an arm. If the same `$name` exists as an outer `let` binding,
+`match` treats it as a constant pattern instead.
+
+```tql
+match this {
+  {src: {ip: $ip, ..}, dst: {port: 443, ..}, ..} => {
+    remote_ip = $ip
+  }
+}
+```

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -238,15 +238,16 @@ match action {
 
 Use `|` to list multiple alternatives for the same arm. Each arm contains one or
 more patterns, an optional guard, and a pipeline in braces. Constant patterns
-include strings, numbers, booleans, `null`, durations, times, IP addresses, and
-subnets. A negative numeric literal, such as `-1`, is also valid.
+include strings, numbers, booleans, `null`, durations, times, IP addresses,
+subnets, lists, and records. A negative numeric literal, such as `-1`, is also
+valid.
 
 Use `_` as a wildcard fallback for all remaining events. The wildcard must be
 the only pattern in its arm and must be the final arm, unless the arm has a
-guard. A guarded wildcard can fail and later arms can still match. An unguarded
-standalone binding, such as `$value`, also matches all remaining events and must
-be in the final arm. If you omit a wildcard or another irrefutable final arm,
-events that don't match any arm pass through unchanged.
+guard. A guarded wildcard can fail and later arms can still match, but it does
+not make the `match` exhaustive. Every `match` statement must include an
+unguarded final wildcard arm, so Tenzir can prove at compile time that the arms
+cover every possible value.
 
 ```tql
 match record_type {
@@ -256,12 +257,13 @@ match record_type {
   "CNAME" | "DNAME" => {
     record_family = "alias"
   }
+  _ => {
+    record_family = "other"
+  }
 }
 ```
 
-In this example, events with any other `record_type` continue downstream without
-a `record_family` field. Branch pipelines follow the same output type rules as
-`if` branches.
+Branch pipelines follow the same output type rules as `if` branches.
 
 ### Guards
 
@@ -272,28 +274,14 @@ is `true`; events where the guard is `false` or `null` continue to later arms.
 
 ```tql
 match status {
-  500..599 | 429 if retries > 0 => {
+  499..600 | 429 if retries > 0 => {
     action = "retry"
   }
-  500..599 => {
+  499..600 => {
     action = "page"
   }
   _ => {
     action = "ignore"
-  }
-}
-```
-
-Bindings from the matched pattern are available in the guard and in the arm
-pipeline:
-
-```tql
-match this {
-  {src: {ip: $ip, ..}, ..} if $ip.is_private() => {
-    zone = "internal"
-  }
-  {src: {ip: $ip, ..}, ..} => {
-    zone = "external"
   }
 }
 ```
@@ -314,95 +302,39 @@ match status {
 }
 ```
 
-When you combine guarded alternatives with bindings, each alternative must bind
-the same names from the same matched paths. If the alternatives need different
-bindings, split them into separate guarded arms.
-
-### List patterns
-
-List patterns match list values structurally. Elements are matched in order.
-Without `..`, the list must have exactly the listed elements. With a trailing
-`..`, the list may contain additional trailing elements.
+List and record constants are compared by equality:
 
 ```tql
-match tags {
-  ["prod", $service, ..] => {
-    environment = "production"
-    service = $service
+match value {
+  ["prod", "checkout"] => {
+    class = "checkout"
   }
-  [] => {
-    environment = "unknown"
+  {action: "allow", port: 443} => {
+    class = "allow web"
   }
-  [..] => {
-    environment = "other"
-  }
-}
-```
-
-You can nest list patterns anywhere a pattern is accepted:
-
-```tql
-match this {
-  {labels: ["prod", $service, ..], ..} => {
-    service = $service
-  }
-}
-```
-
-The `..` rest marker is only valid as the final list item.
-
-### Record patterns
-
-Record patterns match record values structurally. Listed fields must exist and
-match their nested patterns. Without `..`, the pattern is exact and rejects extra
-fields. With `..`, extra fields are ignored.
-
-```tql
-match this {
-  {action: "allow", dst_port: 80..443, ..} => {
-    verdict = "web allow"
-  }
-  {action: "deny"} => {
-    verdict = "exact deny record"
-  }
-  {..} => {
-    verdict = "other record"
+  _ => {
+    class = "other"
   }
 }
 ```
 
 ### Range patterns
 
-Range patterns use `lower..upper` and include both bounds.
+Range patterns use `lower..upper` and exclude both bounds.
 
 ```tql
 match status {
-  200..299 => {
+  199..300 => {
     class = "success"
   }
-  400..499 => {
+  399..500 => {
     class = "client error"
   }
-  500..599 => {
+  499..600 => {
     class = "server error"
   }
-}
-```
-
-### Bindings
-
-Bindings capture matched values for use in the arm pipeline. A binding name must
-be unique within an arm. If the same `$name` exists as an outer `let` binding,
-`match` treats it as a constant pattern instead.
-
-```tql
-match this {
-  {src: {ip: $ip, ..}, dst: {port: 443, ..}, ..} => {
-    remote_ip = $ip
+  _ => {
+    class = "other"
   }
 }
 ```
-
-Use a binding before you assign to the field it came from. Tenzir rejects arm
-pipelines that read a binding after assigning to the matched field, because that
-would make the binding depend on the mutation order inside the arm.

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -242,8 +242,10 @@ strings, numbers, booleans, `null`, durations, times, IP addresses, and subnets.
 A negative numeric literal, such as `-1`, is also valid.
 
 Use `_` as a wildcard fallback for all remaining events. The wildcard must be
-the only pattern in its arm and must be the final arm. If you omit the wildcard,
-events that don't match any arm pass through unchanged.
+the only pattern in its arm and must be the final arm. A standalone binding, such
+as `$value`, also matches all remaining events and must be in the final arm. If
+you omit a wildcard or another irrefutable final arm, events that don't match any
+arm pass through unchanged.
 
 ```tql
 match record_type {
@@ -311,3 +313,7 @@ match this {
   }
 }
 ```
+
+Use a binding before you assign to the field it came from. Tenzir rejects arm
+pipelines that read a binding after assigning to the matched field, because that
+would make the binding depend on the mutation order inside the arm.

--- a/src/content/docs/reference/statements.mdx
+++ b/src/content/docs/reference/statements.mdx
@@ -239,15 +239,16 @@ match action {
 
 Use `|` to list multiple alternatives for the same arm. Each arm contains one or
 more patterns, an optional guard, and a pipeline in braces. Constant patterns
-include strings, numbers, booleans, `null`, durations, times, IP addresses, and
-subnets. A negative numeric literal, such as `-1`, is also valid.
+include strings, numbers, booleans, `null`, durations, times, IP addresses,
+subnets, lists, and records. A negative numeric literal, such as `-1`, is also
+valid.
 
 Use `_` as a wildcard fallback for all remaining events. The wildcard must be
 the only pattern in its arm and must be the final arm, unless the arm has a
-guard. A guarded wildcard can fail and later arms can still match. An unguarded
-standalone binding, such as `$value`, also matches all remaining events and must
-be in the final arm. If you omit a wildcard or another irrefutable final arm,
-events that don't match any arm pass through unchanged.
+guard. A guarded wildcard can fail and later arms can still match, but it does
+not make the `match` exhaustive. Every `match` statement must include an
+unguarded final wildcard arm, so Tenzir can prove at compile time that the arms
+cover every possible value.
 
 ```tql
 match record_type {
@@ -257,12 +258,13 @@ match record_type {
   "CNAME" | "DNAME" => {
     record_family = "alias"
   }
+  _ => {
+    record_family = "other"
+  }
 }
 ```
 
-In this example, events with any other `record_type` continue downstream without
-a `record_family` field. Branch pipelines follow the same output type rules as
-`if` branches.
+Branch pipelines follow the same output type rules as `if` branches.
 
 ### Guards
 
@@ -273,28 +275,14 @@ is `true`; events where the guard is `false` or `null` continue to later arms.
 
 ```tql
 match status {
-  500..599 | 429 if retries > 0 => {
+  499..600 | 429 if retries > 0 => {
     action = "retry"
   }
-  500..599 => {
+  499..600 => {
     action = "page"
   }
   _ => {
     action = "ignore"
-  }
-}
-```
-
-Bindings from the matched pattern are available in the guard and in the arm
-pipeline:
-
-```tql
-match this {
-  {src: {ip: $ip, ..}, ..} if $ip.is_private() => {
-    zone = "internal"
-  }
-  {src: {ip: $ip, ..}, ..} => {
-    zone = "external"
   }
 }
 ```
@@ -315,95 +303,39 @@ match status {
 }
 ```
 
-When you combine guarded alternatives with bindings, each alternative must bind
-the same names from the same matched paths. If the alternatives need different
-bindings, split them into separate guarded arms.
-
-### List patterns
-
-List patterns match list values structurally. Elements are matched in order.
-Without `..`, the list must have exactly the listed elements. With a trailing
-`..`, the list may contain additional trailing elements.
+List and record constants are compared by equality:
 
 ```tql
-match tags {
-  ["prod", $service, ..] => {
-    environment = "production"
-    service = $service
+match value {
+  ["prod", "checkout"] => {
+    class = "checkout"
   }
-  [] => {
-    environment = "unknown"
+  {action: "allow", port: 443} => {
+    class = "allow web"
   }
-  [..] => {
-    environment = "other"
-  }
-}
-```
-
-You can nest list patterns anywhere a pattern is accepted:
-
-```tql
-match this {
-  {labels: ["prod", $service, ..], ..} => {
-    service = $service
-  }
-}
-```
-
-The `..` rest marker is only valid as the final list item.
-
-### Record patterns
-
-Record patterns match record values structurally. Listed fields must exist and
-match their nested patterns. Without `..`, the pattern is exact and rejects extra
-fields. With `..`, extra fields are ignored.
-
-```tql
-match this {
-  {action: "allow", dst_port: 80..443, ..} => {
-    verdict = "web allow"
-  }
-  {action: "deny"} => {
-    verdict = "exact deny record"
-  }
-  {..} => {
-    verdict = "other record"
+  _ => {
+    class = "other"
   }
 }
 ```
 
 ### Range patterns
 
-Range patterns use `lower..upper` and include both bounds.
+Range patterns use `lower..upper` and exclude both bounds.
 
 ```tql
 match status {
-  200..299 => {
+  199..300 => {
     class = "success"
   }
-  400..499 => {
+  399..500 => {
     class = "client error"
   }
-  500..599 => {
+  499..600 => {
     class = "server error"
   }
-}
-```
-
-### Bindings
-
-Bindings capture matched values for use in the arm pipeline. A binding name must
-be unique within an arm. If the same `$name` exists as an outer `let` binding,
-`match` treats it as a constant pattern instead.
-
-```tql
-match this {
-  {src: {ip: $ip, ..}, dst: {port: 443, ..}, ..} => {
-    remote_ip = $ip
+  _ => {
+    class = "other"
   }
 }
 ```
-
-Use a binding before you assign to the field it came from. Tenzir rejects arm
-pipelines that read a binding after assigning to the matched field, because that
-would make the binding depend on the mutation order inside the arm.

--- a/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
+++ b/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
@@ -339,14 +339,67 @@ connection_info = {
 ```
 
 The ternary form is appropriate _only for genuinely binary choices_. The moment
-you need a third branch, switch to if/else chains or preferably a [record
-constant lookup](#use-record-constants-for-mappings-instead-of-if-else-chains):
+you need a third branch, switch to `match` for branch pipelines or a
+[record constant lookup](#use-record-constants-for-value-mappings) for pure
+value mappings:
 
 ```tql
 // Three or more enum-like outcomes → record constant
 let $protocols = { tcp: 6, udp: 17, icmp: 1 }
 protocol_num = $protocols[proto]? else 255
 ```
+
+### Use match for finite case branching
+
+Use `match` when you route events by comparing one value against a finite set of
+cases. This keeps dispatching logic close to the field it depends on, and the
+final `_` arm makes the fallback explicit.
+
+✅ Clear:
+
+```tql
+from {action: "allow"},
+     {action: "deny"},
+     {action: "reset"}
+match action {
+  "allow" => {
+    verdict = "allowed"
+  }
+  "deny" => {
+    verdict = "blocked"
+  }
+  _ => {
+    verdict = "unknown"
+  }
+}
+```
+
+Use guarded arms when the case also depends on another field:
+
+```tql
+from {status: 503, retries: 1},
+     {status: 503, retries: 0},
+     {status: 429, retries: 0},
+     {status: 404, retries: 0}
+match status {
+  499..600 | 429 if retries > 0 => {
+    action = "retry"
+  }
+  499..600 => {
+    action = "page"
+  }
+  429 => {
+    action = "throttle"
+  }
+  _ => {
+    action = "ignore"
+  }
+}
+```
+
+Keep `if` for a single predicate or a simple binary decision. Use record
+constants when you only map keys to values and don't need to run different
+statements.
 
 ### Use `in` for multi-value membership tests
 
@@ -608,7 +661,7 @@ where risk_score > 0.8          // What does 0.8 mean?
 
 ## Record constants and mappings
 
-### Use record constants for mappings instead of if-else chains
+### Use record constants for value mappings
 
 ✅ Clean record-based mappings with else fallback:
 
@@ -696,10 +749,11 @@ These inline chains are a serious anti-pattern because:
 - **Unreadable**: Eyes can't parse the logic flow easily
 - **Error-prone**: Easy to mix up conditions and values
 - **Unmaintainable**: Adding/removing conditions requires rewriting the entire expression
-- **Debugging nightmare**: Can't set breakpoints or log intermediate values
-- **Performance issues**: Every condition is evaluated sequentially
+- **Hard to inspect**: You can't see each case as a separate branch
+- **Wrong abstraction**: Static value lookups belong in records, and branch
+  pipelines belong in `match`
 
-✅ Always use record constants instead:
+✅ Use record constants for pure value lookup:
 
 ```tql
 // Clean, maintainable lookups with record indexing
@@ -720,6 +774,9 @@ This pattern is particularly powerful for:
 - Mapping between different naming conventions
 - Providing sensible defaults for missing data
 - Creating reusable transformation logic
+
+If each case needs to run statements instead of returning values, use `match`
+instead of forcing the logic into a record.
 
 ## Writing comments
 
@@ -962,16 +1019,25 @@ ocsf.severity_id = $severities[source.severity]? else 0
 ✅ Derive `status_id` from status codes, e.g., HTTP:
 
 ```tql
-if http_status >= 200 and http_status < 400 {
-  ocsf.status_id = 1  // Success
-} else if http_status >= 400 {
-  ocsf.status_id = 2  // Failure
-} else {
-  ocsf.status_id = 0  // Unknown
+from {http_status: 200},
+     {http_status: 302},
+     {http_status: 404},
+     {http_status: 503},
+     {http_status: 100}
+match http_status {
+  199..400 => {
+    ocsf.status_id = 1  // Success
+  }
+  399..600 => {
+    ocsf.status_id = 2  // Failure
+  }
+  _ => {
+    ocsf.status_id = 0  // Unknown
+  }
 }
 ```
 
-❌ Don't use `record` mapping when status code are partitioned into ranges.
+❌ Don't use `record` mapping when status codes are partitioned into ranges.
 
 ✅ Use `status_detail` for human-readable status messages.
 

--- a/src/content/docs/tutorials/map-data-to-ocsf/index.mdx
+++ b/src/content/docs/tutorials/map-data-to-ocsf/index.mdx
@@ -402,24 +402,29 @@ ocsf.connection_info = {
   protocol_name: move zeek.proto,
   protocol_num: $proto_nums[zeek.proto]? else -1
 }
-// If we cannot use static records, branch with if/else statements.
+// Use `if` for binary predicates and `match` for finite case dispatch.
 if ocsf.src_endpoint.ip.is_v6() or ocsf.dst_endpoint.ip.is_v6() {
   ocsf.connection_info.protocol_ver_id = 6
 } else {
   ocsf.connection_info.protocol_ver_id = 4
 }
-if zeek.local_orig and zeek.local_resp {
-  ocsf.connection_info.direction = "Lateral"
-  ocsf.connection_info.direction_id = 3
-} else if zeek.local_orig {
-  ocsf.connection_info.direction = "Outbound"
-  ocsf.connection_info.direction_id = 2
-} else if zeek.local_resp {
-  ocsf.connection_info.direction = "Inbound"
-  ocsf.connection_info.direction_id = 1
-} else {
-  ocsf.connection_info.direction = "Unknown"
-  ocsf.connection_info.direction_id = 0
+match ({orig: zeek.local_orig, resp: zeek.local_resp}) {
+  {orig: true, resp: true} => {
+    ocsf.connection_info.direction = "Lateral"
+    ocsf.connection_info.direction_id = 3
+  }
+  {orig: true, resp: false} => {
+    ocsf.connection_info.direction = "Outbound"
+    ocsf.connection_info.direction_id = 2
+  }
+  {orig: false, resp: true} => {
+    ocsf.connection_info.direction = "Inbound"
+    ocsf.connection_info.direction_id = 1
+  }
+  _ => {
+    ocsf.connection_info.direction = "Unknown"
+    ocsf.connection_info.direction_id = 0
+  }
 }
 drop zeek.local_orig, zeek.local_resp
 // The `status` attribute in OCSF is a success indicator. While we could use


### PR DESCRIPTION
## Summary

- Document the `match` statement in the statements reference.
- Cross-link the expressions reference from conditional expressions to `match`.
- Add real-world transformation examples for firewall actions and HTTP status classes.

## Checks

- `bun run lint:markdown`
- `bun run generate:excalidraw:placeholders && bun run build`

<sub>
⚙️ Code PR: tenzir/tenzir#6110<br>
🎫 References TNZ-240
</sub>