### PR TITLE
Document Microsoft Graph delta queries

### DIFF
--- a/src/content/docs/integrations/microsoft/graph.mdx
+++ b/src/content/docs/integrations/microsoft/graph.mdx
@@ -11,7 +11,9 @@ Entra client-credentials authentication, emits each object from the OData
 `value` array, follows `@odata.nextLink` pagination, and uses a bounded default
 HTTP retry policy for throttling and transient service failures. When Microsoft
 Graph returns `Retry-After`, the operator waits for that duration before
-retrying.
+retrying. For resources that support Microsoft Graph delta queries, the
+operator can store the returned `@odata.deltaLink` in memory and poll for
+incremental changes.
 
 Common security use cases include collecting Microsoft Entra audit and sign-in
 logs, reading users and groups for enrichment, and extracting inventory from
@@ -114,6 +116,33 @@ from_microsoft_graph "users",
     select: ["id", "displayName", "signInActivity"],
   }
 ```
+
+## Poll changes with delta queries
+
+Use `delta=true` for Microsoft Graph resources that support delta queries, such
+as `users`, `groups`, `auditLogs/signIns`, and `auditLogs/directoryAudits`.
+Pass the collection resource without `/delta`; the operator appends `/delta`
+for the initial request and then polls the returned `@odata.deltaLink`.
+
+```tql
+from_microsoft_graph "auditLogs/signIns",
+  delta=true,
+  poll_interval=5min,
+  auth={
+    tenant_id: secret("ms-graph-tenant-id"),
+    client_id: secret("ms-graph-client-id"),
+    client_secret: secret("ms-graph-client-secret"),
+  },
+  odata={
+    filter: "createdDateTime ge 2026-04-24T00:00:00Z",
+    select: ["id", "createdDateTime", "userPrincipalName", "status"],
+  }
+```
+
+The `odata` options apply only to the initial delta request. Later polls use the
+stored delta link exactly as Microsoft Graph returned it. Delta state is stored
+in memory, so a pipeline restart starts a new initial delta query unless the
+executor restores a snapshot that contains the operator state.
 
 ## See Also
 

--- a/src/content/docs/integrations/microsoft/graph.mdx
+++ b/src/content/docs/integrations/microsoft/graph.mdx
@@ -120,12 +120,12 @@ from_microsoft_graph "users",
 ## Poll changes with delta queries
 
 Use `delta=true` for Microsoft Graph resources that support delta queries, such
-as `users`, `groups`, `auditLogs/signIns`, and `auditLogs/directoryAudits`.
-Pass the collection resource without `/delta`; the operator appends `/delta`
-for the initial request and then polls the returned `@odata.deltaLink`.
+as `users` and `groups`. Pass the collection resource without `/delta`; the
+operator appends `/delta` for the initial request and then polls the returned
+`@odata.deltaLink`.
 
 ```tql
-from_microsoft_graph "auditLogs/signIns",
+from_microsoft_graph "users",
   delta=true,
   poll_interval=5min,
   auth={
@@ -134,15 +134,23 @@ from_microsoft_graph "auditLogs/signIns",
     client_secret: secret("ms-graph-client-secret"),
   },
   odata={
-    filter: "createdDateTime ge 2026-04-24T00:00:00Z",
-    select: ["id", "createdDateTime", "userPrincipalName", "status"],
+    select: ["id", "displayName", "userPrincipalName"],
   }
 ```
 
-The `odata` options apply only to the initial delta request. Later polls use the
-stored delta link exactly as Microsoft Graph returned it. Delta state is stored
-in memory, so a pipeline restart starts a new initial delta query unless the
-executor restores a snapshot that contains the operator state.
+The operator doesn't maintain its own list of delta-capable Microsoft Graph
+resources. Microsoft Graph support can differ by resource, API version, tenant,
+and licensing. If a resource doesn't support delta queries, Microsoft Graph
+returns the error and Tenzir reports it.
+
+The `odata` options apply only to the initial delta request. Microsoft Graph
+decides which query options are valid for each resource. For example, Microsoft
+Graph supports `$select` for `users` and `groups` delta queries, but doesn't
+support `$top` there. Filters for those delta queries are limited to object ID
+scoping. Later polls use the stored delta link exactly as Microsoft Graph
+returned it. Delta state is stored in memory, so a pipeline restart starts a new
+initial delta query unless the executor restores a snapshot that contains the
+operator state.
 
 ## See Also
 

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -380,7 +380,7 @@ operators:
     example: 'from_kafka "logs"'
     path: 'reference/operators/from_kafka'
   - name: 'from_microsoft_graph'
-    description: 'Reads events from a Microsoft Graph v1.0 collection.'
+    description: 'Reads events from a Microsoft Graph collection.'
     example: 'from_microsoft_graph "auditLogs/signIns", auth={…}'
     path: 'reference/operators/from_microsoft_graph'
   - name: 'from_mysql'
@@ -1482,7 +1482,7 @@ from_kafka "logs"
 
 </ReferenceCard>
 
-<ReferenceCard title="from_microsoft_graph" description="Reads events from a Microsoft Graph v1.0 collection." href="/reference/operators/from_microsoft_graph">
+<ReferenceCard title="from_microsoft_graph" description="Reads events from a Microsoft Graph collection." href="/reference/operators/from_microsoft_graph">
 
 ```tql
 from_microsoft_graph "auditLogs/signIns", auth={…}

--- a/src/content/docs/reference/operators/from_microsoft_graph.mdx
+++ b/src/content/docs/reference/operators/from_microsoft_graph.mdx
@@ -10,7 +10,7 @@ import Integration from '@components/see-also/Integration.astro';
 Reads events from a Microsoft Graph collection.
 
 ```tql
-from_microsoft_graph resource:string, auth=record, [version=string, odata=record, tls=bool|record]
+from_microsoft_graph resource:string, auth=record, [delta=bool, poll_interval=duration, version=string, odata=record, tls=bool|record]
 ```
 
 ## Description
@@ -23,6 +23,11 @@ The operator uses Microsoft Entra client credentials to fetch access tokens,
 adds the `Authorization` header, and refreshes the token when needed. It follows
 `@odata.nextLink` URLs until the collection is exhausted.
 
+By default, the operator performs a one-shot collection read. With
+`delta=true`, it uses Microsoft Graph delta queries: the initial request reads
+the resource's `/delta` endpoint, stores the final `@odata.deltaLink`, and polls
+that link for incremental changes.
+
 The operator retries throttled and transient Microsoft Graph responses with a
 bounded default HTTP retry policy. It honors `Retry-After` for throttling
 responses such as `429 Too Many Requests` and also retries transient service
@@ -30,8 +35,9 @@ failures such as `503 Service Unavailable` and `504 Gateway Timeout`.
 Permanent client and authorization failures such as `400 Bad Request`,
 `401 Unauthorized`, and `403 Forbidden` fail without retries.
 
-This operator is for one-shot collection reads. It does not store Microsoft
-Graph delta links or poll for changes.
+Delta query state is in memory. If the pipeline restarts without an executor
+snapshot that contains the operator state, the next run starts a new initial
+delta query.
 
 ### `resource: string`
 
@@ -58,7 +64,9 @@ application permission such as `AuditLog.Read.All`.
 
 ### `odata = record (optional)`
 
-OData query options to append to the initial request.
+OData query options to append to the initial request. In delta mode, these
+options apply only to the initial `/delta` request. Later polls use the
+`@odata.deltaLink` exactly as Microsoft Graph returned it.
 
 The `odata` record supports the following fields:
 
@@ -67,6 +75,23 @@ The `odata` record supports the following fields:
 | `filter` | `string`         | A `$filter` expression.                          |
 | `select` | `list<string>`   | Fields to request with `$select`.                |
 | `top`    | `uint64` or `int64` | The page size to request with `$top`; must be positive. |
+
+### `delta = bool (optional)`
+
+Whether to use Microsoft Graph delta queries. Defaults to `false`.
+
+When `delta=true`, pass the collection resource, such as `users`,
+`auditLogs/signIns`, or `auditLogs/directoryAudits`. The operator appends
+`/delta` unless the resource already ends with `/delta`.
+
+The operator warns, but still runs, when you use delta mode with a resource
+that isn't in Tenzir's known delta-capable resource list. Microsoft Graph may
+add delta support for more resources over time.
+
+### `poll_interval = duration (optional)`
+
+The time between delta polls after the initial delta query completes. Defaults
+to `1min`. The value must be positive and is only valid with `delta=true`.
 
 ### `version = string (optional)`
 
@@ -122,6 +147,23 @@ from_microsoft_graph "users",
   },
   odata={
     select: ["id", "displayName", "signInActivity"],
+  }
+```
+
+### Poll sign-in log changes with delta queries
+
+```tql
+from_microsoft_graph "auditLogs/signIns",
+  delta=true,
+  poll_interval=5min,
+  auth={
+    tenant_id: secret("ms-graph-tenant-id"),
+    client_id: secret("ms-graph-client-id"),
+    client_secret: secret("ms-graph-client-secret"),
+  },
+  odata={
+    filter: "createdDateTime ge 2026-04-24T00:00:00Z",
+    select: ["id", "createdDateTime", "userPrincipalName", "status"],
   }
 ```
 

--- a/src/content/docs/reference/operators/from_microsoft_graph.mdx
+++ b/src/content/docs/reference/operators/from_microsoft_graph.mdx
@@ -77,9 +77,14 @@ application permission such as `AuditLog.Read.All`.
 
 ### `odata = record (optional)`
 
-OData query options to append to the initial request. In delta mode, these
-options apply only to the initial `/delta` request. Later polls use the
+OData query options to append to the initial request. Microsoft Graph decides
+which query options are valid for each resource. In delta mode, these options
+apply only to the initial `/delta` request. Later polls use the
 `@odata.deltaLink` exactly as Microsoft Graph returned it.
+
+For example, Microsoft Graph supports `$select` for `users` and `groups` delta
+queries, but doesn't support `$top` there. Filters for those delta queries are
+limited to object ID scoping.
 
 The `odata` record supports the following fields:
 
@@ -93,13 +98,14 @@ The `odata` record supports the following fields:
 
 Whether to use Microsoft Graph delta queries. Defaults to `false`.
 
-When `delta=true`, pass the collection resource, such as `users`,
-`auditLogs/signIns`, or `auditLogs/directoryAudits`. The operator appends
-`/delta` unless the resource already ends with `/delta`.
+When `delta=true`, pass a Microsoft Graph collection resource that supports
+delta queries, such as `users` or `groups`. The operator appends `/delta`
+unless the resource already ends with `/delta`.
 
-The operator warns, but still runs, when you use delta mode with a resource
-that isn't in Tenzir's known delta-capable resource list. Microsoft Graph may
-add delta support for more resources over time.
+The operator doesn't maintain its own list of delta-capable Microsoft Graph
+resources. Microsoft Graph support can differ by resource, API version, tenant,
+and licensing. If a resource doesn't support delta queries, Microsoft Graph
+returns the error and Tenzir reports it.
 
 ### `poll_interval = duration (optional)`
 
@@ -163,10 +169,10 @@ from_microsoft_graph "users",
   }
 ```
 
-### Poll sign-in log changes with delta queries
+### Poll user changes with delta queries
 
 ```tql
-from_microsoft_graph "auditLogs/signIns",
+from_microsoft_graph "users",
   delta=true,
   poll_interval=5min,
   auth={
@@ -175,8 +181,7 @@ from_microsoft_graph "auditLogs/signIns",
     client_secret: secret("ms-graph-client-secret"),
   },
   odata={
-    filter: "createdDateTime ge 2026-04-24T00:00:00Z",
-    select: ["id", "createdDateTime", "userPrincipalName", "status"],
+    select: ["id", "displayName", "userPrincipalName"],
   }
 ```
 

--- a/src/content/docs/reference/operators/from_microsoft_graph.mdx
+++ b/src/content/docs/reference/operators/from_microsoft_graph.mdx
@@ -23,6 +23,19 @@ The operator uses Microsoft Entra client credentials to fetch access tokens,
 adds the `Authorization` header, and refreshes the token when needed. It follows
 `@odata.nextLink` URLs until the collection is exhausted.
 
+The operator doesn't inject its own `@` fields into emitted events. Microsoft
+Graph may include annotation fields on resource objects, and the operator
+handles them as follows:
+
+| Field          | Behavior |
+| :------------- | :------- |
+| `@odata.etag`  | Omitted from the emitted event when it appears as a top-level resource field. |
+| `@odata.type`  | Preserved because it can identify polymorphic Graph resource types. |
+| `@removed`     | Preserved because delta query responses use it to mark deleted or removed objects. |
+
+The operator doesn't emit OData envelope metadata such as `@odata.context`,
+`@odata.nextLink`, or `@odata.deltaLink` as events.
+
 By default, the operator performs a one-shot collection read. With
 `delta=true`, it uses Microsoft Graph delta queries: the initial request reads
 the resource's `/delta` endpoint, stores the final `@odata.deltaLink`, and polls


### PR DESCRIPTION
## 🔍 Problem

- `from_microsoft_graph` now supports delta query polling, but the docs still describe only one-shot collection reads.
- Delta queries have important behavior to document: initial-only OData options, opaque delta links, polling, and in-memory state.

## 🛠️ Solution

- Update the Microsoft Graph integration page with a delta query workflow and example.
- Extend the operator reference with `delta`, `poll_interval`, known resource behavior, and state limitations.
- Adjust the operator index wording so the source is not described as only `v1.0`.

## 💬 Review

- Please focus on whether the in-memory state limitation and initial-only OData behavior are explicit enough.

<sub>
⚙️ Code PR: tenzir/tenzir#6182<br>
⚙️ Plugin PR: tenzir/tenzir-plugins#543<br>
🎫 References TNZ-379
</sub>
