### PR TITLE
Update Discord invite

### DIFF
--- a/src/utils/redirects.mjs
+++ b/src/utils/redirects.mjs
@@ -1,6 +1,6 @@
 /** Static redirect paths (external URLs, versioned aliases). */
 const STATIC_REDIRECTS = {
-  "/discord": "https://discord.gg/xqbDgVTCxZ",
+  "/discord": "https://discord.gg/AvUBhhpPBQ",
   "/sbom":
     "https://github.com/tenzir/tenzir/releases/latest/download/tenzir.spdx.json",
   // Architecture hoisting


### PR DESCRIPTION
## 🔍 Problem

- The docs Discord redirect points at an outdated invite.

## 🛠️ Solution

- Update the redirect to use the current Discord invite.

## 💬 Review

- Confirm the `/discord` redirect points at the expected invite URL.