### PR TITLE
Document implicit command-line stdio

### DIFF
--- a/.agents/references/content.md
+++ b/.agents/references/content.md
@@ -17,8 +17,9 @@ operators, functions, and other documentation pages:
 `<Guide>node-setup/tune-performance</Guide>`,
 `<Integration>kafka</Integration>`.
 
-Use plain markdown links only when you need custom link text, emphasis, or a
-specific anchor target.
+Use plain markdown links only when you need custom link text or emphasis.
+Semantic components support anchor targets, for example
+`<Guide>node-setup/tune-performance#benchmark-the-node</Guide>`.
 
 ## Consecutive code blocks
 

--- a/src/components/see-also/Explanation.astro
+++ b/src/components/see-also/Explanation.astro
@@ -1,13 +1,9 @@
 ---
-import { pathWithBase } from "@utils/base";
-import { resolveLinkedPageTitle } from "@utils/page-title";
 import ExplanationIcon from "../icons/ExplanationIcon.astro";
-
-const path = Astro.slots.has("default")
-  ? (await Astro.slots.render("default")).trim()
-  : "";
-const href = pathWithBase(`/explanations/${path}`);
-const title = await resolveLinkedPageTitle("explanations", path);
+import SemanticPageLink from "./SemanticPageLink.astro";
 ---
 
-<a href={href} class="semantic-link"><ExplanationIcon class="inline-icon" />{title}</a>
+<SemanticPageLink collection="explanations" hrefPrefix="/explanations/">
+  <ExplanationIcon slot="icon" class="inline-icon" />
+  <slot />
+</SemanticPageLink>

--- a/src/components/see-also/Fn.astro
+++ b/src/components/see-also/Fn.astro
@@ -1,13 +1,9 @@
 ---
-import { pathWithBase } from "@utils/base";
 import FunctionIcon from "../icons/FunctionIcon.astro";
-
-const name = Astro.slots.has("default")
-  ? (await Astro.slots.render("default")).trim()
-  : "";
-// Replace :: with / for namespaced functions (e.g., ocsf::category_name -> ocsf/category_name)
-const path = name.replace(/::/g, "/");
-const href = pathWithBase(`/reference/functions/${path}`);
+import SemanticCodeLink from "./SemanticCodeLink.astro";
 ---
 
-<a href={href} class="semantic-link"><FunctionIcon class="inline-icon" /><code>{name}</code></a>
+<SemanticCodeLink hrefPrefix="/reference/functions/">
+  <FunctionIcon slot="icon" class="inline-icon" />
+  <slot />
+</SemanticCodeLink>

--- a/src/components/see-also/Guide.astro
+++ b/src/components/see-also/Guide.astro
@@ -1,13 +1,9 @@
 ---
-import { pathWithBase } from "@utils/base";
-import { resolveLinkedPageTitle } from "@utils/page-title";
 import GuideIcon from "../icons/GuideIcon.astro";
-
-const path = Astro.slots.has("default")
-  ? (await Astro.slots.render("default")).trim()
-  : "";
-const href = pathWithBase(`/guides/${path}`);
-const title = await resolveLinkedPageTitle("guides", path);
+import SemanticPageLink from "./SemanticPageLink.astro";
 ---
 
-<a href={href} class="semantic-link"><GuideIcon class="inline-icon" />{title}</a>
+<SemanticPageLink collection="guides" hrefPrefix="/guides/">
+  <GuideIcon slot="icon" class="inline-icon" />
+  <slot />
+</SemanticPageLink>

--- a/src/components/see-also/Integration.astro
+++ b/src/components/see-also/Integration.astro
@@ -1,13 +1,9 @@
 ---
-import { pathWithBase } from "@utils/base";
-import { resolveLinkedPageTitle } from "@utils/page-title";
 import IntegrationIcon from "../icons/IntegrationIcon.astro";
-
-const path = Astro.slots.has("default")
-  ? (await Astro.slots.render("default")).trim()
-  : "";
-const href = pathWithBase(`/integrations/${path}`);
-const title = await resolveLinkedPageTitle("integrations", path);
+import SemanticPageLink from "./SemanticPageLink.astro";
 ---
 
-<a href={href} class="semantic-link"><IntegrationIcon class="inline-icon" />{title}</a>
+<SemanticPageLink collection="integrations" hrefPrefix="/integrations/">
+  <IntegrationIcon slot="icon" class="inline-icon" />
+  <slot />
+</SemanticPageLink>

--- a/src/components/see-also/Op.astro
+++ b/src/components/see-also/Op.astro
@@ -1,13 +1,9 @@
 ---
-import { pathWithBase } from "@utils/base";
 import OperatorIcon from "../icons/OperatorIcon.astro";
-
-const name = Astro.slots.has("default")
-  ? (await Astro.slots.render("default")).trim()
-  : "";
-// Replace :: with / for namespaced operators (e.g., context::enrich -> context/enrich)
-const path = name.replace(/::/g, "/");
-const href = pathWithBase(`/reference/operators/${path}`);
+import SemanticCodeLink from "./SemanticCodeLink.astro";
 ---
 
-<a href={href} class="semantic-link"><OperatorIcon class="inline-icon" /><code>{name}</code></a>
+<SemanticCodeLink hrefPrefix="/reference/operators/">
+  <OperatorIcon slot="icon" class="inline-icon" />
+  <slot />
+</SemanticCodeLink>

--- a/src/components/see-also/Reference.astro
+++ b/src/components/see-also/Reference.astro
@@ -1,13 +1,9 @@
 ---
-import { pathWithBase } from "@utils/base";
-import { resolveLinkedPageTitle } from "@utils/page-title";
 import ReferenceIcon from "../icons/ReferenceIcon.astro";
-
-const path = Astro.slots.has("default")
-  ? (await Astro.slots.render("default")).trim()
-  : "";
-const href = pathWithBase(`/reference/${path}`);
-const title = await resolveLinkedPageTitle("reference", path);
+import SemanticPageLink from "./SemanticPageLink.astro";
 ---
 
-<a href={href} class="semantic-link"><ReferenceIcon class="inline-icon" />{title}</a>
+<SemanticPageLink collection="reference" hrefPrefix="/reference/">
+  <ReferenceIcon slot="icon" class="inline-icon" />
+  <slot />
+</SemanticPageLink>

--- a/src/components/see-also/SemanticCodeLink.astro
+++ b/src/components/see-also/SemanticCodeLink.astro
@@ -1,0 +1,22 @@
+---
+import { pathWithBase } from "@utils/base";
+import {
+  normalizePagePath,
+  parseSemanticLinkTarget,
+} from "@utils/semantic-link-target";
+
+interface Props {
+  hrefPrefix: string;
+}
+
+const { hrefPrefix } = Astro.props;
+const target = Astro.slots.has("default")
+  ? (await Astro.slots.render("default")).trim()
+  : "";
+const { path, anchor } = parseSemanticLinkTarget(target);
+const name = normalizePagePath(path);
+const hrefPath = name.replace(/::/g, "/");
+const href = pathWithBase(`${hrefPrefix}${hrefPath}${anchor}`);
+---
+
+<a href={href} class="semantic-link"><slot name="icon" /><code>{name}</code></a>

--- a/src/components/see-also/SemanticPageLink.astro
+++ b/src/components/see-also/SemanticPageLink.astro
@@ -1,0 +1,24 @@
+---
+import { pathWithBase } from "@utils/base";
+import { resolveLinkedPageTitle } from "@utils/page-title";
+import {
+  normalizePagePath,
+  parseSemanticLinkTarget,
+} from "@utils/semantic-link-target";
+
+interface Props {
+  collection: string;
+  hrefPrefix: string;
+}
+
+const { collection, hrefPrefix } = Astro.props;
+const target = Astro.slots.has("default")
+  ? (await Astro.slots.render("default")).trim()
+  : "";
+const { path, anchor } = parseSemanticLinkTarget(target);
+const pagePath = normalizePagePath(path);
+const href = pathWithBase(`${hrefPrefix}${pagePath}${anchor}`);
+const title = await resolveLinkedPageTitle(collection, pagePath);
+---
+
+<a href={href} class="semantic-link"><slot name="icon" />{title}</a>

--- a/src/components/see-also/Tutorial.astro
+++ b/src/components/see-also/Tutorial.astro
@@ -1,13 +1,9 @@
 ---
-import { pathWithBase } from "@utils/base";
-import { resolveLinkedPageTitle } from "@utils/page-title";
 import TutorialIcon from "../icons/TutorialIcon.astro";
-
-const path = Astro.slots.has("default")
-  ? (await Astro.slots.render("default")).trim()
-  : "";
-const href = pathWithBase(`/tutorials/${path}`);
-const title = await resolveLinkedPageTitle("tutorials", path);
+import SemanticPageLink from "./SemanticPageLink.astro";
 ---
 
-<a href={href} class="semantic-link"><TutorialIcon class="inline-icon" />{title}</a>
+<SemanticPageLink collection="tutorials" hrefPrefix="/tutorials/">
+  <TutorialIcon slot="icon" class="inline-icon" />
+  <slot />
+</SemanticPageLink>

--- a/src/content/docs/guides/basic-usage/run-pipelines.mdx
+++ b/src/content/docs/guides/basic-usage/run-pipelines.mdx
@@ -23,15 +23,31 @@ For example, write `from {x: 42}` and click _Run_ to see a single event show up.
 
 ## On the command line
 
-On the command line, run `tenzir <pipeline>` where `<pipeline>` is the
-definition of the pipeline. See [Install
-Tenzir](/guides/installation) for how to get the binary.
+On the command line, run `tenzir <pipeline>` where `<pipeline>` is the definition
+of the pipeline. See [Install Tenzir](/guides/installation) for how to get the
+binary.
 
-If the pipeline expects events as its input, an implicit `from_stdin |
-read_json` will be prepended. If it expects bytes instead, only `from_stdin` is
-prepended. Likewise, if the pipeline outputs events, an implicit `to_stdout`
-will be appended. If it outputs bytes instead, no implicit output operator is
-appended.
+The command-line runner completes open pipelines with standard input or standard
+output. A pipeline that already starts with a source and ends with a sink runs as
+written:
+
+```sh
+tenzir 'from_file "events.json" { read_json } | to_file "events.csv" { write_csv }'
+```
+
+A transformation-only pipeline reads JSON events from standard input and writes
+TQL events to standard output:
+
+```sh
+echo '{"x":1}' | tenzir 'select x | head'
+```
+
+A parser-to-printer pipeline reads bytes from standard input and writes bytes to
+standard output:
+
+```sh
+cat input.yaml | tenzir 'read_yaml | select x | write_csv'
+```
 
 The diagram below illustrates these mechanics:
 

--- a/src/content/docs/guides/basic-usage/run-pipelines.mdx
+++ b/src/content/docs/guides/basic-usage/run-pipelines.mdx
@@ -24,8 +24,7 @@ For example, write `from {x: 42}` and click _Run_ to see a single event show up.
 ## On the command line
 
 On the command line, run `tenzir <pipeline>` where `<pipeline>` is the definition
-of the pipeline. See [Install Tenzir](/guides/installation) for how to get the
-binary.
+of the pipeline. See <Guide>installation</Guide> for how to get the binary.
 
 The command-line runner completes open pipelines with standard input or standard
 output. A pipeline that already starts with a source and ends with a sink runs as

--- a/src/content/docs/reference/programs.mdx
+++ b/src/content/docs/reference/programs.mdx
@@ -12,13 +12,13 @@ following rules:
 
 :::note[Pipeline Auto-Completion]
 When a pipeline is not closed, Tenzir attempts to _auto-complete_ it in
-interactive execution contexts. On the
-[command line](/guides/basic-usage/run-pipelines/#on-the-command-line), Tenzir
-uses standard input and standard output as the missing source or sink. For event
+interactive execution contexts. For the command-line execution context described
+in <Guide>basic-usage/run-pipelines#on-the-command-line</Guide>, Tenzir uses
+standard input and standard output as the missing source or sink. For event
 pipelines, it prepends `from_stdin { read_json }` or appends
 `to_stdout { write_tql }`. For byte pipelines, it reads raw bytes from standard
-input or writes raw bytes to standard output. In the
-[web interface](/guides/basic-usage/run-pipelines/#in-the-platform),
+input or writes raw bytes to standard output. For the web execution context
+described in <Guide>basic-usage/run-pipelines#in-the-platform</Guide>,
 auto-completion takes place with an output operator: The web app
 appends <Op>serve</Op> to turn the dataflow into a REST API, allowing your
 browser to access it by routing the data through the platform.

--- a/src/content/docs/reference/programs.mdx
+++ b/src/content/docs/reference/programs.mdx
@@ -11,13 +11,17 @@ following rules:
    output.
 
 :::note[Pipeline Auto-Completion]
-When a pipeline is not closed, Tenzir attempts to _auto-complete_ it. On the
-[command line](/guides/basic-usage/run-pipelines/#on-the-command-line), it
-suffices to write a sequence of transformations because Tenzir automatically
-adds a JSON input operator at the beginning and TQL output operator at the end.
-In the [web interface](/guides/basic-usage/run-pipelines/#in-the-platform),
-auto-completion takes place with an output operator so that your browser can
-access the pipeline output through the platform.
+When a pipeline is not closed, Tenzir attempts to _auto-complete_ it in
+interactive execution contexts. On the
+[command line](/guides/basic-usage/run-pipelines/#on-the-command-line), Tenzir
+uses standard input and standard output as the missing source or sink. For event
+pipelines, it prepends `from_stdin { read_json }` or appends
+`to_stdout { write_tql }`. For byte pipelines, it reads raw bytes from standard
+input or writes raw bytes to standard output. In the
+[web interface](/guides/basic-usage/run-pipelines/#in-the-platform),
+auto-completion takes place with an output operator: The web app
+appends <Op>serve</Op> to turn the dataflow into a REST API, allowing your
+browser to access it by routing the data through the platform.
 :::
 
 ## Statement chaining

--- a/src/utils/remark-see-also-links.ts
+++ b/src/utils/remark-see-also-links.ts
@@ -6,6 +6,10 @@ import { remark } from "remark";
 import remarkMdx from "remark-mdx";
 import type { Plugin } from "unified";
 import { visit } from "unist-util-visit";
+import {
+  normalizePagePath,
+  parseSemanticLinkTarget,
+} from "./semantic-link-target";
 
 /**
  * Remark plugin for semantic cross-reference components such as Op and Fn.
@@ -92,8 +96,9 @@ export const remarkSeeAlsoLinks: Plugin<[], Root> = () => (tree) => {
       const slug = mdastToString(node).trim();
       if (!slug) return;
 
-      const path = slug.replace(/::/g, "/");
-      const href = `${semanticComponents[node.name].hrefPrefix}${path}`;
+      const { path, anchor } = parseSemanticLinkTarget(slug);
+      const normalizedPath = normalizePagePath(path).replace(/::/g, "/");
+      const href = `${semanticComponents[node.name].hrefPrefix}${normalizedPath}${anchor}`;
 
       node.attributes = node.attributes || [];
       const hasHrefAttribute = node.attributes.some(

--- a/src/utils/semantic-link-target.ts
+++ b/src/utils/semantic-link-target.ts
@@ -1,0 +1,20 @@
+export interface SemanticLinkTarget {
+  path: string;
+  anchor: string;
+}
+
+export function parseSemanticLinkTarget(target: string): SemanticLinkTarget {
+  const hashIndex = target.indexOf("#");
+  if (hashIndex === -1) {
+    return { path: target, anchor: "" };
+  }
+
+  return {
+    path: target.slice(0, hashIndex),
+    anchor: target.slice(hashIndex),
+  };
+}
+
+export function normalizePagePath(path: string): string {
+  return path.replace(/\/+$/, "");
+}


### PR DESCRIPTION
## Summary

- Document command-line auto-completion for closed, event, and byte pipelines.
- Update the v6 migration guide with the restored implicit standard input and output behavior.
- Clarify the programs reference note for command-line and platform auto-completion.

## Checks

- bun run lint:markdown
- bun run build

<sub>
⚙️ Code PR: tenzir/tenzir#6147
</sub>