### PR TITLE
Document from_http parser inference

### DIFF
--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -3,6 +3,7 @@ title: Fetch via HTTP and APIs
 ---
 
 This guide shows you how to interact with HTTP APIs using the
+
 <Op>from_http</Op> and <Op>to_http</Op> operators. You'll learn to make GET
 requests, send data, handle authentication, and implement pagination for large
 result sets.
@@ -30,18 +31,21 @@ Start with these fundamental patterns for making HTTP requests to APIs.
 To fetch data from an API endpoint, pass the URL as the first parameter:
 
 ```tql
-from_http "https://api.example.com/data" {
-  read_json
-}
+from_http "https://api.example.com/data.json"
 ```
 
 The operator makes a GET request by default and sends the response body to the
-required parsing sub-pipeline.
+parser. If the response has a supported `Content-Type` header or the URL path
+has a supported extension, Tenzir infers the parser automatically.
 
 ### Parsing the HTTP response body
 
-The `from_http` operator requires an explicit parsing sub-pipeline. Use it to
-specify how Tenzir should parse the response body.
+You can omit the parsing sub-pipeline when Tenzir can infer the response
+format. Tenzir first checks a non-empty `Content-Type` response header and then
+falls back to the URL path extension.
+
+Use an explicit parsing sub-pipeline when the response format is ambiguous,
+custom, or not reflected by the header or URL.
 
 The operator automatically handles HTTP `Content-Encoding`. If the downloaded
 file itself is compressed, add the matching decompressor to the sub-pipeline.

--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -2,9 +2,8 @@
 title: Fetch via HTTP and APIs
 ---
 
-This guide shows you how to interact with HTTP APIs using the
-
-<Op>from_http</Op> and <Op>to_http</Op> operators. You'll learn to make GET
+This guide shows you how to interact with HTTP APIs using <Op>from_http</Op>
+and <Op>to_http</Op> operators. You'll learn to make GET
 requests, send data, handle authentication, and implement pagination for large
 result sets.
 

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -373,7 +373,7 @@ operators:
     path: 'reference/operators/from_google_cloud_storage'
   - name: 'from_http'
     description: 'Sends an HTTP/1.1 request and returns the response as events.'
-    example: 'from_http "https://example.com/api" { read_json }'
+    example: 'from_http "https://example.com/api/events.json"'
     path: 'reference/operators/from_http'
   - name: 'from_kafka'
     description: 'Receives events from an Apache Kafka topic.'
@@ -1469,7 +1469,7 @@ from_google_cloud_storage "gs://my-bucket/data/**.json"
 <ReferenceCard title="from_http" description="Sends an HTTP/1.1 request and returns the response as events." href="/reference/operators/from_http">
 
 ```tql
-from_http "https://example.com/api" { read_json }
+from_http "https://example.com/api/events.json"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -1,7 +1,7 @@
 ---
 title: from_http
 category: Inputs/Events
-example: 'from_http "https://example.com/api" { read_json }'
+example: 'from_http "https://example.com/api/events.json"'
 ---
 
 import Op from '@components/see-also/Op.astro';
@@ -15,7 +15,7 @@ from_http url:string, [method=string, body=record|string|blob, encode=string,
           headers=record, error_field=field, paginate=string,
           paginate_delay=duration, connection_timeout=duration,
           max_retry_count=int, retry_delay=duration, tls=record]
-          { … }
+          [{ … }]
 ```
 
 ## Description
@@ -23,8 +23,20 @@ from_http url:string, [method=string, body=record|string|blob, encode=string,
 The `from_http` operator issues an HTTP request and returns the response as
 events.
 
-The `from_http` operator requires a parser sub-pipeline. The operator sends the
-HTTP response body to that sub-pipeline as bytes.
+The `from_http` operator sends the HTTP response body to a parser sub-pipeline
+as bytes. You can provide the sub-pipeline explicitly, or omit it when Tenzir
+can infer the response format.
+
+When you omit the parser sub-pipeline, Tenzir infers the parser for each
+response page in this order:
+
+1. Use a non-empty `Content-Type` response header.
+2. Use the URL path extension.
+3. Emit an error that asks you to provide an explicit parser sub-pipeline.
+
+If a response contains a non-empty unsupported `Content-Type` header, Tenzir
+doesn't fall back to the URL extension. Provide an explicit parser sub-pipeline
+for ambiguous or custom formats.
 
 Use the sub-pipeline to parse the response body. The operator automatically
 handles HTTP `Content-Encoding`. If the downloaded file itself is compressed,
@@ -107,11 +119,12 @@ import TLSOptions from '@partials/operators/TLSOptions.mdx';
 The `server=true` flag is no longer supported. Use <Op>accept_http</Op> to
 listen for incoming HTTP requests.
 
-### `{ … }`
+### `{ … } (optional)`
 
-A required pipeline that receives the response body as bytes, allowing parsing
-per request. This is especially useful in scenarios where the response body can
-be parsed into multiple events.
+An optional pipeline that receives the response body as bytes, allowing parsing
+per request. Explicit parser sub-pipelines take precedence over inferred
+formats. This is especially useful for ambiguous formats, custom parsing, or
+scenarios where the response body can be parsed into multiple events.
 
 Inside the pipeline, the `$response` variable is available as a record with the
 following fields:
@@ -154,6 +167,23 @@ head 1
   total: 9,
   took: 296,
   has_more: false,
+}
+```
+
+### Infer the parser
+
+Omit the parser sub-pipeline when the response declares a supported
+`Content-Type` header or the URL path has a supported extension:
+
+```tql
+from_http "https://example.com/events.json"
+```
+
+Explicit parser sub-pipelines still take precedence:
+
+```tql
+from_http "https://example.com/events" {
+  read_ndjson
 }
 ```
 


### PR DESCRIPTION
## 🔍 Problem

- The `from_http` docs still described the parser subpipeline as required.
- The collection guide examples didn't mention parser inference from response metadata or URL extensions.

## 🛠️ Solution

- Document the inference order: `Content-Type`, then URL path extension, then an explicit-parser diagnostic.
- Clarify when to keep an explicit parser subpipeline.
- Update the `from_http` reference, collection guide, and operator overview examples.

## 💬 Review

- Check whether the precedence and unsupported `Content-Type` behavior are clear enough for users.
- Check that the examples fit the new optional parser syntax.

<sub>
⚙️ Code PR: tenzir/tenzir#6186<br>
🎫 References TNZ-501
</sub>
