### PR TITLE
Document repeat string function

### DIFF
--- a/src/content/docs/guides/transformation/manipulate-strings.mdx
+++ b/src/content/docs/guides/transformation/manipulate-strings.mdx
@@ -433,6 +433,22 @@ Padding functions:
   beginning
 - <Fn>pad_end</Fn> - Add characters to the end
 
+## Repeat strings
+
+Use <Fn>repeat</Fn> to repeat a string a fixed number of times:
+
+```tql
+from {separator: "-"}
+line = separator.repeat(8)
+```
+
+```tql
+{
+  separator: "-",
+  line: "--------",
+}
+```
+
 ## Read file contents
 
 Access text from files during processing:

--- a/src/content/docs/reference/functions.mdx
+++ b/src/content/docs/reference/functions.mdx
@@ -199,6 +199,10 @@ functions:
     description: 'Replaces characters within a string based on a regular expression.'
     example: '"hello".replace("l+o", "y")'
     path: 'reference/functions/replace_regex'
+  - name: 'repeat'
+    description: 'Repeats a string a specified number of times.'
+    example: '"na".repeat(8)'
+    path: 'reference/functions/repeat'
   - name: 'reverse'
     description: 'Reverses the characters of a string.'
     example: '"hello".reverse()'
@@ -2265,6 +2269,14 @@ join(["a", "b", "c"], ",")
 
 ```tql
 "hello".replace("l+o", "y")
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="repeat" description="Repeats a string a specified number of times." href="/reference/functions/repeat">
+
+```tql
+"na".repeat(8)
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/functions/repeat.mdx
+++ b/src/content/docs/reference/functions/repeat.mdx
@@ -1,0 +1,53 @@
+---
+title: repeat
+category: String/Transformation
+example: '"na".repeat(8)'
+---
+
+Repeats a string a specified number of times.
+
+```tql
+repeat(x:string, n:int) -> string
+```
+
+## Description
+
+The `repeat` function returns a new string consisting of `x` repeated `n` times.
+If `n` is `0`, the function returns an empty string.
+
+### `x: string`
+
+The string to repeat.
+
+### `n: int`
+
+The number of times to repeat `x`. Must be non-negative.
+
+## Examples
+
+### Repeat a string
+
+```tql
+from {message: "na".repeat(8)}
+```
+
+```tql
+{message: "nananananananana"}
+```
+
+### Repeat zero times
+
+```tql
+from {message: "na".repeat(0)}
+```
+
+```tql
+{message: ""}
+```
+
+## See Also
+
+- <Fn>pad_end</Fn>
+- <Fn>pad_start</Fn>
+- <Fn>replace</Fn>
+- <Guide>transformation/manipulate-strings</Guide>


### PR DESCRIPTION
## 🔍 Problem

- tenzir/tenzir#6181 adds the `repeat` string function.
- The function reference does not yet document its signature or examples.

## 🛠️ Solution

- Add a `repeat` function reference page with usage, arguments, and examples.
- Add `repeat` to the function overview index under String/Transformation.

## 💬 Review

- The examples use method-call syntax to match the surrounding string function pages.

<sub>
⚙️ Code PR: tenzir/tenzir#6181
</sub>
