### PR TITLE
Document Microsoft Graph source

### DIFF
--- a/src/content/docs/integrations/index.mdx
+++ b/src/content/docs/integrations/index.mdx
@@ -27,6 +27,7 @@ communication over numerous protocols and APIs:
 - **Cloud storage**: <Integration>amazon/s3</Integration>,
   <Integration>google/cloud-storage</Integration>,
   <Integration>microsoft/azure-blob-storage</Integration>
+- **Cloud APIs**: <Integration>microsoft/graph</Integration>
 - **Message queues**: <Integration>kafka</Integration>,
   <Integration>nats</Integration>, <Integration>amazon/sqs</Integration>,
   <Integration>amqp</Integration>

--- a/src/content/docs/integrations/microsoft/defender.mdx
+++ b/src/content/docs/integrations/microsoft/defender.mdx
@@ -16,8 +16,17 @@ to Tenzir using [Azure Event Hubs][event-hubs].
 [defender-identity]: https://learn.microsoft.com/en-us/defender-for-identity/what-is
 [defender-cloud]: https://learn.microsoft.com/en-us/defender-xdr/microsoft-365-security-center-defender-cloud
 [event-hubs]: https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-about
+[graph-security-api]: https://learn.microsoft.com/en-us/graph/api/resources/security-api-overview
+[defender-xdr-api]: https://learn.microsoft.com/en-us/defender-xdr/api-overview
 
 ![Microsoft Defender](defender.svg)
+
+For Microsoft Defender and Microsoft 365 data that is exposed as Microsoft
+Graph collections, use <Integration>microsoft/graph</Integration> with
+<Op>from_microsoft_graph</Op>. Use Azure Event Hubs for real-time Defender
+streaming. For the Microsoft API surface, see the [Microsoft Graph Security API
+reference][graph-security-api] and the [Microsoft Defender XDR API
+reference][defender-xdr-api].
 
 :::tip[Microsoft Defender Setup]
 The following example assumes that you have already set up Microsoft Defender
@@ -36,3 +45,9 @@ the target Event Hub and enable all event types that you want to collect.
 For detailed instructions on setting up Azure Event Hubs and consuming events
 with Tenzir, see the [Azure Event Hubs integration
 documentation](/integrations/microsoft/azure-event-hubs).
+
+## See Also
+
+- <Op>from_microsoft_graph</Op>
+- <Integration>microsoft/graph</Integration>
+- <Integration>microsoft/azure-event-hubs</Integration>

--- a/src/content/docs/integrations/microsoft/graph.mdx
+++ b/src/content/docs/integrations/microsoft/graph.mdx
@@ -50,7 +50,7 @@ Useful Microsoft Graph reference pages:
 - [Groups API][groups-api]
 
 [register-app]: https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app
-[client-secret]: https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app#add-credentials
+[client-secret]: https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials?tabs=client-secret
 [add-permissions]: https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis#application-permission-to-microsoft-graph
 [admin-consent]: https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent
 [permissions-reference]: https://learn.microsoft.com/en-us/graph/permissions-reference

--- a/src/content/docs/integrations/microsoft/graph.mdx
+++ b/src/content/docs/integrations/microsoft/graph.mdx
@@ -1,0 +1,105 @@
+---
+title: Microsoft Graph
+---
+
+Microsoft Graph is the unified API for Microsoft 365, Microsoft Entra ID, and
+other Microsoft cloud services.
+
+Use <Op>from_microsoft_graph</Op> to read events and inventory data from
+Microsoft Graph `v1.0` collection resources. The operator handles Microsoft
+Entra client-credentials authentication, emits each object from the OData
+`value` array, and follows `@odata.nextLink` pagination.
+
+Common security use cases include collecting Microsoft Entra audit and sign-in
+logs, reading users and groups for enrichment, and extracting inventory from
+Microsoft 365 services that expose collection resources through Microsoft
+Graph.
+
+:::tip[Prerequisites]
+Create a Microsoft Entra application registration, grant the application
+permissions required by the Microsoft Graph resource that you want to read, and
+create a client secret. For example, reading `auditLogs/signIns` requires an
+application permission such as `AuditLog.Read.All`.
+:::
+
+## Prepare Microsoft Graph access
+
+Before you run a pipeline, prepare the Microsoft Entra application and verify
+that it can read the Microsoft Graph resource you want to collect:
+
+1. [Register an application][register-app] in Microsoft Entra ID and record the
+   **Application (client) ID** and tenant ID.
+2. [Create a client secret][client-secret] for the application and record the
+   secret value.
+3. [Add Microsoft Graph application permissions][add-permissions] for the API
+   calls you plan to make. The `from_microsoft_graph` operator uses
+   application permissions because it authenticates without a signed-in user.
+4. [Grant administrator consent][admin-consent] for those application
+   permissions.
+5. Look up the required permissions in the [Microsoft Graph permissions
+   reference][permissions-reference] or on the reference page for the resource.
+
+Useful Microsoft Graph reference pages:
+
+- [Use the Microsoft Graph API][use-api]
+- [Get access without a user][app-auth]
+- [Microsoft Graph permissions reference][permissions-reference]
+- [Sign-ins API][signins-api]
+- [Directory audits API][directory-audits-api]
+- [Users API][users-api]
+- [Groups API][groups-api]
+
+[register-app]: https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app
+[client-secret]: https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app#add-credentials
+[add-permissions]: https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis#application-permission-to-microsoft-graph
+[admin-consent]: https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent
+[permissions-reference]: https://learn.microsoft.com/en-us/graph/permissions-reference
+[use-api]: https://learn.microsoft.com/en-us/graph/use-the-api
+[app-auth]: https://learn.microsoft.com/en-us/graph/auth-v2-service
+[signins-api]: https://learn.microsoft.com/en-us/graph/api/signin-list
+[directory-audits-api]: https://learn.microsoft.com/en-us/graph/api/directoryaudit-list
+[users-api]: https://learn.microsoft.com/en-us/graph/api/user-list
+[groups-api]: https://learn.microsoft.com/en-us/graph/api/group-list
+
+## Read sign-in logs
+
+The following pipeline reads Microsoft Entra sign-in logs and requests only a
+subset of fields:
+
+```tql
+from_microsoft_graph "auditLogs/signIns",
+  auth={
+    tenant_id: "contoso.onmicrosoft.com",
+    client_id: "00000000-0000-0000-0000-000000000000",
+    client_secret: secret("ms-graph-client-secret"),
+  },
+  odata={
+    filter: "createdDateTime ge 2026-04-24T00:00:00Z",
+    select: ["id", "createdDateTime", "userPrincipalName", "status"],
+    top: 1000,
+  }
+```
+
+## Read directory objects
+
+You can read users, groups, or other directory collections for enrichment and
+inventory workflows:
+
+```tql
+from_microsoft_graph "users",
+  auth={
+    tenant_id: secret("ms-graph-tenant-id"),
+    client_id: secret("ms-graph-client-id"),
+    client_secret: secret("ms-graph-client-secret"),
+  },
+  odata={
+    select: ["id", "displayName", "userPrincipalName"],
+  }
+```
+
+## See Also
+
+- <Op>from_microsoft_graph</Op>
+- <Op>from_http</Op>
+- <Integration>microsoft/defender</Integration>
+- <Integration>microsoft/sentinel-log-analytics</Integration>

--- a/src/content/docs/integrations/microsoft/graph.mdx
+++ b/src/content/docs/integrations/microsoft/graph.mdx
@@ -6,7 +6,7 @@ Microsoft Graph is the unified API for Microsoft 365, Microsoft Entra ID, and
 other Microsoft cloud services.
 
 Use <Op>from_microsoft_graph</Op> to read events and inventory data from
-Microsoft Graph `v1.0` collection resources. The operator handles Microsoft
+Microsoft Graph collection resources. The operator handles Microsoft
 Entra client-credentials authentication, emits each object from the OData
 `value` array, and follows `@odata.nextLink` pagination.
 
@@ -94,6 +94,21 @@ from_microsoft_graph "users",
   },
   odata={
     select: ["id", "displayName", "userPrincipalName"],
+  }
+```
+
+Use `version="beta"` to read Microsoft Graph beta collections:
+
+```tql
+from_microsoft_graph "users",
+  version="beta",
+  auth={
+    tenant_id: secret("ms-graph-tenant-id"),
+    client_id: secret("ms-graph-client-id"),
+    client_secret: secret("ms-graph-client-secret"),
+  },
+  odata={
+    select: ["id", "displayName", "signInActivity"],
   }
 ```
 

--- a/src/content/docs/integrations/microsoft/sentinel-log-analytics.mdx
+++ b/src/content/docs/integrations/microsoft/sentinel-log-analytics.mdx
@@ -8,7 +8,7 @@ alerts with [Azure Monitor][azure-monitor], or query them with [KQL][kql]. To
 read Microsoft Entra and Microsoft 365 data from Microsoft Graph, use
 <Integration>microsoft/graph</Integration> instead.
 
-[azure-monitor]: https://learn.microsoft.com/en-us/azure/azure-monitor/overview
+[azure-monitor]: https://learn.microsoft.com/en-us/azure/azure-monitor/fundamentals/overview
 [sentinel]: https://learn.microsoft.com/en-us/azure/sentinel/overview
 [kql]: https://learn.microsoft.com/en-us/kusto/query/
 
@@ -29,8 +29,8 @@ This separation lets you send all data to one DCE while routing different
 streams to different tables, or even different cost tiers, by configuring
 multiple DCRs.
 
-[dce]: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/data-collection-endpoint-overview
-[dcr]: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/data-collection-rule-overview
+[dce]: https://learn.microsoft.com/en-us/azure/azure-monitor/data-collection/data-collection-endpoint-overview
+[dcr]: https://learn.microsoft.com/en-us/azure/azure-monitor/data-collection/data-collection-rule-overview
 [workspace]: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-workspace-overview
 
 ## Storage Tiers
@@ -46,8 +46,8 @@ The [Sentinel Data Lake][data-lake] uses Auxiliary tables to store high-volume
 logs (like NetFlow or firewall allows) cost-effectively for up to 12 years.
 
 [analytics]: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs#log-analytics-workspace
-[auxiliary]: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/create-custom-table#table-plan
-[data-lake]: https://learn.microsoft.com/en-us/azure/sentinel/sentinel-data-lake
+[auxiliary]: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/create-custom-table-auxiliary
+[data-lake]: https://learn.microsoft.com/en-us/azure/sentinel/datalake/sentinel-lake-overview
 
 ## Prerequisites
 
@@ -72,9 +72,9 @@ how these Azure resources work together.
 [logs-ingestion-api]: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview
 [create-workspace]: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/quick-create-workspace
 [entra]: https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app
-[create-dce]: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/data-collection-endpoint-overview#create-a-data-collection-endpoint
+[create-dce]: https://learn.microsoft.com/en-us/azure/azure-monitor/data-collection/data-collection-endpoint-overview#create-a-data-collection-endpoint
 [custom-table]: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/create-custom-table
-[create-dcr]: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/data-collection-rule-create-edit
+[create-dcr]: https://learn.microsoft.com/en-us/azure/azure-monitor/data-collection/data-collection-rule-create-edit
 
 :::tip[End-to-End Tutorial]
 Microsoft's [Logs Ingestion API tutorial][tutorial] walks through all these

--- a/src/content/docs/integrations/microsoft/sentinel-log-analytics.mdx
+++ b/src/content/docs/integrations/microsoft/sentinel-log-analytics.mdx
@@ -4,7 +4,9 @@ title: Sentinel & Log Analytics
 
 Send security logs and events from Tenzir to Microsoft's Log Analytics
 platform. You can analyze them with [Microsoft Sentinel][sentinel], create
-alerts with [Azure Monitor][azure-monitor], or query them with [KQL][kql].
+alerts with [Azure Monitor][azure-monitor], or query them with [KQL][kql]. To
+read Microsoft Entra and Microsoft 365 data from Microsoft Graph, use
+<Integration>microsoft/graph</Integration> instead.
 
 [azure-monitor]: https://learn.microsoft.com/en-us/azure/azure-monitor/overview
 [sentinel]: https://learn.microsoft.com/en-us/azure/sentinel/overview
@@ -49,7 +51,10 @@ logs (like NetFlow or firewall allows) cost-effectively for up to 12 years.
 
 ## Prerequisites
 
-Before using this integration, set up the following in the Azure Portal:
+Before using this integration, set up the following in the Azure Portal. The
+[Logs Ingestion API overview][logs-ingestion-api], [Data Collection Endpoint
+(DCE) overview][dce], and [Data Collection Rule (DCR) overview][dcr] explain
+how these Azure resources work together.
 
 1. **Log Analytics Workspace**: [Create a workspace][create-workspace] if you
    don't have one.
@@ -64,6 +69,7 @@ Before using this integration, set up the following in the Azure Portal:
 6. **Permissions**: Grant your Entra app the **Monitoring Metrics Publisher**
    role on the DCR.
 
+[logs-ingestion-api]: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview
 [create-workspace]: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/quick-create-workspace
 [entra]: https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app
 [create-dce]: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/data-collection-endpoint-overview#create-a-data-collection-endpoint
@@ -122,3 +128,9 @@ to_azure_log_analytics \
 
 Auxiliary tables store data in Parquet format with retention up to 12 years,
 making them ideal for historical forensics and ad-hoc KQL queries.
+
+## See Also
+
+- <Op>from_microsoft_graph</Op>
+- <Op>to_azure_log_analytics</Op>
+- <Integration>microsoft/graph</Integration>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -383,6 +383,10 @@ operators:
     description: 'Receives events from an Apache Kafka topic.'
     example: 'from_kafka "logs"'
     path: 'reference/operators/from_kafka'
+  - name: 'from_microsoft_graph'
+    description: 'Reads events from a Microsoft Graph v1.0 collection.'
+    example: 'from_microsoft_graph "auditLogs/signIns", auth={…}'
+    path: 'reference/operators/from_microsoft_graph'
   - name: 'from_mysql'
     description: 'Reads events from a MySQL database.'
     example: 'from_mysql table="users", host="db.example.com", database="mydb"'
@@ -1478,6 +1482,14 @@ from_http "https://example.com/api" { read_json }
 
 ```tql
 from_kafka "logs"
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="from_microsoft_graph" description="Reads events from a Microsoft Graph v1.0 collection." href="/reference/operators/from_microsoft_graph">
+
+```tql
+from_microsoft_graph "auditLogs/signIns", auth={…}
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators/from_microsoft_graph.mdx
+++ b/src/content/docs/reference/operators/from_microsoft_graph.mdx
@@ -7,10 +7,10 @@ example: 'from_microsoft_graph "auditLogs/signIns", auth={…}'
 import Op from '@components/see-also/Op.astro';
 import Integration from '@components/see-also/Integration.astro';
 
-Reads events from a Microsoft Graph `v1.0` collection.
+Reads events from a Microsoft Graph collection.
 
 ```tql
-from_microsoft_graph resource:string, auth=record, [odata=record]
+from_microsoft_graph resource:string, auth=record, [version=string, odata=record, tls=bool|record]
 ```
 
 ## Description
@@ -28,8 +28,8 @@ Graph delta links or poll for changes.
 
 ### `resource: string`
 
-The Microsoft Graph `v1.0` resource path to read, without a leading slash. For
-example, use `users`, `groups`, or `auditLogs/signIns`.
+The Microsoft Graph resource path to read, without a leading slash or API
+version. For example, use `users`, `groups`, or `auditLogs/signIns`.
 
 ### `auth = record`
 
@@ -61,6 +61,16 @@ The `odata` record supports the following fields:
 | `select` | `list<string>`   | Fields to request with `$select`.                |
 | `top`    | `uint64` or `int64` | The page size to request with `$top`; must be positive. |
 
+### `version = string (optional)`
+
+The Microsoft Graph API version to use for the initial request. Supported
+values are `v1.0` and `beta`. Defaults to `v1.0`.
+
+### `tls = bool | record (optional)`
+
+TLS options for Microsoft Graph requests. Use a record to configure options such
+as `cacert` when a local proxy or custom trust store intercepts HTTPS traffic.
+
 ## Examples
 
 ### Read Microsoft Entra sign-in logs
@@ -90,6 +100,21 @@ from_microsoft_graph "users",
   },
   odata={
     select: ["id", "displayName", "userPrincipalName"],
+  }
+```
+
+### Read beta users
+
+```tql
+from_microsoft_graph "users",
+  version="beta",
+  auth={
+    tenant_id: secret("ms-graph-tenant-id"),
+    client_id: secret("ms-graph-client-id"),
+    client_secret: secret("ms-graph-client-secret"),
+  },
+  odata={
+    select: ["id", "displayName", "signInActivity"],
   }
 ```
 

--- a/src/content/docs/reference/operators/from_microsoft_graph.mdx
+++ b/src/content/docs/reference/operators/from_microsoft_graph.mdx
@@ -1,0 +1,99 @@
+---
+title: from_microsoft_graph
+category: Inputs/Events
+example: 'from_microsoft_graph "auditLogs/signIns", auth={…}'
+---
+
+import Op from '@components/see-also/Op.astro';
+import Integration from '@components/see-also/Integration.astro';
+
+Reads events from a Microsoft Graph `v1.0` collection.
+
+```tql
+from_microsoft_graph resource:string, auth=record, [odata=record]
+```
+
+## Description
+
+The `from_microsoft_graph` operator sends authenticated `GET` requests to the
+[Microsoft Graph API](https://learn.microsoft.com/en-us/graph/overview) and
+emits each object in the OData `value` array as a separate event.
+
+The operator uses Microsoft Entra client credentials to fetch access tokens,
+adds the `Authorization` header, and refreshes the token when needed. It follows
+`@odata.nextLink` URLs until the collection is exhausted.
+
+This operator is for one-shot collection reads. It does not store Microsoft
+Graph delta links or poll for changes.
+
+### `resource: string`
+
+The Microsoft Graph `v1.0` resource path to read, without a leading slash. For
+example, use `users`, `groups`, or `auditLogs/signIns`.
+
+### `auth = record`
+
+Microsoft Entra application credentials for app-only authentication.
+
+The `auth` record supports the following fields:
+
+| Field           | Type              | Description                                                                 |
+| :-------------- | :---------------- | :-------------------------------------------------------------------------- |
+| `tenant_id`     | `string` or `secret` | The Microsoft Entra tenant ID or tenant domain.                       |
+| `client_id`     | `string` or `secret` | The application client ID.                                            |
+| `client_secret` | `string` or `secret` | The application client secret.                                        |
+| `scope`         | `string` or `secret` | The OAuth scope. Defaults to `https://graph.microsoft.com/.default`.  |
+| `authority`     | `string` or `secret` | The OAuth authority. Defaults to `https://login.microsoftonline.com`. |
+
+The application must have the Microsoft Graph application permissions required
+for the selected resource. For example, reading sign-in logs requires an
+application permission such as `AuditLog.Read.All`.
+
+### `odata = record (optional)`
+
+OData query options to append to the initial request.
+
+The `odata` record supports the following fields:
+
+| Field    | Type             | Description                                      |
+| :------- | :--------------- | :----------------------------------------------- |
+| `filter` | `string`         | A `$filter` expression.                          |
+| `select` | `list<string>`   | Fields to request with `$select`.                |
+| `top`    | `uint64` or `int64` | The page size to request with `$top`; must be positive. |
+
+## Examples
+
+### Read Microsoft Entra sign-in logs
+
+```tql
+from_microsoft_graph "auditLogs/signIns",
+  auth={
+    tenant_id: "contoso.onmicrosoft.com",
+    client_id: "00000000-0000-0000-0000-000000000000",
+    client_secret: secret("ms-graph-client-secret"),
+  },
+  odata={
+    filter: "createdDateTime ge 2026-04-24T00:00:00Z",
+    select: ["id", "createdDateTime", "userPrincipalName", "status"],
+    top: 1000,
+  }
+```
+
+### Read users
+
+```tql
+from_microsoft_graph "users",
+  auth={
+    tenant_id: secret("ms-graph-tenant-id"),
+    client_id: secret("ms-graph-client-id"),
+    client_secret: secret("ms-graph-client-secret"),
+  },
+  odata={
+    select: ["id", "displayName", "userPrincipalName"],
+  }
+```
+
+## See Also
+
+- <Op>from_http</Op>
+- <Integration>microsoft/graph</Integration>

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -358,6 +358,7 @@ export const integrations = [
           "integrations/microsoft/azure-blob-storage",
           "integrations/microsoft/azure-event-hubs",
           "integrations/microsoft/defender",
+          "integrations/microsoft/graph",
           "integrations/microsoft/sentinel-log-analytics",
           "integrations/microsoft/windows-event-logs",
         ],


### PR DESCRIPTION
## 🔍 Problem

- The new Microsoft Graph source needs user-facing documentation.
- Existing Microsoft integration pages do not explain when to use Microsoft Graph instead of Event Hubs or Log Analytics ingestion.

## 🛠️ Solution

- Add a Microsoft Graph integration page with sign-in log and directory object examples.
- Add a `from_microsoft_graph` operator reference covering authentication, OData options, pagination, and examples.
- Cross-link the Defender and Sentinel & Log Analytics pages to the Microsoft Graph integration.

## 💬 Review

- Review the positioning between Microsoft Graph, Defender streaming through Event Hubs, and Sentinel Log Analytics ingestion.
- Delta query support is intentionally not documented because it is not part of this change.

<sub>
⚙️ Code PR: tenzir/tenzir#6165<br>
⚙️ Plugin PR: tenzir/tenzir-plugins#539<br>
🎫 References TNZ-387, TNZ-379, TNZ-380<br>
✅ Closes TNZ-396
</sub>
