### PR TITLE
Update SQS integration docs

### DIFF
--- a/src/content/docs/guides/collecting/read-from-message-brokers.mdx
+++ b/src/content/docs/guides/collecting/read-from-message-brokers.mdx
@@ -121,13 +121,20 @@ this = message.parse_json()
 
 ### Configure polling
 
-Use long polling to reduce API calls and receive messages in batches:
+Use long polling to reduce empty responses, and set `batch_size` to control the
+maximum number of messages per receive request:
 
 ```tql
-from_sqs "sqs://my-queue", poll_time=5s
+from_sqs "sqs://my-queue", poll_time=5s, batch_size=10
 ```
 
-SQS automatically deletes messages after successful receipt.
+By default, Tenzir deletes each SQS message after emitting it. Set
+`delete=false` to leave messages in the queue so SQS makes them visible again
+after the queue's visibility timeout:
+
+```tql
+from_sqs "sqs://my-queue", delete=false, visibility_timeout=30s
+```
 
 ## Google Cloud Pub/Sub
 

--- a/src/content/docs/guides/collecting/read-from-message-brokers.mdx
+++ b/src/content/docs/guides/collecting/read-from-message-brokers.mdx
@@ -129,11 +129,11 @@ from_sqs "sqs://my-queue", poll_time=5s, batch_size=10
 ```
 
 By default, Tenzir deletes each SQS message after emitting it. Set
-`delete=false` to leave messages in the queue so SQS makes them visible again
-after the queue's visibility timeout:
+`keep_messages=true` to leave messages in the queue so SQS makes them visible
+again after the queue's visibility timeout:
 
 ```tql
-from_sqs "sqs://my-queue", delete=false, visibility_timeout=30s
+from_sqs "sqs://my-queue", keep_messages=true, visibility_timeout=30s
 ```
 
 ## Google Cloud Pub/Sub

--- a/src/content/docs/integrations/amazon/sqs.mdx
+++ b/src/content/docs/integrations/amazon/sqs.mdx
@@ -11,8 +11,6 @@ messages to SQS queues with <Op>to_sqs</Op>.
 
 ![SQS](sqs.svg)
 
-## How it works
-
 When Tenzir reads from an SQS queue, it emits one event per SQS message. The
 event uses the `tenzir.sqs` schema and contains the message body in the
 `message` field together with SQS metadata such as the message ID, receive

--- a/src/content/docs/integrations/amazon/sqs.mdx
+++ b/src/content/docs/integrations/amazon/sqs.mdx
@@ -17,17 +17,17 @@ event uses the `tenzir.sqs` schema and contains the message body in the
 count, and send time.
 
 By default, Tenzir deletes each received message from the queue after it emits
-the event. Set `delete=false` to receive messages without deleting them.
+the event. Set `keep_messages=true` to receive messages without deleting them.
 Combine it with `visibility_timeout` to control when SQS makes the messages
 visible again:
 
 ```tql
-from_sqs "sqs://my-queue", delete=false, visibility_timeout=30s
+from_sqs "sqs://my-queue", keep_messages=true, visibility_timeout=30s
 ```
 
-With `delete=false`, SQS makes the message visible again after the queue's
-visibility timeout. Use this when you want to inspect or replay messages. It
-doesn't make downstream processing transactional.
+With `keep_messages=true`, SQS makes the message visible again after the
+queue's visibility timeout. Use this when you want to inspect or replay
+messages. It doesn't make downstream processing transactional.
 
 The `poll_time` option configures [SQS long polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html).
 Long polling waits for messages to arrive and reduces empty responses when the
@@ -86,7 +86,7 @@ Tenzir needs these SQS permissions:
 
 You don't need `sqs:GetQueueUrl` when you pass a full queue URL. You also don't
 need `sqs:DeleteMessage` for `from_sqs` pipelines that always use
-`delete=false`.
+`keep_messages=true`.
 
 ## Examples
 
@@ -112,7 +112,7 @@ this = message.parse_json()
 
 ```tql
 from_sqs "sqs://my-queue",
-  delete=false,
+  keep_messages=true,
   poll_time=5s,
   batch_size=10,
   visibility_timeout=30s

--- a/src/content/docs/integrations/amazon/sqs.mdx
+++ b/src/content/docs/integrations/amazon/sqs.mdx
@@ -6,29 +6,58 @@ title: SQS
 message queue on AWS. It supports microservices, distributed systems, and
 serverless applications.
 
-Tenzir can interact with SQS by sending messages to and reading messages from
-SQS queues.
+Tenzir can receive messages from SQS queues with <Op>from_sqs</Op> and send
+messages to SQS queues with <Op>to_sqs</Op>.
 
 ![SQS](sqs.svg)
 
-When reading from SQS queues, Tenzir receives one SQS message at a time and
-emits the message body in the `message` field, together with SQS metadata such
-as the message ID and receive count.
+## How it works
 
-The `poll_time` parameter configures [long polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html).
-This reduces empty responses when there are no messages available.
+When Tenzir reads from an SQS queue, it emits one event per SQS message. The
+event uses the `tenzir.sqs` schema and contains the message body in the
+`message` field together with SQS metadata such as the message ID, receive
+count, and send time.
 
-Tenzir pipelines that read from an SQS queue automatically send a deletion
-request after receiving messages.
+By default, Tenzir deletes each received message from the queue after it emits
+the event. Set `delete=false` to receive messages without deleting them.
+Combine it with `visibility_timeout` to control when SQS makes the messages
+visible again:
 
-:::tip[URL Support]
-Use `from_sqs` and `to_sqs` directly with `sqs://` URLs.
-:::
+```tql
+from_sqs "sqs://my-queue", delete=false, visibility_timeout=30s
+```
+
+With `delete=false`, SQS makes the message visible again after the queue's
+visibility timeout. Use this when you want to inspect or replay messages. It
+doesn't make downstream processing transactional.
+
+The `poll_time` option configures [SQS long polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html).
+Long polling waits for messages to arrive and reduces empty responses when the
+queue has no visible messages.
+
+The `batch_size` option controls the maximum number of messages that SQS returns
+per receive request. SQS supports values from `1` to `10`.
+
+## Queue identifiers
+
+Pass a queue name, an `sqs://` URL, or a full SQS queue URL:
+
+```tql
+from_sqs "alerts"
+from_sqs "sqs://alerts"
+from_sqs "https://sqs.eu-west-1.amazonaws.com/123456789012/alerts",
+  aws_region="eu-west-1"
+```
+
+When you pass a queue name or an `sqs://` URL, Tenzir resolves the queue URL
+with `sqs:GetQueueUrl`. When you pass a full queue URL, Tenzir uses it directly.
+Set `aws_region` when the queue is outside the default AWS SDK region so request
+signing uses the correct region.
 
 ## Configuration
 
-Follow the [standard configuration instructions](/integrations/amazon) to authenticate with your
-AWS credentials.
+Follow the [Amazon integration configuration](/integrations/amazon) to
+authenticate with your AWS credentials.
 
 Alternatively, use the `aws_iam` parameter to provide explicit credentials:
 
@@ -40,8 +69,26 @@ from_sqs "my-queue", aws_iam={
 }
 ```
 
-See the `from_sqs` and `to_sqs` operator documentation for all available
-options, including IAM role assumption.
+You can also use `aws_iam` to assume an IAM role:
+
+```tql
+from_sqs "my-queue", aws_iam={
+  region: "eu-west-1",
+  assume_role: "arn:aws:iam::123456789012:role/my-sqs-role",
+  session_name: "tenzir-session"
+}
+```
+
+Tenzir needs these SQS permissions:
+
+| Operator      | Required permissions                                      |
+| ------------- | --------------------------------------------------------- |
+| <Op>from_sqs</Op> | `sqs:GetQueueUrl`, `sqs:ReceiveMessage`, `sqs:DeleteMessage` |
+| <Op>to_sqs</Op>   | `sqs:GetQueueUrl`, `sqs:SendMessage`                       |
+
+You don't need `sqs:GetQueueUrl` when you pass a full queue URL. You also don't
+need `sqs:DeleteMessage` for `from_sqs` pipelines that always use
+`delete=false`.
 
 ## Examples
 
@@ -49,16 +96,34 @@ options, including IAM role assumption.
 
 ```tql
 from {foo: 42}
-to_sqs "sqs://my-queue"
+to_sqs "sqs://my-queue", message=this.print_json()
 ```
 
 ### Receive messages from an SQS queue
 
 ```tql
-from_sqs "sqs://my-queue", poll_time=5s
+from_sqs "sqs://my-queue", poll_time=5s, batch_size=10
 this = message.parse_json()
 ```
 
 ```tql
 {foo: 42}
 ```
+
+### Receive messages without deleting them
+
+```tql
+from_sqs "sqs://my-queue",
+  delete=false,
+  poll_time=5s,
+  batch_size=10,
+  visibility_timeout=30s
+this = message.parse_json()
+```
+
+## See Also
+
+- <Op>from_sqs</Op>
+- <Op>to_sqs</Op>
+- <Guide>collecting/read-from-message-brokers</Guide>
+- <Guide>routing/send-to-destinations</Guide>

--- a/src/content/docs/reference/operators/from_sqs.mdx
+++ b/src/content/docs/reference/operators/from_sqs.mdx
@@ -11,7 +11,8 @@ Receives messages from an [Amazon SQS][sqs] queue.
 [sqs]: https://docs.aws.amazon.com/sqs/
 
 ```tql
-from_sqs queue:str, [poll_time=duration, aws_region=str, aws_iam=record]
+from_sqs queue:str, [delete=bool, batch_size=int, poll_time=duration,
+                     visibility_timeout=duration, aws_region=str, aws_iam=record]
 ```
 
 ## Description
@@ -38,14 +39,14 @@ All fields except `message` and `message_id` are optional because SQS only
 returns them when they are present on the message.
 
 The operator uses long polling, which reduces empty responses when there are no
-messages available. After the operator emits a message successfully, it deletes
+messages available. By default, after the operator emits a message, it deletes
 the message from the queue.
 
 The operator requires the following AWS permissions:
 
 - `sqs:GetQueueUrl` (only when passing a queue name; not required for URLs)
 - `sqs:ReceiveMessage`
-- `sqs:DeleteMessage`
+- `sqs:DeleteMessage` (only when `delete=true`)
 
 ### `queue: str`
 
@@ -64,6 +65,45 @@ The long polling timeout per request.
 The value must be between `1s` and `20s`.
 
 Defaults to `3s`.
+
+### `batch_size = int (optional)`
+
+The maximum number of messages to receive per SQS request.
+
+The value must be between `1` and `10`.
+
+Defaults to `1`.
+
+### `delete = bool (optional)`
+
+Whether to delete messages from the queue after receiving and emitting them.
+
+Defaults to `true`.
+
+Set this option to `false` to keep received messages in the queue:
+
+```tql
+from_sqs "my-queue", delete=false
+```
+
+When `delete=false`, SQS hides each received message until the queue's
+visibility timeout expires, then makes the message visible again. This option
+only skips `DeleteMessage`; it doesn't make downstream processing
+transactional.
+
+### `visibility_timeout = duration (optional)`
+
+The receive-level visibility timeout for messages returned by SQS.
+
+The value must be between `0s` and `12h`. When omitted, SQS uses the queue's
+configured visibility timeout.
+
+Use this option with `delete=false` to control when messages become available
+for redelivery:
+
+```tql
+from_sqs "my-queue", delete=false, visibility_timeout=30s
+```
 
 ### `aws_region = str (optional)`
 
@@ -85,7 +125,18 @@ from_sqs "sqs://tenzir"
 ### Parse JSON messages
 
 ```tql
-from_sqs "sqs://alerts", poll_time=5s
+from_sqs "sqs://alerts", poll_time=5s, batch_size=10
+this = message.parse_json()
+```
+
+### Receive messages without deleting them
+
+```tql
+from_sqs "sqs://alerts",
+  delete=false,
+  poll_time=5s,
+  batch_size=10,
+  visibility_timeout=30s
 this = message.parse_json()
 ```
 

--- a/src/content/docs/reference/operators/from_sqs.mdx
+++ b/src/content/docs/reference/operators/from_sqs.mdx
@@ -11,7 +11,7 @@ Receives messages from an [Amazon SQS][sqs] queue.
 [sqs]: https://docs.aws.amazon.com/sqs/
 
 ```tql
-from_sqs queue:str, [delete=bool, batch_size=int, poll_time=duration,
+from_sqs queue:str, [keep_messages=bool, batch_size=int, poll_time=duration,
                      visibility_timeout=duration, aws_region=str, aws_iam=record]
 ```
 
@@ -46,7 +46,7 @@ The operator requires the following AWS permissions:
 
 - `sqs:GetQueueUrl` (only when passing a queue name; not required for URLs)
 - `sqs:ReceiveMessage`
-- `sqs:DeleteMessage` (only when `delete=true`)
+- `sqs:DeleteMessage` (unless `keep_messages=true`)
 
 ### `queue: str`
 
@@ -74,19 +74,19 @@ The value must be between `1` and `10`.
 
 Defaults to `1`.
 
-### `delete = bool (optional)`
+### `keep_messages = bool (optional)`
 
-Whether to delete messages from the queue after receiving and emitting them.
+Whether to keep messages in the queue after receiving and emitting them.
 
-Defaults to `true`.
+Defaults to `false`.
 
-Set this option to `false` to keep received messages in the queue:
+Set this option to `true` to keep received messages in the queue:
 
 ```tql
-from_sqs "my-queue", delete=false
+from_sqs "my-queue", keep_messages=true
 ```
 
-When `delete=false`, SQS hides each received message until the queue's
+When `keep_messages=true`, SQS hides each received message until the queue's
 visibility timeout expires, then makes the message visible again. This option
 only skips `DeleteMessage`; it doesn't make downstream processing
 transactional.
@@ -98,11 +98,11 @@ The receive-level visibility timeout for messages returned by SQS.
 The value must be between `0s` and `12h`. When omitted, SQS uses the queue's
 configured visibility timeout.
 
-Use this option with `delete=false` to control when messages become available
-for redelivery:
+Use this option with `keep_messages=true` to control when messages become
+available for redelivery:
 
 ```tql
-from_sqs "my-queue", delete=false, visibility_timeout=30s
+from_sqs "my-queue", keep_messages=true, visibility_timeout=30s
 ```
 
 ### `aws_region = str (optional)`
@@ -133,7 +133,7 @@ this = message.parse_json()
 
 ```tql
 from_sqs "sqs://alerts",
-  delete=false,
+  keep_messages=true,
   poll_time=5s,
   batch_size=10,
   visibility_timeout=30s


### PR DESCRIPTION
## 🔍 Problem

- The SQS integration page didn't reflect the current `from_sqs` and `to_sqs` behavior in enough detail.
- The new `from_sqs` receive controls need documentation: `keep_messages=true`, `batch_size`, and `visibility_timeout`.
- Users need the visibility-timeout caveat when choosing replayable receive behavior.

## 🛠️ Solution

- Refresh the SQS integration page with current receive/send examples, queue identifier forms, IAM permissions, long polling, batch size, visibility timeout, and deletion behavior.
- Update the `from_sqs` reference with the new receive controls and clarify when `sqs:DeleteMessage` is required.
- Update the message broker collecting guide so it no longer implies unconditional deletion and shows the relevant receive tuning options.

## 💬 Review

- Focus on whether the SQS deletion and redelivery semantics are clear enough for users choosing between default receive-and-delete and replayable receive behavior.
- Check that the documented limits match SQS: `batch_size` from `1` to `10`, receive-level `visibility_timeout` from `0s` to `12h`.

<sub>
⚙️ Code PRs: tenzir/tenzir#6167, tenzir/tenzir#6174
</sub>
