### PR TITLE
Document queue URLs for from_sqs and to_sqs

### DIFF
--- a/src/content/docs/reference/operators/from_sqs.mdx
+++ b/src/content/docs/reference/operators/from_sqs.mdx
@@ -43,7 +43,7 @@ the message from the queue.
 
 The operator requires the following AWS permissions:
 
-- `sqs:GetQueueUrl`
+- `sqs:GetQueueUrl` (only when passing a queue name; not required for URLs)
 - `sqs:ReceiveMessage`
 - `sqs:DeleteMessage`
 
@@ -51,6 +51,11 @@ The operator requires the following AWS permissions:
 
 The name of the queue to receive messages from. You can optionally prefix the
 queue name with `sqs://`.
+
+You can also pass a full queue URL (`https://...` or `http://...`) instead of a
+name. When a URL is given, the operator skips the `GetQueueUrl` lookup and
+talks to the URL's host directly. Set `aws_region` when the queue is in a
+non-default AWS region so SigV4 signing matches.
 
 ### `poll_time = duration (optional)`
 
@@ -88,6 +93,13 @@ this = message.parse_json()
 
 ```tql
 from_sqs "my-queue", aws_region="us-east-1"
+```
+
+### Pass a queue URL directly
+
+```tql
+from_sqs "https://sqs.eu-west-1.amazonaws.com/123456789012/my-queue",
+  aws_region="eu-west-1"
 ```
 
 ### Use explicit credentials

--- a/src/content/docs/reference/operators/to_sqs.mdx
+++ b/src/content/docs/reference/operators/to_sqs.mdx
@@ -27,13 +27,18 @@ warning.
 
 The operator requires the following AWS permissions:
 
-- `sqs:GetQueueUrl`
+- `sqs:GetQueueUrl` (only when passing a queue name; not required for URLs)
 - `sqs:SendMessage`
 
 ### `queue: str`
 
 The name of the queue to send messages to. You can optionally prefix the queue
 name with `sqs://`.
+
+You can also pass a full queue URL (`https://...` or `http://...`) instead of a
+name. When a URL is given, the operator skips the `GetQueueUrl` lookup and
+talks to the URL's host directly. Set `aws_region` when the queue is in a
+non-default AWS region so SigV4 signing matches.
 
 ### `message = str | blob (optional)`
 
@@ -71,6 +76,14 @@ to_sqs "alerts-queue", message=payload
 ```tql
 from {alert: "security event detected"}
 to_sqs "alerts-queue", aws_region="us-east-1"
+```
+
+### Pass a queue URL directly
+
+```tql
+from {alert: "security event detected"}
+to_sqs "https://sqs.eu-west-1.amazonaws.com/123456789012/alerts-queue",
+  aws_region="eu-west-1"
 ```
 
 ### Use explicit credentials


### PR DESCRIPTION
## Summary

- Document that `from_sqs` and `to_sqs` accept a full queue URL (`https://...` or `http://...`) in addition to a queue name.
- Note that `sqs:GetQueueUrl` is only required when passing a name.
- Add an example for passing a URL directly with `aws_region`.

Pairs with the `tenzir/tenzir` change that adds URL pass-through to the new SQS operators.