### PR TITLE
Copy heading anchor links

### DIFF
--- a/src/components/PageFrame.astro
+++ b/src/components/PageFrame.astro
@@ -18,6 +18,35 @@ const { hasSidebar } = Astro.locals.starlightRoute;
   </div>
 </div>
 
+<script>
+  document.addEventListener("click", (event) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+
+    const link = event.target.closest<HTMLAnchorElement>(
+      "a.sl-anchor-link[href^='#']",
+    );
+    if (!link || !navigator.clipboard) {
+      return;
+    }
+
+    const url = new URL(link.getAttribute("href") ?? "", window.location.href);
+    navigator.clipboard.writeText(url.toString()).catch(() => {});
+  });
+</script>
+
 <style>
   .layout-wrapper {
     min-height: 100vh;


### PR DESCRIPTION
## 🔍 Problem

- Heading anchor links only navigate to the section.
- Users still need to manually copy the resulting URL when sharing a section.

## 🛠️ Solution

- Copy the absolute section URL to the clipboard on ordinary left-clicks of Starlight heading anchor links.
- Preserve existing hash navigation and leave modifier clicks untouched.

## 💬 Review

- Verify the delegated listener is scoped narrowly to `.sl-anchor-link` anchors.
- Checks: `git diff --check` passes. `bun run lint:biome` was not run because `bun` is unavailable in this shell.