### PR TITLE
Document fixture-name test selection

### DIFF
--- a/src/content/docs/guides/testing/run-tests.mdx
+++ b/src/content/docs/guides/testing/run-tests.mdx
@@ -108,9 +108,19 @@ in that suite are included automatically. Empty and whitespace-only patterns
 are silently ignored.
 :::
 
-### By fixture tag
+### By fixture
 
-Use `--fixture-tag` to select tests by the fixtures they request:
+Use `--fixture-name` to select tests that request a fixture directly:
+
+```sh
+uvx tenzir-test --fixture-name node
+uvx tenzir-test --fixture-name docker-compose
+```
+
+Fixture-name matching is case-sensitive and uses the configured fixture name,
+not fixture options.
+
+Use `--fixture-tag` to select tests by fixture metadata:
 
 ```sh
 uvx tenzir-test --fixture-tag container
@@ -125,12 +135,17 @@ and `docker-compose` tags:
 uvx tenzir-test --fixture-tag docker-compose
 ```
 
-Repeat `--fixture-tag` to match any tag. Combine it with paths and `--match` to narrow the
+Repeat `--fixture-name` or `--fixture-tag` to match any selected fixture name
+or tag. Combine fixture selectors with paths and `--match` to narrow the
 selection:
 
 ```sh
+uvx tenzir-test tests/integrations/ --match kafka --fixture-name docker-compose
 uvx tenzir-test tests/integrations/ --match kafka --fixture-tag container
 ```
+
+Use `--fixture` only to start fixtures in standalone foreground mode. It
+doesn't select tests.
 
 ## Retry flaky tests
 

--- a/src/content/docs/reference/test-framework/index.mdx
+++ b/src/content/docs/reference/test-framework/index.mdx
@@ -185,12 +185,17 @@ Useful options:
   containing glob metacharacters use fnmatch syntax. Repeatable; tests matching
   any pattern are selected. When combined with positional TEST paths, only tests
   matching both are run (intersection).
+- `--fixture-name`: Select tests that request a fixture with the given name.
+  Matching is case-sensitive and uses the configured fixture name, not fixture
+  options. Repeatable; tests matching any selected fixture name or fixture tag
+  are selected.
 - `--fixture-tag`: Select tests that request fixtures with the given tag.
-  Repeatable; tests matching any tag are selected. When combined with
-  positional TEST paths or `--match` patterns, only tests matching all selectors are
-  run (intersection). Use `--fixture-tag container` to run tests backed by container
-  fixtures, or `--fixture-tag docker-compose` to run tests using the built-in Docker
-  Compose fixture.
+  Repeatable; tests matching any selected fixture tag or fixture name are
+  selected. When combined with positional TEST paths or `--match` patterns,
+  only tests matching all selectors are run (intersection). Use
+  `--fixture-tag container` to run tests backed by container fixtures, or
+  `--fixture-tag docker-compose` to run tests using the built-in Docker Compose
+  fixture.
 - `--fixture`: Activate fixtures in standalone foreground mode without running
   tests. Repeatable. Accepts bare names (`--fixture mysql`) or YAML mapping
   specs (`--fixture 'kafka: {port: 9092}'`). When provided, positional TEST
@@ -504,10 +509,20 @@ If a matched test belongs to a suite (configured via `test.yaml`), all tests in
 that suite are included automatically so the shared fixture lifecycle stays
 intact.
 
-### Filter tests by fixture tag
+### Filter tests by fixture
 
-Use `--fixture-tag` to select tests by metadata inherited from their
-requested fixtures:
+Use `--fixture-name` to select tests that request a fixture directly:
+
+```sh
+uvx tenzir-test --fixture-name node
+uvx tenzir-test --fixture-name docker-compose
+```
+
+Fixture-name matching is case-sensitive and uses the fixture name from the
+`fixtures` configuration, ignoring fixture options.
+
+Use `--fixture-tag` to select tests by metadata inherited from their requested
+fixtures:
 
 ```sh
 uvx tenzir-test --fixture-tag container
@@ -519,18 +534,24 @@ Fixture tags are cumulative. The built-in `docker-compose` fixture has both the
 Compose tests and `--fixture-tag docker-compose` selects only tests that request the
 Docker Compose fixture.
 
-Repeat the flag to match any tag:
+Repeat fixture selectors to match any selected fixture name or tag:
 
 ```sh
+uvx tenzir-test --fixture-name node --fixture-name sink
 uvx tenzir-test --fixture-tag container --fixture-tag node
+uvx tenzir-test --fixture-name node --fixture-tag container
 ```
 
-Combine fixture tags with positional paths or `--match` patterns to narrow the
-selection:
+Combine fixture selectors with positional paths or `--match` patterns to narrow
+the selection:
 
 ```sh
+uvx tenzir-test tests/integrations/ --match kafka --fixture-name docker-compose
 uvx tenzir-test tests/integrations/ --match kafka --fixture-tag container
 ```
+
+The fixture selector is separate from `--fixture`, which starts fixtures in
+standalone foreground mode without running tests.
 
 The harness infers tags from tagged fixture abstractions. Fixtures that use
 `tenzir_test.fixtures.container_runtime` inherit the `container` tag


### PR DESCRIPTION
## 🔍 Problem

- The test framework docs only describe selecting tests by fixture tag.
- The companion code PR adds `--fixture-name`, so users need the new selector semantics documented alongside the existing tag selector.

## 🛠️ Solution

- Document `--fixture-name` in the testing guide and test framework reference.
- Clarify that fixture names and tags combine with OR semantics before intersecting with paths and `--match`.
- Keep `--fixture` documented as standalone foreground fixture mode, not a test selector.

## 💬 Review

- Check that the guide and reference use the same selector language.
- Confirm the examples cover both direct fixture-name selection and tag selection.

<sub>
⚙️ Code PR: tenzir/test#45
</sub>
