### PR TITLE
Document Microsoft Graph retries

### DIFF
--- a/src/content/docs/integrations/microsoft/graph.mdx
+++ b/src/content/docs/integrations/microsoft/graph.mdx
@@ -8,7 +8,10 @@ other Microsoft cloud services.
 Use <Op>from_microsoft_graph</Op> to read events and inventory data from
 Microsoft Graph collection resources. The operator handles Microsoft
 Entra client-credentials authentication, emits each object from the OData
-`value` array, and follows `@odata.nextLink` pagination.
+`value` array, follows `@odata.nextLink` pagination, and uses a bounded default
+HTTP retry policy for throttling and transient service failures. When Microsoft
+Graph returns `Retry-After`, the operator waits for that duration before
+retrying.
 
 Common security use cases include collecting Microsoft Entra audit and sign-in
 logs, reading users and groups for enrichment, and extracting inventory from

--- a/src/content/docs/reference/operators/from_microsoft_graph.mdx
+++ b/src/content/docs/reference/operators/from_microsoft_graph.mdx
@@ -23,6 +23,13 @@ The operator uses Microsoft Entra client credentials to fetch access tokens,
 adds the `Authorization` header, and refreshes the token when needed. It follows
 `@odata.nextLink` URLs until the collection is exhausted.
 
+The operator retries throttled and transient Microsoft Graph responses with a
+bounded default HTTP retry policy. It honors `Retry-After` for throttling
+responses such as `429 Too Many Requests` and also retries transient service
+failures such as `503 Service Unavailable` and `504 Gateway Timeout`.
+Permanent client and authorization failures such as `400 Bad Request`,
+`401 Unauthorized`, and `403 Forbidden` fail without retries.
+
 This operator is for one-shot collection reads. It does not store Microsoft
 Graph delta links or poll for changes.
 


### PR DESCRIPTION
## 🔍 Problem

- The Microsoft Graph docs did not describe the new default retry behavior for throttling and transient service failures.

## 🛠️ Solution

- Document the bounded retry policy in the `from_microsoft_graph` operator reference.
- Mention `Retry-After` handling in the Microsoft Graph integration guide.

## 💬 Review

- Check that the retry behavior is described without exposing implementation details.

<sub>
⚙️ Code PR: tenzir/tenzir#6179<br>
🎫 References TNZ-380
</sub>
