### PR TITLE
Document write_all

### DIFF
--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -731,6 +731,10 @@ operators:
     description: 'Connects to a remote TCP or TLS endpoint and sends events.'
     example: 'to_tcp "collector.example.com:5044" { write_json }'
     path: 'reference/operators/to_tcp'
+  - name: 'write_all'
+    description: 'Concatenates one field from all input events into a byte stream.'
+    example: 'write_all data'
+    path: 'reference/operators/write_all'
   - name: 'write_bitz'
     description: 'Writes events in *BITZ* format.'
     example: 'write_bitz'
@@ -2336,6 +2340,14 @@ pipeline::run { … }
 ## Printing
 
 <CardGrid>
+
+<ReferenceCard title="write_all" description="Concatenates one field from all input events into a byte stream." href="/reference/operators/write_all">
+
+```tql
+write_all data
+```
+
+</ReferenceCard>
 
 <ReferenceCard title="write_bitz" description="Writes events in *BITZ* format." href="/reference/operators/write_bitz">
 

--- a/src/content/docs/reference/operators/write_all.mdx
+++ b/src/content/docs/reference/operators/write_all.mdx
@@ -1,0 +1,67 @@
+---
+title: write_all
+category: Printing
+example: 'write_all data'
+---
+
+Concatenates one field from all input events into a byte stream.
+
+```tql
+write_all field
+```
+
+## Description
+
+The `write_all` operator takes one field selector and appends the field's values
+in input order. It accepts fields of type `blob` and `string`.
+
+For `blob` fields, `write_all` appends the bytes verbatim. For `string` fields,
+it appends the existing string bytes without adding separators or escaping.
+
+The operator skips `null` values and events where the selected field is missing.
+It emits no bytes if all values are skipped.
+
+## Examples
+
+### Write strings without separators
+
+```tql
+from {data: "hello"}, {data: " "}, {data: "world"}
+to_stdout {
+  write_all data
+}
+```
+
+```txt
+hello world
+```
+
+### Copy a binary file
+
+Use <Op>read_all</Op> with `binary=true` to read a file into a `blob` field,
+then write that field back as raw bytes.
+
+```tql
+from_file "/tmp/report.pdf" {
+  read_all binary=true
+}
+to_file "/tmp/report-copy.pdf" {
+  write_all data
+}
+```
+
+### Write a nested field
+
+```tql
+from {payload: {data: b"foo"}}, {payload: {data: b"bar"}}
+to_file "/tmp/payload.bin" {
+  write_all payload.data
+}
+```
+
+## See Also
+
+- <Op>read_all</Op>
+- <Op>to_file</Op>
+- <Op>to_stdout</Op>
+- <Op>write_lines</Op>


### PR DESCRIPTION
## 🔍 Problem

The code change adds `write_all`, but docs.tenzir.com needs the operator reference so users can discover the new raw-byte writer and its relationship to `read_all`.

## 🛠️ Solution

- Add a `write_all` reference page with syntax, behavior, and examples.
- Add `write_all` to the operator reference index and printing card grid.

## 💬 Review

Check that the examples match the code PR behavior for string concatenation, binary roundtrips, nested field selectors, and skipped null or missing values.

<sub>
⚙️ Code PR: tenzir/tenzir#6187<br>
🎫 References TNZ-577
</sub>