### PR TITLE
Document chart axis ordering

### DIFF
--- a/src/content/docs/reference/operators/chart_area.mdx
+++ b/src/content/docs/reference/operators/chart_area.mdx
@@ -21,6 +21,9 @@ Platform](https://app.tenzir.com).
 
 Positions on the x-axis for each data point.
 
+Area charts use a continuous x-axis. Numeric, duration, and timestamp values are
+sorted by value before rendering.
+
 ### `y = any`
 
 Positions on the y-axis for each data point.

--- a/src/content/docs/reference/operators/chart_bar.mdx
+++ b/src/content/docs/reference/operators/chart_bar.mdx
@@ -21,6 +21,12 @@ Platform](https://app.tenzir.com).
 
 Label for each bar.
 
+String, IP, subnet, and `null` labels use the order in which they first appear
+in the input. Use <Op>sort</Op> before <Op>chart_bar</Op> to control the order
+of categorical bars.
+
+Numeric, duration, and timestamp labels are sorted by value.
+
 ### `y|value = any`
 
 Positions on the y-axis for each data point.

--- a/src/content/docs/reference/operators/chart_line.mdx
+++ b/src/content/docs/reference/operators/chart_line.mdx
@@ -21,6 +21,9 @@ Platform](https://app.tenzir.com).
 
 Positions on the x-axis for each data point.
 
+Line charts use a continuous x-axis. Numeric, duration, and timestamp values are
+sorted by value before rendering.
+
 ### `y = any`
 
 Positions on the y-axis for each data point.

--- a/src/content/docs/reference/operators/chart_pie.mdx
+++ b/src/content/docs/reference/operators/chart_pie.mdx
@@ -19,6 +19,12 @@ Platform](https://app.tenzir.com).
 
 Name of each slice on the chart.
 
+String, IP, subnet, and `null` labels use the order in which they first appear
+in the input. Use <Op>sort</Op> before <Op>chart_pie</Op> to control the order
+of categorical slices.
+
+Numeric, duration, and timestamp labels are sorted by value.
+
 ### `y|value = any`
 
 Value of each slice on the chart.

--- a/src/content/docs/reference/operators/sort.mdx
+++ b/src/content/docs/reference/operators/sort.mdx
@@ -66,3 +66,4 @@ sort src_ip, -dest_ip
 - <Op>rare</Op>
 - <Op>reverse</Op>
 - <Op>top</Op>
+- <Tutorial>plot-data-with-charts</Tutorial>

--- a/src/content/docs/tutorials/plot-data-with-charts/index.mdx
+++ b/src/content/docs/tutorials/plot-data-with-charts/index.mdx
@@ -147,6 +147,10 @@ understanding of the data at hand.
 
    ![Bar chart](./chart-bar.png)
 
+   Bar charts with categorical labels preserve the input order of the labels.
+   Use <Op>sort</Op> before <Op>chart_bar</Op> when you want to order
+   categorical bars by a metric instead of first-seen order.
+
 </Steps>
 
 ##### Group and stack bars


### PR DESCRIPTION
## 🔍 Problem

- The chart docs did not describe how x-axis values are ordered.
- The distinction between categorical bar/pie labels and continuous line/area axes was implicit.

## 🛠️ Solution

- Document that categorical `chart_bar` and `chart_pie` labels keep first-seen input order.
- Document that numeric, duration, and timestamp axes are sorted by value.
- Add a tutorial note that upstream `sort` controls categorical bar order.

## 💬 Review

- Check that the operator references describe behavior consistently across bar, pie, line, and area charts.

<sub>
⚙️ Code PR: tenzir/tenzir#6158<br>
🎫 References TNZ-586
</sub>