### PR TITLE
Add docs for `internal_memory_size` function

### DIFF
--- a/src/content/docs/reference/functions.mdx
+++ b/src/content/docs/reference/functions.mdx
@@ -759,6 +759,10 @@ functions:
     description: 'Prints a value as a YAML document.'
     example: 'record.print_yaml()'
     path: 'reference/functions/print_yaml'
+  - name: 'internal_memory_size'
+    description: 'Estimates the internal memory size of a value in bytes.'
+    example: 'internal_memory_size(this)'
+    path: 'reference/functions/internal_memory_size'
   - name: 'type_id'
     description: 'Retrieves the type id of an expression.'
     example: 'type_id(1 + 3.2)'
@@ -2413,6 +2417,14 @@ uint(4.2)
 ### Introspection
 
 <CardGrid>
+
+<ReferenceCard title="internal_memory_size" description="Estimates the internal memory size of a value in bytes." href="/reference/functions/internal_memory_size">
+
+```tql
+internal_memory_size(this)
+```
+
+</ReferenceCard>
 
 <ReferenceCard title="type_id" description="Retrieves the type id of an expression." href="/reference/functions/type_id">
 

--- a/src/content/docs/reference/functions/internal_memory_size.mdx
+++ b/src/content/docs/reference/functions/internal_memory_size.mdx
@@ -1,0 +1,62 @@
+---
+title: internal_memory_size
+category: Type System/Introspection
+example: 'internal_memory_size(this)'
+---
+
+Estimates the internal memory size of a value in bytes.
+
+```tql
+internal_memory_size(x:any) -> int
+```
+
+## Description
+
+The `internal_memory_size` function returns an approximate number of bytes that
+the value `x` occupies in Tenzir's internal columnar representation.
+
+:::caution[Unstable estimate]
+The exact accounting rules are not stable. The returned size is an
+implementation detail and may change.
+:::
+
+The estimate includes non-null primitive values, strings, blobs, records, and
+lists. Null values don't contribute to the result.
+
+## Examples
+
+### Estimate the size of an event
+
+```tql
+from {
+  src_ip: 192.168.1.10,
+  msg: "allowed",
+  ports: [22, 443],
+}
+size = internal_memory_size(this)
+```
+```tql
+{
+  src_ip: 192.168.1.10,
+  msg: "allowed",
+  ports: [22, 443],
+  size: 39,
+}
+```
+
+### Measure data flow and forward a summary
+
+Subscribe to a topic, aggregate over a time window, and ship the result to an
+external system:
+
+```tql
+subscribe "firewall-events"
+summarize start=min(time), end=max(time), size=sum(internal_memory_size(this)),
+          options={frequency: 15min}
+to_amqp "amqp://user:pass@localhost:5672/"
+```
+
+## See Also
+
+- <Fn>type_id</Fn>
+- <Fn>type_of</Fn>


### PR DESCRIPTION
## 🔍 Problem

The \`internal_memory_size\` function was added to Tenzir but lacked user-facing documentation.

## 🛠️ Solution

- Add a reference page for \`internal_memory_size\` with signature, description, and examples
- Register the function in the functions index

## 💬 Review

The function is marked as returning an unstable/implementation-specific estimate, which is called out prominently in the docs.

<sub>
📎 Related: tenzir/tenzir#6152<br>
🎫 References TNZ-576
</sub>