### PR TITLE
Add Lefthook lint harness

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,5 +1,13 @@
 # Worktrunk project configuration
 # https://worktrunk.dev/reference/hook
 
-# Install dependencies when creating worktrees
-pre-start = "bun install"
+# Prepare new worktrees before follow-up commands run.
+[[pre-start]]
+deps = "bun install"
+
+[[pre-start]]
+lefthook = "bun run lefthook:install"
+
+# Gate Worktrunk merges with the same harness used by Git pre-push and CI.
+[[pre-merge]]
+lint = "bun run lint"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,12 +7,14 @@ on:
   pull_request:
 
 jobs:
-  markdown:
-    name: Markdown
+  lefthook:
+    name: Lefthook
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -22,41 +24,25 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run markdown linter
-        run: bun run lint:markdown
+      - name: Validate Lefthook config
+        run: bun run lefthook:validate
 
-  biome:
-    name: Biome
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Run Lefthook on changed files
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            base="origin/$BASE_REF"
+          elif [ -n "$BEFORE_SHA" ] && [[ ! "$BEFORE_SHA" =~ ^0+$ ]]; then
+            base="$BEFORE_SHA"
+          else
+            base="$(git rev-list --max-parents=0 HEAD)"
+          fi
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run Biome
-        run: bun run lint:biome
-
-  prettier:
-    name: Prettier (Markdown)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run Prettier
-        run: bun run lint:prettier
+          git diff --name-only -z --diff-filter=ACMR "$base" HEAD |
+            bun run lint:files

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Validate Lefthook config
         run: bun run lefthook:validate
 
-      - name: Run Lefthook on changed files
+      - name: Run Lefthook
         env:
           BASE_REF: ${{ github.base_ref }}
           BEFORE_SHA: ${{ github.event.before }}
@@ -44,5 +44,11 @@ jobs:
             base="$(git rev-list --max-parents=0 HEAD)"
           fi
 
-          git diff --name-only -z --diff-filter=ACMR "$base" HEAD |
-            bun run lint:files
+          if git diff --name-only --diff-filter=ACMRD "$base" HEAD |
+            grep -Eq '^(lefthook\.yml|package\.json|bun\.lock|biome\.json|\.prettierrc\.json|\.markdownlint\.json|\.github/workflows/lint\.yaml)$'
+          then
+            bun run lint
+          else
+            git diff --name-only -z --diff-filter=ACMR "$base" HEAD |
+              bun run lint:files
+          fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -28,35 +26,4 @@ jobs:
         run: bun run lefthook:validate
 
       - name: Run Lefthook
-        env:
-          BASE_REF: ${{ github.base_ref }}
-          BEFORE_SHA: ${{ github.event.before }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF"
-            base="origin/$BASE_REF"
-          elif [ -n "$BEFORE_SHA" ] && [[ ! "$BEFORE_SHA" =~ ^0+$ ]]; then
-            base="$BEFORE_SHA"
-          else
-            base="$(git rev-list --max-parents=0 HEAD)"
-          fi
-
-          full_lint_required=false
-          while IFS= read -r file; do
-            case "$file" in
-              lefthook.yml|package.json|bun.lock|biome.json|.prettierrc.json|.prettierignore|.markdownlint.json|.markdownlintignore|.github/workflows/lint.yaml)
-                full_lint_required=true
-                break
-                ;;
-            esac
-          done < <(git diff --name-only --diff-filter=ACMRD "$base" HEAD)
-
-          if [ "$full_lint_required" = true ]; then
-            bun run lint
-          else
-            git diff --name-only -z --diff-filter=ACMR "$base" HEAD |
-              bun run lint:files
-          fi
+        run: bun run lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,9 +44,17 @@ jobs:
             base="$(git rev-list --max-parents=0 HEAD)"
           fi
 
-          if git diff --name-only --diff-filter=ACMRD "$base" HEAD |
-            grep -Eq '^(lefthook\.yml|package\.json|bun\.lock|biome\.json|\.prettierrc\.json|\.markdownlint\.json|\.github/workflows/lint\.yaml)$'
-          then
+          full_lint_required=false
+          while IFS= read -r file; do
+            case "$file" in
+              lefthook.yml|package.json|bun.lock|biome.json|.prettierrc.json|.prettierignore|.markdownlint.json|.markdownlintignore|.github/workflows/lint.yaml)
+                full_lint_required=true
+                break
+                ;;
+            esac
+          done < <(git diff --name-only --diff-filter=ACMRD "$base" HEAD)
+
+          if [ "$full_lint_required" = true ]; then
             bun run lint
           else
             git diff --name-only -z --diff-filter=ACMR "$base" HEAD |

--- a/.pi/npm/.gitignore
+++ b/.pi/npm/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,3 +1,0 @@
-{
-  "packages": ["npm:pi-formatter"]
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,18 @@ for live preview during development.
 Only use `bun run build` when you actually need to inspect build artifacts.
 Output goes to `dist/`.
 
+After installing dependencies, install the checked-in Git hooks with:
+
+```sh
+bun run lefthook:install
+```
+
+Git runs Lefthook's `pre-push` hook automatically after that. To reproduce the
+same harness manually across the repository, run `bun run lint`. To check an
+explicit file list, pass NUL-separated paths on standard input to
+`bun run lint:files`. To auto-fix formatting issues, run `bun run lint:fix` or
+`bunx lefthook run fix --file <path>` for targeted files.
+
 ### Generated Content
 
 Some content is auto-generated and excluded from linting:
@@ -75,6 +87,7 @@ Some content is auto-generated and excluded from linting:
 
 ### Linting
 
-- Run `bun run lint` to check markdownlint, ESLint, and Prettier.
+- Run `bun run lint` to check markdownlint, Biome, and Prettier through
+  Lefthook.
 - Run `bun run lint:fix` to apply automatic fixes across all linters.
 - Link checking runs separately in CI via `bun run build:linkcheck`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,10 +84,3 @@ Some content is auto-generated and excluded from linting:
 - **Agent Skill**: Run `bun run build:skill` to generate the Tenzir agent skill.
   Requires `bun run build:full` first to generate per-page markdown files in `dist/`.
   Generated files: `tenzir-skill/SKILL.md`, `tenzir-skill/<doc-hierarchy>/`.
-
-### Linting
-
-- Run `bun run lint` to check markdownlint, Biome, and Prettier through
-  Lefthook.
-- Run `bun run lint:fix` to apply automatic fixes across all linters.
-- Link checking runs separately in CI via `bun run build:linkcheck`.

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.6",
         "@peculiar/webcrypto": "^1.5.0",
+        "lefthook": "^2.1.6",
         "markdownlint-cli": "^0.48.0",
         "playwright": "^1.58.2",
         "prettier": "^3.8.1",
@@ -698,6 +699,28 @@
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
+
+    "lefthook": ["lefthook@2.1.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.6", "lefthook-darwin-x64": "2.1.6", "lefthook-freebsd-arm64": "2.1.6", "lefthook-freebsd-x64": "2.1.6", "lefthook-linux-arm64": "2.1.6", "lefthook-linux-x64": "2.1.6", "lefthook-openbsd-arm64": "2.1.6", "lefthook-openbsd-x64": "2.1.6", "lefthook-windows-arm64": "2.1.6", "lefthook-windows-x64": "2.1.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,36 @@
+min_version: 2.1.6
+glob_matcher: doublestar
+skip_lfs: true
+no_auto_install: true
+
+pre-push:
+  parallel: true
+  jobs:
+    - name: markdownlint
+      glob: "**/*.{md,mdx}"
+      run: bun run lint:markdown:files -- {push_files}
+
+    - name: prettier
+      glob: "**/*.md"
+      exclude: ".claude/CLAUDE.md"
+      run: bun run lint:prettier:files -- {push_files}
+
+    - name: biome
+      glob: "**/*.{astro,js,jsx,json,jsonc,mjs,ts,tsx}"
+      run: bun run lint:biome:files -- {push_files}
+
+fix:
+  parallel: false
+  jobs:
+    - name: markdownlint
+      glob: "**/*.{md,mdx}"
+      run: bun run lint:markdown:fix:files -- {files}
+
+    - name: biome
+      glob: "**/*.{astro,js,jsx,json,jsonc,mjs,ts,tsx}"
+      run: bun run lint:biome:fix:files -- {files}
+
+    - name: prettier
+      glob: "**/*.md"
+      exclude: ".claude/CLAUDE.md"
+      run: bun run lint:prettier:fix:files -- {files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,6 +6,18 @@ no_auto_install: true
 pre-push:
   parallel: true
   jobs:
+    - name: markdownlint-full
+      glob: "{lefthook.yml,package.json,bun.lock,.markdownlint.json,.markdownlintignore}"
+      run: bun run lint:markdown
+
+    - name: prettier-full
+      glob: "{lefthook.yml,package.json,bun.lock,.prettierrc.json,.prettierignore}"
+      run: bun run lint:prettier
+
+    - name: biome-full
+      glob: "{lefthook.yml,package.json,bun.lock,biome.json}"
+      run: git ls-files -z -- '*.astro' '*.js' '*.jsx' '*.json' '*.jsonc' '*.mjs' '*.ts' '*.tsx' | xargs -0 bun run lint:biome:files --
+
     - name: markdownlint
       glob: "**/*.{md,mdx}"
       run: bun run lint:markdown:files -- {push_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,18 +6,6 @@ no_auto_install: true
 pre-push:
   parallel: true
   jobs:
-    - name: markdownlint-full
-      glob: "{lefthook.yml,package.json,bun.lock,.markdownlint.json,.markdownlintignore}"
-      run: bun run lint:markdown
-
-    - name: prettier-full
-      glob: "{lefthook.yml,package.json,bun.lock,.prettierrc.json,.prettierignore}"
-      run: bun run lint:prettier
-
-    - name: biome-full
-      glob: "{lefthook.yml,package.json,bun.lock,biome.json}"
-      run: git ls-files -z -- '*.astro' '*.js' '*.jsx' '*.json' '*.jsonc' '*.mjs' '*.ts' '*.tsx' | xargs -0 bun run lint:biome:files --
-
     - name: markdownlint
       glob: "**/*.{md,mdx}"
       run: bun run lint:markdown:files -- {push_files}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "sync:openapi": "bash scripts/sync-openapi.sh",
     "lint": "lefthook run pre-push --all-files",
     "lint:files": "lefthook run pre-push --files-from-stdin",
-    "lint:push": "lefthook run pre-push",
+    "lint:push": "lefthook run pre-push --all-files",
     "lint:markdown": "markdownlint '**/*.md' '**/*.mdx' --ignore node_modules --ignore .astro",
     "lint:markdown:files": "markdownlint --ignore node_modules --ignore .astro",
     "lint:markdown:fix": "markdownlint '**/*.md' '**/*.mdx' --ignore node_modules --ignore .astro --fix",

--- a/package.json
+++ b/package.json
@@ -14,18 +14,28 @@
     "generate:excalidraw": "node scripts/generate-excalidraw-svgs.mjs",
     "generate:excalidraw:placeholders": "node scripts/generate-placeholder-svgs.mjs",
     "sync:openapi": "bash scripts/sync-openapi.sh",
-    "lint": "bun run lint:markdown && bun run lint:biome && bun run lint:prettier",
+    "lint": "lefthook run pre-push --all-files",
+    "lint:files": "lefthook run pre-push --files-from-stdin",
+    "lint:push": "lefthook run pre-push",
     "lint:markdown": "markdownlint '**/*.md' '**/*.mdx' --ignore node_modules --ignore .astro",
+    "lint:markdown:files": "markdownlint --ignore node_modules --ignore .astro",
     "lint:markdown:fix": "markdownlint '**/*.md' '**/*.mdx' --ignore node_modules --ignore .astro --fix",
+    "lint:markdown:fix:files": "markdownlint --ignore node_modules --ignore .astro --fix",
     "lint:biome": "biome check",
+    "lint:biome:files": "biome check",
     "lint:biome:fix": "biome check --write",
+    "lint:biome:fix:files": "biome check --write",
     "lint:prettier": "prettier --check '**/*.md'",
+    "lint:prettier:files": "prettier --check",
     "lint:prettier:fix": "prettier --write '**/*.md'",
+    "lint:prettier:fix:files": "prettier --write",
+    "lefthook:install": "lefthook install",
+    "lefthook:validate": "lefthook validate",
     "test:inline-partials": "bun run scripts/verify-inline-partials.ts",
     "test:sitemap-excerpts": "bun run scripts/verify-sitemap-excerpts.ts",
     "build:linkcheck": "CHECK_LINKS=true bun run build",
     "build:full": "bun run generate && CHECK_LINKS=true LLMS_TXT=true bun run build",
-    "lint:fix": "bun run lint:markdown:fix && bun run lint:biome:fix && bun run lint:prettier:fix"
+    "lint:fix": "lefthook run fix --all-files"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.1",
@@ -71,6 +81,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.6",
     "@peculiar/webcrypto": "^1.5.0",
+    "lefthook": "^2.1.6",
     "markdownlint-cli": "^0.48.0",
     "playwright": "^1.58.2",
     "prettier": "^3.8.1"

--- a/src/content/docs/guides/contribution/documentation.mdx
+++ b/src/content/docs/guides/contribution/documentation.mdx
@@ -24,9 +24,8 @@ https://github.com/tenzir/docs. We use [Astro](https://astro.build) with
 
 | Command                   | Action                                           |
 | :------------------------ | :----------------------------------------------- |
-| `bun run lint:markdown`   | Lint all Markdown files                          |
-| `bun run lint:biome`      | Lint and check formatting of JS/TS/Astro files   |
-| `bun run lint:prettier`   | Check Markdown formatting                        |
+| `bun run lint`            | Run markdownlint, Biome, and Prettier            |
+| `bun run lint:fix`        | Fix formatting issues across all linters         |
 | `bun run build:linkcheck` | Validate all internal and external links         |
 | `bun run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `bun run astro -- --help` | Get help using the Astro CLI                     |
@@ -55,13 +54,21 @@ For git workflow, branching strategy, and commit message conventions, see our
    bun install
    ```
 
-3. **Start development server**:
+3. **Install Git hooks**:
+
+   ```bash
+   bun run lefthook:install
+   ```
+
+   The hooks run the same Lefthook lint harness used by CI.
+
+4. **Start development server**:
 
    ```bash
    bun run dev
    ```
 
-4. **View the site**: Browse to `http://localhost:4321/`
+5. **View the site**: Browse to `http://localhost:4321/`
 
 The development server includes:
 
@@ -269,15 +276,15 @@ Follow these conventions to maintain consistency across all documentation files.
 
 - Every file must end with a newline character, but avoid empty lines at the
   end of a file.
+- Before you commit, run `bun run lint` to check markdownlint, Biome, and
+  Prettier through Lefthook.
+- To fix formatting issues, run `bun run lint:fix`. To fix an explicit set of
+  files, run `bunx lefthook run fix --file <path>`.
 
 #### Markdown Content
 
 - Break lines at **80 characters**.
-- When editing Markdown, run `bun run lint:markdown:fix` and `bun run
-  lint:prettier:fix` when you're done.
 
 #### Code
 
 - Avoid empty lines within functions.
-- When editing source code (`.js`, `.jsx`, `.ts`, `.tsx`, `.astro` files), run
-  `bun run lint:biome:fix` when you're done.


### PR DESCRIPTION
## 🔍 Problem

- Local formatting checks and CI used separate harnesses.
- Worktrunk worktrees installed dependencies but did not install or run the shared Git hook setup.
- The old `.pi` formatter package setup was still tracked even though the repo now uses Bun-managed tools.

## 🛠️ Solution

- Add a checked-in Lefthook configuration for `pre-push` checks and explicit formatting fixes.
- Route `bun run lint`, CI, and Worktrunk `pre-merge` through Lefthook.
- Install Lefthook from Worktrunk `pre-start` after `bun install`.
- Remove the obsolete `.pi` formatter setup.

## 💬 Review

- Check the changed-file CI diff handling and NUL-separated file list plumbing.
- Check that the parallel `pre-push` jobs are read-only and that the serial `fix` hook avoids Markdown writer races.
