### PR TITLE
Update agent skill names

### DIFF
--- a/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
+++ b/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
@@ -39,8 +39,10 @@ to select targets.
 Append `@<skill-name>` to install a specific skill:
 
 ```bash
-npx skills add tenzir/skills@ocsf
 npx skills add tenzir/skills@tenzir-docs
+npx skills add tenzir/skills@tenzir-ocsf
+npx skills add tenzir/skills@tenzir-create-parser-package
+npx skills add tenzir/skills@tenzir-create-ocsf-mapping
 ```
 
 ### Choose the installation scope
@@ -61,7 +63,7 @@ npx skills add -g tenzir/skills
 Install a specific skill globally:
 
 ```bash
-npx skills add -g tenzir/skills@ocsf
+npx skills add -g tenzir/skills@tenzir-docs
 ```
 
 ### Target specific agents
@@ -111,7 +113,7 @@ npx skills remove
 Remove a specific skill:
 
 ```bash
-npx skills remove ocsf
+npx skills remove tenzir-docs
 ```
 
 Remove all installed Tenzir skills:


### PR DESCRIPTION
## 🔍 Problem

The agent skills guide still shows only the old individual install examples and does not explain the new user/contributor grouping from `tenzir/skills`.

## 🛠️ Solution

- Add examples for the renamed package-authoring skills.
- Document the Tenzir users and Tenzir contributors skill groups.
- Update the global install and remove examples to use `tenzir-docs`.

## 💬 Review

Check that the skill names match `tenzir/skills` after tenzir/skills#2.

<sub>
⚙️ Code PR: tenzir/skills#2
</sub>