### PR TITLE
Document HTTP retry warnings

### DIFF
--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -228,6 +228,7 @@ from_http "https://api.example.com/data", max_retry_count=3, retry_delay=2s {
 
 This retries transient transport failures and HTTP `429` and `5xx` responses
 up to 3 times. The delay starts at 2 seconds and backs off exponentially.
+Tenzir emits a diagnostic before each retry with the reason and wait time.
 
 ## See Also
 

--- a/src/content/docs/reference/operators/to_http.mdx
+++ b/src/content/docs/reference/operators/to_http.mdx
@@ -27,7 +27,8 @@ which become the request body. By default, the operator sends requests with the
 The operator retries transient transport failures and HTTP `429` and `5xx`
 responses up to `max_retry_count` times. If a response includes a
 `Retry-After` header, Tenzir waits for that duration before retrying.
-Otherwise, it uses exponential backoff starting at `retry_delay`.
+Otherwise, it uses exponential backoff starting at `retry_delay`. Tenzir
+emits a diagnostic before each retry with the reason and wait time.
 
 Non-2xx HTTP status codes emit warnings. Request failures, such as connection
 or retry exhaustion, cause pipeline errors.


### PR DESCRIPTION
## 🔍 Problem

- The HTTP operator docs did not mention the new retry warnings.

## 🛠️ Solution

- Document that `from_http` and `to_http` emit a warning before each retry with the reason and wait time.

## 💬 Review

- Copy-only docs update.
- I did not run docs checks locally.

<sub>
🛠️ Code PR: tenzir/tenzir#6170
</sub>
