### PR TITLE
Add skills changelog project

### DIFF
--- a/src/changelog-projects.json
+++ b/src/changelog-projects.json
@@ -19,6 +19,11 @@
     "color": "purple",
     "repository": "tenzir/ship"
   },
+  "tenzir-skills": {
+    "icon": "puzzle",
+    "color": "orange",
+    "repository": "tenzir/skills"
+  },
   "tree-sitter-tql": {
     "icon": "sun",
     "color": "yellow",


### PR DESCRIPTION
## 🔍 Problem

- The changelog project configuration omits `tenzir/skills`, so generated changelog navigation cannot include its releases.

## 🛠️ Solution

- Add `tenzir-skills` to the configured changelog projects between Tenzir Ship and Tree-sitter TQL.

## 💬 Review

- Check the project ordering and metadata values for the new changelog entry.
