### PR TITLE
Document package metadata field

### DIFF
--- a/public/packages/sslbl/package.yaml
+++ b/public/packages/sslbl/package.yaml
@@ -7,6 +7,10 @@ description: |
   The [SSLBL](https://sslbl.abuse.ch/) package provides a lookup table with
   SHA1 hashes of blacklisted certificates for TLS monitoring use cases.
 
+metadata:
+  upstream: https://sslbl.abuse.ch/blacklist/sslblacklist.csv
+  category: threat-intelligence
+
 inputs:
   refresh_interval:
     name: Time between context updates

--- a/src/content/docs/explanations/packages.mdx
+++ b/src/content/docs/explanations/packages.mdx
@@ -41,8 +41,8 @@ A package is a directory with the following structure:
 </FileTree>
 
 The `package.yaml` manifest is the only required file. It identifies the
-directory as a package and contains metadata, context definitions, and input
-specifications.
+directory as a package and contains descriptive fields, external metadata,
+context definitions, and input specifications.
 
 ## Package components
 
@@ -76,6 +76,13 @@ available for lookup and enrichment operations.
 **Examples** in the `examples` directory demonstrate how to use the package.
 These self-contained snippets appear in the Tenzir Library and help users
 understand package capabilities.
+
+### Metadata
+
+The top-level `metadata` key stores opaque package data for external tools.
+Tenzir accepts the key in `package.yaml` but does not interpret its contents.
+Unknown top-level keys outside the package schema still fail validation, so use
+`metadata` for non-engine data that should travel with the package definition.
 
 ### Tests
 

--- a/src/content/docs/guides/packages/create-a-package.mdx
+++ b/src/content/docs/guides/packages/create-a-package.mdx
@@ -20,7 +20,7 @@ Create a directory with the standard package layout:
   - pipelines/ Deployable pipelines
   - tests/ Integration tests
     - inputs/ Sample data for test pipelines
-  - package.yaml Manifest: metadata, contexts, and inputs
+  - package.yaml Manifest: descriptive fields, metadata, contexts, and inputs
 
 </FileTree>
 
@@ -31,8 +31,8 @@ from test pipelines using `f"{env("TENZIR_INPUTS")}/filename.txt"`.
 ## Add the package manifest
 
 The `package.yaml` file is the **package manifest**. It identifies the directory
-as a package and contains metadata, context definitions, and input
-specifications.
+as a package and contains descriptive fields, external metadata, context
+definitions, and input specifications.
 
 ### Add descriptive metadata
 
@@ -55,6 +55,22 @@ description: |
   A brief description of what your package does and the use cases it supports.
   You can use **Markdown** formatting here.
 ```
+
+### Add external metadata
+
+Use the top-level `metadata` field for data consumed by external tools. Tenzir
+accepts this field but does not interpret its contents.
+
+```yaml title="package.yaml"
+metadata:
+  vendor: Acme
+  source: https://github.com/acme/tenzir-packages
+  categories:
+    - threat-intelligence
+```
+
+Unknown top-level keys outside the package schema fail validation. Put
+non-engine package data under `metadata` instead.
 
 ### Define inputs
 

--- a/src/content/docs/tutorials/write-a-package/index.mdx
+++ b/src/content/docs/tutorials/write-a-package/index.mdx
@@ -38,15 +38,15 @@ Create a directory named `sslbl` and add the standard package layout:
   - operators/ Reusable building blocks for pipelines
   - pipelines/ Deployable pipelines
   - tests/ Integration tests
-  - package.yaml Manifest: metadata, contexts, and inputs
+  - package.yaml Manifest: descriptive fields, metadata, contexts, and inputs
 
 </FileTree>
 
 ## Add the package manifest
 
 The [`package.yaml`](/packages/sslbl/package.yaml) is the **package manifest**.
-I contains descriptive metadata, but also the definitions of contexts and
-inputs, as we shall see below.
+It contains descriptive fields, metadata for external tools, and the definitions
+of contexts and inputs, as we shall see below.
 
 ### Add descriptive metadata
 
@@ -59,7 +59,15 @@ package_icon: |
 description: |
   The [SSLBL](https://sslbl.abuse.ch/) package provides a lookup table with
   SHA1 hashes of blacklisted certificates for TLS monitoring use cases.
+
+metadata:
+  upstream: https://sslbl.abuse.ch/blacklist/sslblacklist.csv
+  category: threat-intelligence
 ```
+
+Tenzir accepts the top-level `metadata` field for external tooling and keeps its
+contents opaque. Unknown top-level keys outside the package schema still fail
+validation, so put non-engine data under `metadata`.
 
 ### Define the lookup table context
 


### PR DESCRIPTION
## 🔍 Problem

- tenzir/tenzir#6149 added support for top-level `metadata` in package manifests.
- The package authoring docs still treated manifest metadata only as descriptive engine fields and did not explain where external tool data belongs.

## 🛠️ Solution

- Document top-level `metadata` as opaque data for external tools.
- Clarify that unknown top-level package keys outside the schema still fail validation.
- Update the SSLBL package tutorial and sample manifest to show the new field.

## 💬 Review

- Focus on whether the distinction between descriptive package fields and opaque external metadata is clear enough for package authors.

<sub>
⚙️ Code PR: tenzir/tenzir#6149
</sub>