### PR TITLE
Mark v5 docs preview as legacy

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -139,6 +139,7 @@ export default defineConfig({
         "./src/assets/css/utilities.css",
       ],
       components: {
+        Banner: "./src/components/LegacyDocsBanner.astro",
         PageFrame: "./src/components/PageFrame.astro",
         PageTitle: "./src/components/PageTitle.astro",
         Sidebar: "./src/components/Sidebar.astro",

--- a/src/components/LegacyDocsBanner.astro
+++ b/src/components/LegacyDocsBanner.astro
@@ -1,0 +1,55 @@
+---
+const latestDocsUrl = "https://docs.tenzir.com/";
+const migrationGuideUrl = "https://docs.tenzir.com/guides/tenzir-v6-migration/";
+---
+
+<div class="sl-banner legacy-docs-banner" data-pagefind-ignore>
+  <strong>Legacy docs for Tenzir v5.x.</strong>
+  <span>
+    For the latest Tenzir v6 series, visit
+    <a href={latestDocsUrl}>docs.tenzir.com</a>.
+  </span>
+  <span>
+    Migrating from v5? Read the
+    <a href={migrationGuideUrl}>Tenzir v6 migration guide</a>.
+  </span>
+</div>
+
+<style>
+  @layer starlight.core {
+    .legacy-docs-banner {
+      --__sl-banner-text: var(--tnz-neutral-800);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1rem;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem var(--sl-nav-pad-x);
+      background: linear-gradient(
+        90deg,
+        var(--tnz-yellow-400),
+        var(--tnz-yellow-300)
+      );
+      color: var(--__sl-banner-text);
+      font-size: clamp(1rem, 2vw, 1.25rem);
+      line-height: var(--sl-line-height-headings);
+      text-align: center;
+      text-wrap: balance;
+      box-shadow: var(--sl-shadow-md);
+    }
+
+    .legacy-docs-banner strong {
+      font-weight: 800;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+
+    .legacy-docs-banner a {
+      color: var(--__sl-banner-text);
+      font-weight: 800;
+      text-decoration: underline;
+      text-decoration-thickness: 0.1em;
+      text-underline-offset: 0.15em;
+    }
+  }
+</style>


### PR DESCRIPTION
## 🔍 Problem

- We need a stable preview that can serve as the legacy Tenzir v5.x docs before the v6 documentation overhaul in #197 lands.
- Readers must not mistake this preview for the latest documentation.

## 🛠️ Solution

- Add a site-wide legacy-docs banner using Starlight’s banner component override.
- Point readers to the latest docs and the v6 migration guide that lands with #197.

## 💬 Review

- Check the banner copy and visibility.
- Confirm that linking to the future migration guide on docs.tenzir.com is the right target for the preview workflow.

<sub>
📎 Related: tenzir/docs#197
</sub>
