### PR TITLE
Add Platform Data Flow explanation page

### DIFF
--- a/src/content/docs/explanations/platform/data-flow.mdx
+++ b/src/content/docs/explanations/platform/data-flow.mdx
@@ -2,10 +2,13 @@
 title: Platform Data Flow
 ---
 
-When a [node](/explanations/node) starts, it opens a single outbound,
-TLS-encrypted WebSocket connection to the [platform](/explanations/platform).
-This page describes what flows over that connection so you can reason about
+This page explains what data flows between a [node](/explanations/node)
+and the [platform](/explanations/platform), so you can reason about
 privacy, compliance, and what an operator of the platform can see.
+
+When a node starts, it opens a single outbound, TLS-encrypted WebSocket
+connection to the platform. All communication between the two travels
+over that connection.
 
 For the bigger picture on TLS termination and trust boundaries, see the
 [FAQ entry on data privacy](/explanations/faqs#can-tenzir-see-my-data).

--- a/src/content/docs/explanations/platform/data-flow.mdx
+++ b/src/content/docs/explanations/platform/data-flow.mdx
@@ -2,8 +2,8 @@
 title: Platform Data Flow
 ---
 
-This page explains what data flows between a [node](/explanations/node)
-and the [platform](/explanations/platform), so you can reason about
+This page explains what data flows between a <Explanation>node</Explanation>
+and the <Explanation>platform</Explanation>, so you can reason about
 privacy, compliance, and what an operator of the platform can see.
 
 When a node starts, it opens a single outbound, TLS-encrypted WebSocket

--- a/src/content/docs/explanations/platform/data-flow.mdx
+++ b/src/content/docs/explanations/platform/data-flow.mdx
@@ -2,89 +2,94 @@
 title: Platform Data Flow
 ---
 
-This page explains what data flows between a <Explanation>node</Explanation>
-and the <Explanation>platform</Explanation>, so you can reason about
-privacy, compliance, and what an operator of the platform can see.
+This page explains what data flows between a
+[Tenzir Node](/explanations/node) and the
+[Tenzir Platform](/explanations/platform), so you can reason about
+privacy, compliance, and what an operator of the Tenzir Platform can see.
 
-When a node starts, it opens a single outbound, TLS-encrypted WebSocket
-connection to the platform. All communication between the two travels
-over that connection.
+When a Tenzir Node starts, it opens a single outbound, TLS-encrypted
+WebSocket connection to the Tenzir Platform. All communication between
+the two travels over that connection.
 
 For the bigger picture on TLS termination and trust boundaries, see the
 [FAQ entry on data privacy](/explanations/faqs#can-tenzir-see-my-data).
 
 ## The connection is a tunnel, not a feed
 
-The node does not push state to the platform. It opens the WebSocket,
-authenticates, and then waits. The platform — and through it, the app —
-uses this connection as a reverse tunnel to call the
-[node API](/reference/node/api) on demand.
+The Tenzir Node does not push state to the Tenzir Platform. It opens the
+WebSocket, authenticates, and then waits. The Tenzir Platform — and
+through it, the app — uses this connection as a reverse tunnel to call
+the [node API](/reference/node/api) on demand.
 
-In other words: whatever the app shows you about a node was pulled from
-that node at the moment you asked for it. The platform does not maintain
-a continuously updated mirror of the node's state.
+In other words: whatever the app shows you about a Tenzir Node was
+pulled from that node at the moment you asked for it. The Tenzir
+Platform does not maintain a continuously updated mirror of the
+Tenzir Node's state.
 
-The node initiates the connection — the platform never connects to the
-node. For nodes registered with the Tenzir-hosted platform, the endpoint
-defaults to `wss://ws.tenzir.app:443/production`. See
+The Tenzir Node initiates the connection — the Tenzir Platform never
+connects to it. For nodes registered with the hosted Tenzir Platform,
+the endpoint defaults to `wss://ws.tenzir.app:443/production`. See
 <Guide>node-setup/configure-tls</Guide> for the TLS options.
 
 ## What the app pulls on demand
 
 Anything you can retrieve via the [node API](/reference/node/api), the
-platform can retrieve on behalf of an authenticated user in your
+Tenzir Platform can retrieve on behalf of an authenticated user in your
 workspace. In practice this means:
 
-- The list of **pipelines** on the node, their TQL source, labels, and
-  lifecycle state.
+- The list of **pipelines** on the Tenzir Node, their TQL source,
+  labels, and lifecycle state.
 - **Pipeline metrics** such as ingress/egress event and byte counters.
 - **Diagnostics** (warnings and errors) emitted by pipelines.
 - **Contexts** — their names, types, and, if you open them in the app,
   their contents.
-- **Packages** installed on the node and their configuration.
-- **Schemas** the node has seen.
+- **Packages** installed on the Tenzir Node and their configuration.
+- **Schemas** the Tenzir Node has seen.
 
 These are fetched when a page or component in the app needs them. Close
 the page and the requests stop.
 
-## Pipeline data does not flow through the platform
+## Pipeline data does not flow through the Tenzir Platform
 
-Pipelines run entirely on the node. The events flowing through a
-pipeline's operators are **not** routed through the platform, regardless
-of where the pipeline was created.
+Pipelines run entirely on the Tenzir Node. The events flowing through a
+pipeline's operators are **not** routed through the Tenzir Platform,
+regardless of where the pipeline was created.
 
 The single exception is a pipeline you run interactively from the app
 (for example, in the Explorer). In that case the results stream
-node → platform → browser for as long as the view is open, so the app
-can render them. They are not persisted on the platform.
+Tenzir Node → Tenzir Platform → browser for as long as the view is
+open, so the app can render them. They are not persisted on the
+Tenzir Platform.
 
 ## Secrets
 
-When a pipeline accesses a secret, the node requests its value from the
-platform over the same encrypted channel, and the platform replies with
-the resolved value. See <Explanation>secrets</Explanation>.
+When a pipeline accesses a secret, the Tenzir Node requests its value
+from the Tenzir Platform over the same encrypted channel, and the
+Tenzir Platform replies with the resolved value. See
+<Explanation>secrets</Explanation>.
 
 ## What is *not* sent
 
-The platform does **not** receive:
+The Tenzir Platform does **not** receive:
 
-- The **events stored in the node** (Parquet partitions, the catalog,
-  or query results) — unless you explicitly query them from the app.
+- The **events stored in the Tenzir Node** (Parquet partitions, the
+  catalog, or query results) — unless you explicitly query them from
+  the app.
 - The **raw bytes** ingested from your sources.
 - **Pipeline payloads** for pipelines that aren't being viewed live in
   the app.
-- **Node configuration files**, environment variables, or secret values
-  defined locally on the node.
+- **Configuration files**, environment variables, or secret values
+  defined locally on the Tenzir Node.
 - **Operating system logs** or anything outside the `tenzir-node`
   process.
 
 ## Encryption and trust
 
-The WebSocket is TLS-encrypted and terminates at the platform. In the
-Tenzir-hosted editions, the operator of the platform (Tenzir) is
+The WebSocket is TLS-encrypted and terminates at the Tenzir Platform.
+In the editions where Tenzir hosts the Tenzir Platform, Tenzir is
 therefore technically able to observe data that traverses it during
-interactive use. If this is unacceptable, run the platform yourself
-with the [Sovereign Edition](https://tenzir.com/pricing) — see
+interactive use. If this is unacceptable, host the Tenzir Platform
+yourself with the [Sovereign Edition](https://tenzir.com/pricing) — see
 <Guide>platform-setup</Guide>.
 
 ## See Also

--- a/src/content/docs/explanations/platform/data-flow.mdx
+++ b/src/content/docs/explanations/platform/data-flow.mdx
@@ -1,0 +1,93 @@
+---
+title: Platform Data Flow
+---
+
+When a [node](/explanations/node) starts, it opens a single outbound,
+TLS-encrypted WebSocket connection to the [platform](/explanations/platform).
+This page describes what flows over that connection so you can reason about
+privacy, compliance, and what an operator of the platform can see.
+
+For the bigger picture on TLS termination and trust boundaries, see the
+[FAQ entry on data privacy](/explanations/faqs#can-tenzir-see-my-data).
+
+## The connection is a tunnel, not a feed
+
+The node does not push state to the platform. It opens the WebSocket,
+authenticates, and then waits. The platform — and through it, the app —
+uses this connection as a reverse tunnel to call the
+[node API](/reference/node/api) on demand.
+
+In other words: whatever the app shows you about a node was pulled from
+that node at the moment you asked for it. The platform does not maintain
+a continuously updated mirror of the node's state.
+
+The node initiates the connection — the platform never connects to the
+node. For nodes registered with the Tenzir-hosted platform, the endpoint
+defaults to `wss://ws.tenzir.app:443/production`. See
+<Guide>node-setup/configure-tls</Guide> for the TLS options.
+
+## What the app pulls on demand
+
+Anything you can retrieve via the [node API](/reference/node/api), the
+platform can retrieve on behalf of an authenticated user in your
+workspace. In practice this means:
+
+- The list of **pipelines** on the node, their TQL source, labels, and
+  lifecycle state.
+- **Pipeline metrics** such as ingress/egress event and byte counters.
+- **Diagnostics** (warnings and errors) emitted by pipelines.
+- **Contexts** — their names, types, and, if you open them in the app,
+  their contents.
+- **Packages** installed on the node and their configuration.
+- **Schemas** the node has seen.
+
+These are fetched when a page or component in the app needs them. Close
+the page and the requests stop.
+
+## Pipeline data does not flow through the platform
+
+Pipelines run entirely on the node. The events flowing through a
+pipeline's operators are **not** routed through the platform, regardless
+of where the pipeline was created.
+
+The single exception is a pipeline you run interactively from the app
+(for example, in the Explorer). In that case the results stream
+node → platform → browser for as long as the view is open, so the app
+can render them. They are not persisted on the platform.
+
+## Secrets
+
+When a pipeline accesses a secret, the node requests its value from the
+platform over the same encrypted channel, and the platform replies with
+the resolved value. See <Explanation>secrets</Explanation>.
+
+## What is *not* sent
+
+The platform does **not** receive:
+
+- The **events stored in the node** (Parquet partitions, the catalog,
+  or query results) — unless you explicitly query them from the app.
+- The **raw bytes** ingested from your sources.
+- **Pipeline payloads** for pipelines that aren't being viewed live in
+  the app.
+- **Node configuration files**, environment variables, or secret values
+  defined locally on the node.
+- **Operating system logs** or anything outside the `tenzir-node`
+  process.
+
+## Encryption and trust
+
+The WebSocket is TLS-encrypted and terminates at the platform. In the
+Tenzir-hosted editions, the operator of the platform (Tenzir) is
+therefore technically able to observe data that traverses it during
+interactive use. If this is unacceptable, run the platform yourself
+with the [Sovereign Edition](https://tenzir.com/pricing) — see
+<Guide>platform-setup</Guide>.
+
+## See Also
+
+- <Guide>node-setup/configure-tls</Guide>
+- <Explanation>platform</Explanation>
+- <Explanation>node</Explanation>
+- <Explanation>secrets</Explanation>
+- <Explanation>faqs</Explanation>

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -260,6 +260,7 @@ export const explanations = [
       "explanations/pipeline",
       "explanations/node",
       "explanations/platform",
+      "explanations/platform/data-flow",
       "explanations/language",
     ],
     "architecture",


### PR DESCRIPTION
## Summary

Adds a new explanation page documenting how data flows between nodes and the platform, clarifying privacy boundaries and what information the platform can access.

## Changes

- **New page**: `src/content/docs/explanations/platform/data-flow.mdx`
  - Explains the WebSocket connection model (reverse tunnel, not a feed)
  - Documents what data the app pulls on demand (pipelines, metrics, diagnostics, contexts, packages, schemas)
  - Clarifies that pipeline data does not flow through the platform except for interactive queries
  - Describes secret resolution flow
  - Lists what is NOT sent to the platform
  - Discusses encryption, TLS termination, and trust boundaries
  - Includes cross-references to related guides and explanations

- **Updated sidebar**: Added the new page to the explanations section under `explanations/platform/data-flow` in `src/sidebar.ts`

## Implementation Details

The page uses semantic components (`<Guide>`, `<Explanation>`) for cross-references following documentation conventions. It provides clear, practical information about data privacy and compliance considerations for operators deploying nodes with the Tenzir platform.

https://claude.ai/code/session_01PKbEPqw2gThaw4TDoVzYCV