### PR TITLE
Document fixture inline dependencies

### DIFF
--- a/src/content/docs/guides/testing/create-fixtures.mdx
+++ b/src/content/docs/guides/testing/create-fixtures.mdx
@@ -151,6 +151,42 @@ skip:
 An unavailable fixture then skips only that test. Frontmatter does not control
 suite fixture setup because suite fixtures start before any member test runs.
 
+## Declare Python dependencies
+
+Fixture modules can declare Python package dependencies with PEP 723 script
+metadata. Use this when a fixture imports packages that are not part of
+`tenzir-test` itself:
+
+```python
+# fixtures/localstack.py
+# /// script
+# dependencies = ["boto3"]
+# ///
+
+from tenzir_test import fixture
+
+@fixture()
+def localstack():
+    ...
+```
+
+When a fixture file declares dependencies, `tenzir-test` installs them with
+`uv` before importing project fixtures:
+
+```sh
+uv pip install --python <current-python> boto3
+```
+
+This works for `fixtures.py` and for any Python module under `fixtures/`,
+including nested modules imported by `fixtures/__init__.py`. The feature also
+applies in standalone fixture mode, such as `uvx tenzir-test --fixture
+localstack`.
+
+Make sure `uv` is on `PATH` when fixture files declare dependencies. If a
+fixture imports an undeclared package, `tenzir-test` still reports the missing
+dependency and suggests running the harness from a project environment or with
+`uvx --with`.
+
 ## Use container runtime helpers
 
 When a fixture manages a single container directly rather than orchestrating

--- a/src/content/docs/reference/test-framework/index.mdx
+++ b/src/content/docs/reference/test-framework/index.mdx
@@ -1062,6 +1062,24 @@ managers, or `FixtureHandle` instances for advanced scenarios.
 The [fixture guide](/guides/testing/create-fixtures) demonstrates an HTTP echo
 server that exposes `HTTP_FIXTURE_URL` and tears down cleanly.
 
+### Fixture dependencies
+
+Project fixture modules can declare Python package dependencies with a PEP 723
+script metadata block:
+
+```python
+# /// script
+# dependencies = ["boto3"]
+# ///
+
+from tenzir_test import fixture
+```
+
+This applies to normal test execution and standalone fixture mode with
+`tenzir-test --fixture`. When fixture files declare dependencies, `uv` must be
+available on `PATH`. See the [fixture guide](/guides/testing/create-fixtures#declare-python-dependencies)
+for a complete example.
+
 ### Fixture options
 
 Fixtures can declare a frozen dataclass via `options=` on `@fixture()`. The


### PR DESCRIPTION
## 🔍 Problem

- The test framework docs did not describe that project fixtures can declare
  Python dependencies inline.
- Fixture authors needed guidance for both normal test runs and standalone
  fixture mode.

## 🛠️ Solution

- Add how-to guidance to the fixture creation guide.
- Add reference details for scan scope, parser rules, `uv` installation, and
  missing-dependency behavior.

## 💬 Review

- Check that the guide stays task-focused while the reference page covers the
  precise behavior.

<sub>
⚙️ Code PR: tenzir/test#47
</sub>
