### PR TITLE
docs: remove http from main operator index

### DIFF
--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -267,10 +267,6 @@ operators:
     description: 'Add a field with the number of preceding events.'
     example: 'enumerate num'
     path: 'reference/operators/enumerate'
-  - name: 'http'
-    description: 'Sends HTTP/1.1 requests and forwards the response.'
-    example: 'http "example.com"'
-    path: 'reference/operators/http'
   - name: 'move'
     description: 'Moves values from one field to another, removing the original field.'
     example: 'move id=parsed_id, ctx.message=incoming.status'
@@ -1680,13 +1676,6 @@ enumerate num
 
 </ReferenceCard>
 
-<ReferenceCard title="http" description="Sends HTTP/1.1 requests and forwards the response." href="/reference/operators/http">
-
-```tql
-http "example.com"
-```
-
-</ReferenceCard>
 
 <ReferenceCard title="move" description="Moves values from one field to another, removing the original field." href="/reference/operators/move">
 

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -1676,7 +1676,6 @@ enumerate num
 
 </ReferenceCard>
 
-
 <ReferenceCard title="move" description="Moves values from one field to another, removing the original field." href="/reference/operators/move">
 
 ```tql


### PR DESCRIPTION
## 🔍 Problem

- The main operator index still listed `http`, which should no longer appear there.

## 🛠️ Solution

- Remove `http` from the operator metadata list.
- Remove the matching overview card from the operator index page.

## 💬 Review

- Confirm `http` is gone from the main operator overview and no other operator entries changed.
