### PR TITLE
Document pipeline event throughput metrics

### DIFF
--- a/src/content/docs/guides/analytics/collect-metrics.mdx
+++ b/src/content/docs/guides/analytics/collect-metrics.mdx
@@ -43,3 +43,17 @@ sort -runtime
 
 The above example computes the total runtime over all pipelines grouped by their
 unique ID.
+
+## Inspect pipeline throughput
+
+Use `tenzir.metrics.pipeline` events to compare the number of events and bytes
+that enter and leave each pipeline:
+
+```tql
+metrics "pipeline"
+summarize ingress_events=sum(ingress.events), ingress_bytes=sum(ingress.bytes), egress_events=sum(egress.events), egress_bytes=sum(egress.bytes), pipeline_id
+sort -egress_events
+```
+
+The `events` fields count records that passed through the pipeline during the
+metric period. The `bytes` fields approximate the amount of data transferred.


### PR DESCRIPTION
## 🔍 Problem

- TNZ-557 adds event throughput metrics for pipelines running on the new executor.
- The metrics guide did not show how to query event and byte throughput together from pipeline metrics.

## 🛠️ Solution

- Add a pipeline throughput example to the metrics guide.
- Clarify that `events` counts records and `bytes` approximates transferred data.

## 💬 Review

- Focus on whether this belongs in the analytics guide or should move into the `metrics` operator reference.

<sub>
⚙️ Code PR: tenzir/tenzir#6160<br>
🎫 References TNZ-557
</sub>