### PR TITLE
Document Amazon Kinesis operators

### DIFF
--- a/src/content/docs/guides/collecting/read-from-message-brokers.mdx
+++ b/src/content/docs/guides/collecting/read-from-message-brokers.mdx
@@ -4,8 +4,8 @@ title: Read from message brokers
 
 This guide shows you how to receive events from message brokers using TQL.
 You'll learn to subscribe to topics and queues from Apache Kafka (including
-Amazon MSK), NATS JetStream, AMQP-based brokers (like RabbitMQ), Amazon SQS,
-and Google Cloud Pub/Sub.
+Amazon MSK), Amazon Kinesis Data Streams, NATS JetStream, AMQP-based brokers
+(like RabbitMQ), Amazon SQS, and Google Cloud Pub/Sub.
 
 ## Apache Kafka
 
@@ -62,6 +62,23 @@ from_kafka "security-logs",
   options={"bootstrap.servers": "my-cluster.kafka.us-east-1.amazonaws.com:9098"},
   aws_iam={region: "us-east-1"}
 ```
+
+## Amazon Kinesis
+
+[Amazon Kinesis Data Streams](/integrations/amazon/kinesis) is a managed
+streaming service on AWS. Use `from_amazon_kinesis` to receive records from a
+stream.
+
+### Receive from a stream
+
+```tql
+from_amazon_kinesis "security-events", start="trim_horizon"
+this = string(message).parse_json()
+```
+
+The operator emits one event per Kinesis record. The raw payload is stored in
+the `message` field as a `blob`, together with stream, shard, sequence number,
+partition key, and lag metadata.
 
 ## NATS JetStream
 
@@ -158,5 +175,6 @@ content. Parse it to extract structured data.
 - <Integration>kafka</Integration>
 - <Integration>nats</Integration>
 - <Integration>amqp</Integration>
+- <Integration>amazon/kinesis</Integration>
 - <Integration>amazon/sqs</Integration>
 - <Integration>google/cloud-pubsub</Integration>

--- a/src/content/docs/guides/routing/send-to-destinations.mdx
+++ b/src/content/docs/guides/routing/send-to-destinations.mdx
@@ -13,7 +13,8 @@ operators accept expressions for flexible serialization.
 
 ### Message brokers
 
-Send events to message brokers like [Kafka](/integrations/kafka) and
+Send events to message brokers like [Kafka](/integrations/kafka),
+[Amazon Kinesis Data Streams](/integrations/amazon/kinesis), and
 [NATS](/integrations/nats).
 
 Send to Kafka with automatic JSON formatting:
@@ -42,6 +43,13 @@ to_nats "alerts"
 
 The NATS server must have a JetStream stream that captures the subject you
 publish to.
+
+Send to Kinesis with the default NDJSON serialization:
+
+```tql
+subscribe "security-events"
+to_amazon_kinesis "security-events"
+```
 
 ### Analytics platforms
 
@@ -175,6 +183,7 @@ to_kafka f"events.{event_type}"
 
 - <Op>fork</Op>
 - <Op>to_kafka</Op>
+- <Op>to_amazon_kinesis</Op>
 - <Op>to_opensearch</Op>
 - <Op>to_splunk</Op>
 - <Op>to_tcp</Op>

--- a/src/content/docs/integrations/amazon/kinesis.mdx
+++ b/src/content/docs/integrations/amazon/kinesis.mdx
@@ -23,10 +23,10 @@ from_amazon_kinesis "security-events", start="trim_horizon"
 this = string(message).parse_json()
 ```
 
-The source operator lists shards once during startup. If the stream gains new
-shards while a pipeline is running, restart the pipeline to discover them.
-Snapshots store per-shard sequence numbers and resume with at-least-once
-semantics.
+The source operator lists shards during startup and discovers new shards when
+an existing shard closes, such as after a resharding operation, so running
+pipelines follow reshards without a restart. Snapshots store per-shard
+sequence numbers and resume with at-least-once semantics.
 
 ## Configuration
 

--- a/src/content/docs/integrations/amazon/kinesis.mdx
+++ b/src/content/docs/integrations/amazon/kinesis.mdx
@@ -1,0 +1,120 @@
+---
+title: Kinesis
+---
+
+[Amazon Kinesis Data Streams](https://aws.amazon.com/kinesis/data-streams/) is a
+managed streaming data service on AWS.
+
+Tenzir can receive records from Kinesis streams with
+
+<Op>from_amazon_kinesis</Op> and send records to Kinesis streams with
+<Op>to_amazon_kinesis</Op>.
+
+When Tenzir reads from Kinesis, it emits one event per Kinesis record. The event
+uses the `tenzir.amazon_kinesis` schema and contains the raw record payload in
+the `message` field as a `blob`, together with metadata such as the stream,
+shard, sequence number, partition key, arrival time, and lag.
+
+Tenzir does not parse or decompress Kinesis payloads automatically. Convert the
+`message` blob explicitly in TQL when the stream contains structured data:
+
+```tql
+from_amazon_kinesis "security-events", start="trim_horizon"
+this = string(message).parse_json()
+```
+
+The source operator lists shards once during startup. If the stream gains new
+shards while a pipeline is running, restart the pipeline to discover them.
+Snapshots store per-shard sequence numbers and resume with at-least-once
+semantics.
+
+## Configuration
+
+Follow the [Amazon integration configuration](/integrations/amazon) to
+authenticate with your AWS credentials.
+
+Alternatively, use the `aws_iam` parameter to provide explicit credentials:
+
+```tql
+from_amazon_kinesis "security-events", aws_iam={
+  region: "us-east-1",
+  access_key_id: secret("aws-key"),
+  secret_access_key: secret("aws-secret")
+}
+```
+
+You can also use `aws_iam` to assume an IAM role:
+
+```tql
+from_amazon_kinesis "security-events", aws_iam={
+  region: "eu-west-1",
+  assume_role: "arn:aws:iam::123456789012:role/my-kinesis-role",
+  session_name: "tenzir-session"
+}
+```
+
+Set `endpoint` to use a Kinesis-compatible endpoint, such as LocalStack:
+
+```tql
+from_amazon_kinesis "security-events",
+  aws_region="us-east-1",
+  endpoint="http://127.0.0.1:4566"
+```
+
+When `endpoint` is omitted, Tenzir checks `AWS_ENDPOINT_URL_KINESIS` first, then
+`AWS_ENDPOINT_URL`, then uses the default AWS SDK endpoint for the region.
+
+Tenzir needs these Kinesis permissions:
+
+| Operator                     | Required permissions                                                   |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| <Op>from_amazon_kinesis</Op> | `kinesis:ListShards`, `kinesis:GetShardIterator`, `kinesis:GetRecords` |
+| <Op>to_amazon_kinesis</Op>   | `kinesis:PutRecords`                                                   |
+
+## Examples
+
+### Send events to a stream
+
+```tql
+subscribe "alerts"
+to_amazon_kinesis "security-events"
+```
+
+This sends one NDJSON record per input event by using the default
+`message=this.print_ndjson()` expression.
+
+### Send a custom payload
+
+```tql
+from {payload: "security event detected", tenant: "acme"}
+to_amazon_kinesis "security-events",
+  message=payload,
+  partition_key=tenant
+```
+
+If you omit `partition_key`, Tenzir generates a random UUID per event.
+
+### Receive and parse JSON records
+
+```tql
+from_amazon_kinesis "security-events",
+  start="trim_horizon",
+  count=100,
+  exit=true
+this = string(message).parse_json()
+```
+
+### Read from a timestamp
+
+```tql
+from_amazon_kinesis "security-events", start=2026-01-01T00:00:00Z
+```
+
+## See Also
+
+- <Op>from_amazon_kinesis</Op>
+- <Op>to_amazon_kinesis</Op>
+- <Guide>collecting/read-from-message-brokers</Guide>
+- <Guide>routing/send-to-destinations</Guide>
+- <Integration>amazon/sqs</Integration>
+- <Integration>kafka</Integration>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -343,14 +343,14 @@ operators:
     description: 'Receives UDP datagrams and outputs structured events.'
     example: 'accept_udp "0.0.0.0:8090"'
     path: 'reference/operators/accept_udp'
-  - name: 'from_amqp'
-    description: 'Receives messages from an AMQP queue.'
-    example: 'from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"'
-    path: 'reference/operators/from_amqp'
   - name: 'from_amazon_kinesis'
     description: 'Receives records from an Amazon Kinesis data stream.'
     example: 'from_amazon_kinesis "security-events"'
     path: 'reference/operators/from_amazon_kinesis'
+  - name: 'from_amqp'
+    description: 'Receives messages from an AMQP queue.'
+    example: 'from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"'
+    path: 'reference/operators/from_amqp'
   - name: 'from_azure_blob_storage'
     description: 'Reads one or multiple files from Azure Blob Storage.'
     example: 'from_azure_blob_storage "abfs://container/data/**.json"'
@@ -619,14 +619,14 @@ operators:
     description: 'Listens for incoming TCP connections and sends events to all connected clients.'
     example: 'serve_tcp "0.0.0.0:8090" { write_json }'
     path: 'reference/operators/serve_tcp'
-  - name: 'to_amqp'
-    description: 'Sends messages to an AMQP exchange.'
-    example: 'to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"'
-    path: 'reference/operators/to_amqp'
   - name: 'to_amazon_kinesis'
     description: 'Sends records to an Amazon Kinesis data stream.'
     example: 'to_amazon_kinesis "security-events"'
     path: 'reference/operators/to_amazon_kinesis'
+  - name: 'to_amqp'
+    description: 'Sends messages to an AMQP exchange.'
+    example: 'to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"'
+    path: 'reference/operators/to_amqp'
   - name: 'to_sqs'
     description: 'Sends messages to an Amazon SQS queue.'
     example: 'to_sqs "sqs://tenzir"'
@@ -1422,18 +1422,18 @@ accept_zmq "tcp://0.0.0.0:5555", prefix="alerts/" { read_json }
 
 </ReferenceCard>
 
-<ReferenceCard title="from_amqp" description="Receives messages from an AMQP queue." href="/reference/operators/from_amqp">
-
-```tql
-from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"
-```
-
-</ReferenceCard>
-
 <ReferenceCard title="from_amazon_kinesis" description="Receives records from an Amazon Kinesis data stream." href="/reference/operators/from_amazon_kinesis">
 
 ```tql
 from_amazon_kinesis "security-events"
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="from_amqp" description="Receives messages from an AMQP queue." href="/reference/operators/from_amqp">
+
+```tql
+from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"
 ```
 
 </ReferenceCard>
@@ -1878,18 +1878,18 @@ to_amazon_security_lake "s3://…"
 
 </ReferenceCard>
 
-<ReferenceCard title="to_amqp" description="Sends messages to an AMQP exchange." href="/reference/operators/to_amqp">
-
-```tql
-to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"
-```
-
-</ReferenceCard>
-
 <ReferenceCard title="to_amazon_kinesis" description="Sends records to an Amazon Kinesis data stream." href="/reference/operators/to_amazon_kinesis">
 
 ```tql
 to_amazon_kinesis "security-events"
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="to_amqp" description="Sends messages to an AMQP exchange." href="/reference/operators/to_amqp">
+
+```tql
+to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -367,6 +367,10 @@ operators:
     description: 'Receives messages from an AMQP queue.'
     example: 'from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"'
     path: 'reference/operators/from_amqp'
+  - name: 'from_amazon_kinesis'
+    description: 'Receives records from an Amazon Kinesis data stream.'
+    example: 'from_amazon_kinesis "security-events"'
+    path: 'reference/operators/from_amazon_kinesis'
   - name: 'from_azure_blob_storage'
     description: 'Reads one or multiple files from Azure Blob Storage.'
     example: 'from_azure_blob_storage "abfs://container/data/**.json"'
@@ -647,6 +651,14 @@ operators:
     description: 'Sends messages to an AMQP exchange.'
     example: 'to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"'
     path: 'reference/operators/to_amqp'
+  - name: 'to_amazon_kinesis'
+    description: 'Sends records to an Amazon Kinesis data stream.'
+    example: 'to_amazon_kinesis "security-events"'
+    path: 'reference/operators/to_amazon_kinesis'
+  - name: 'to_sqs'
+    description: 'Sends messages to an Amazon SQS queue.'
+    example: 'to_sqs "sqs://tenzir"'
+    path: 'reference/operators/to_sqs'
   - name: 'to_udp'
     description: 'Sends one UDP datagram per input event.'
     example: 'to_udp "127.0.0.1:514"'
@@ -1510,6 +1522,14 @@ from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"
 
 </ReferenceCard>
 
+<ReferenceCard title="from_amazon_kinesis" description="Receives records from an Amazon Kinesis data stream." href="/reference/operators/from_amazon_kinesis">
+
+```tql
+from_amazon_kinesis "security-events"
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="from_azure_blob_storage" description="Reads one or multiple files from Azure Blob Storage." href="/reference/operators/from_azure_blob_storage">
 
 ```tql
@@ -1988,6 +2008,14 @@ to_amazon_sqs "sqs://tenzir"
 
 ```tql
 to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="to_amazon_kinesis" description="Sends records to an Amazon Kinesis data stream." href="/reference/operators/to_amazon_kinesis">
+
+```tql
+to_amazon_kinesis "security-events"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -359,6 +359,10 @@ operators:
     description: 'Reads events from Amazon CloudWatch.'
     example: 'from_amazon_cloudwatch "/aws/lambda/api", mode="search"'
     path: 'reference/operators/from_amazon_cloudwatch'
+  - name: 'from_amazon_kinesis'
+    description: 'Receives records from an Amazon Kinesis data stream.'
+    example: 'from_amazon_kinesis "security-events"'
+    path: 'reference/operators/from_amazon_kinesis'
   - name: 'from_amazon_sqs'
     description: 'Receives messages from an Amazon SQS queue.'
     example: 'from_amazon_sqs "sqs://tenzir", poll_time=5s'
@@ -367,10 +371,6 @@ operators:
     description: 'Receives messages from an AMQP queue.'
     example: 'from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"'
     path: 'reference/operators/from_amqp'
-  - name: 'from_amazon_kinesis'
-    description: 'Receives records from an Amazon Kinesis data stream.'
-    example: 'from_amazon_kinesis "security-events"'
-    path: 'reference/operators/from_amazon_kinesis'
   - name: 'from_azure_blob_storage'
     description: 'Reads one or multiple files from Azure Blob Storage.'
     example: 'from_azure_blob_storage "abfs://container/data/**.json"'
@@ -647,14 +647,14 @@ operators:
     description: 'Listens for incoming TCP connections and sends events to all connected clients.'
     example: 'serve_tcp "0.0.0.0:8090" { write_json }'
     path: 'reference/operators/serve_tcp'
-  - name: 'to_amqp'
-    description: 'Sends messages to an AMQP exchange.'
-    example: 'to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"'
-    path: 'reference/operators/to_amqp'
   - name: 'to_amazon_kinesis'
     description: 'Sends records to an Amazon Kinesis data stream.'
     example: 'to_amazon_kinesis "security-events"'
     path: 'reference/operators/to_amazon_kinesis'
+  - name: 'to_amqp'
+    description: 'Sends messages to an AMQP exchange.'
+    example: 'to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"'
+    path: 'reference/operators/to_amqp'
   - name: 'to_sqs'
     description: 'Sends messages to an Amazon SQS queue.'
     example: 'to_sqs "sqs://tenzir"'
@@ -1506,6 +1506,14 @@ from_amazon_cloudwatch "/aws/lambda/api", mode="search"
 
 </ReferenceCard>
 
+<ReferenceCard title="from_amazon_kinesis" description="Receives records from an Amazon Kinesis data stream." href="/reference/operators/from_amazon_kinesis">
+
+```tql
+from_amazon_kinesis "security-events"
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="from_amazon_sqs" description="Receives messages from an Amazon SQS queue." href="/reference/operators/from_amazon_sqs">
 
 ```tql
@@ -1518,14 +1526,6 @@ from_amazon_sqs "sqs://tenzir", poll_time=5s
 
 ```tql
 from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"
-```
-
-</ReferenceCard>
-
-<ReferenceCard title="from_amazon_kinesis" description="Receives records from an Amazon Kinesis data stream." href="/reference/operators/from_amazon_kinesis">
-
-```tql
-from_amazon_kinesis "security-events"
 ```
 
 </ReferenceCard>
@@ -1996,6 +1996,14 @@ to_amazon_security_lake "s3://…"
 
 </ReferenceCard>
 
+<ReferenceCard title="to_amazon_kinesis" description="Sends records to an Amazon Kinesis data stream." href="/reference/operators/to_amazon_kinesis">
+
+```tql
+to_amazon_kinesis "security-events"
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="to_amazon_sqs" description="Sends messages to an Amazon SQS queue." href="/reference/operators/to_amazon_sqs">
 
 ```tql
@@ -2008,14 +2016,6 @@ to_amazon_sqs "sqs://tenzir"
 
 ```tql
 to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"
-```
-
-</ReferenceCard>
-
-<ReferenceCard title="to_amazon_kinesis" description="Sends records to an Amazon Kinesis data stream." href="/reference/operators/to_amazon_kinesis">
-
-```tql
-to_amazon_kinesis "security-events"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -651,6 +651,10 @@ operators:
     description: 'Sends records to an Amazon Kinesis data stream.'
     example: 'to_amazon_kinesis "security-events"'
     path: 'reference/operators/to_amazon_kinesis'
+  - name: 'to_amazon_security_lake'
+    description: 'Sends OCSF events to Amazon Security Lake.'
+    example: 'to_amazon_security_lake "s3://…"'
+    path: 'reference/operators/to_amazon_security_lake'
   - name: 'to_amqp'
     description: 'Sends messages to an AMQP exchange.'
     example: 'to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"'
@@ -1988,18 +1992,18 @@ to_amazon_cloudwatch "/tenzir/events", stream="default"
 
 </ReferenceCard>
 
-<ReferenceCard title="to_amazon_security_lake" description="Sends OCSF events to Amazon Security Lake." href="/reference/operators/to_amazon_security_lake">
-
-```tql
-to_amazon_security_lake "s3://…"
-```
-
-</ReferenceCard>
-
 <ReferenceCard title="to_amazon_kinesis" description="Sends records to an Amazon Kinesis data stream." href="/reference/operators/to_amazon_kinesis">
 
 ```tql
 to_amazon_kinesis "security-events"
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="to_amazon_security_lake" description="Sends OCSF events to Amazon Security Lake." href="/reference/operators/to_amazon_security_lake">
+
+```tql
+to_amazon_security_lake "s3://…"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -623,6 +623,10 @@ operators:
     description: 'Sends records to an Amazon Kinesis data stream.'
     example: 'to_amazon_kinesis "security-events"'
     path: 'reference/operators/to_amazon_kinesis'
+  - name: 'to_amazon_security_lake'
+    description: 'Sends OCSF events to Amazon Security Lake.'
+    example: 'to_amazon_security_lake "s3://…"'
+    path: 'reference/operators/to_amazon_security_lake'
   - name: 'to_amqp'
     description: 'Sends messages to an AMQP exchange.'
     example: 'to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"'
@@ -643,10 +647,6 @@ operators:
     description: 'Executes YARA rules on byte streams.'
     example: 'yara "/path/to/rules"'
     path: 'reference/operators/yara'
-  - name: 'to_amazon_security_lake'
-    description: 'Sends OCSF events to Amazon Security Lake.'
-    example: 'to_amazon_security_lake "s3://…"'
-    path: 'reference/operators/to_amazon_security_lake'
   - name: 'to_azure_blob_storage'
     description: 'Writes events to one or multiple blobs in Azure Blob Storage.'
     example: 'to_azure_blob_storage "abfs://container/data/{uuid}.json" { write_ndjson }'
@@ -1870,18 +1870,18 @@ serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"
 
 </ReferenceCard>
 
-<ReferenceCard title="to_amazon_security_lake" description="Sends OCSF events to Amazon Security Lake." href="/reference/operators/to_amazon_security_lake">
-
-```tql
-to_amazon_security_lake "s3://…"
-```
-
-</ReferenceCard>
-
 <ReferenceCard title="to_amazon_kinesis" description="Sends records to an Amazon Kinesis data stream." href="/reference/operators/to_amazon_kinesis">
 
 ```tql
 to_amazon_kinesis "security-events"
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="to_amazon_security_lake" description="Sends OCSF events to Amazon Security Lake." href="/reference/operators/to_amazon_security_lake">
+
+```tql
+to_amazon_security_lake "s3://…"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -347,6 +347,10 @@ operators:
     description: 'Receives messages from an AMQP queue.'
     example: 'from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"'
     path: 'reference/operators/from_amqp'
+  - name: 'from_amazon_kinesis'
+    description: 'Receives records from an Amazon Kinesis data stream.'
+    example: 'from_amazon_kinesis "security-events"'
+    path: 'reference/operators/from_amazon_kinesis'
   - name: 'from_azure_blob_storage'
     description: 'Reads one or multiple files from Azure Blob Storage.'
     example: 'from_azure_blob_storage "abfs://container/data/**.json"'
@@ -619,6 +623,10 @@ operators:
     description: 'Sends messages to an AMQP exchange.'
     example: 'to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"'
     path: 'reference/operators/to_amqp'
+  - name: 'to_amazon_kinesis'
+    description: 'Sends records to an Amazon Kinesis data stream.'
+    example: 'to_amazon_kinesis "security-events"'
+    path: 'reference/operators/to_amazon_kinesis'
   - name: 'to_sqs'
     description: 'Sends messages to an Amazon SQS queue.'
     example: 'to_sqs "sqs://tenzir"'
@@ -1422,6 +1430,14 @@ from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"
 
 </ReferenceCard>
 
+<ReferenceCard title="from_amazon_kinesis" description="Receives records from an Amazon Kinesis data stream." href="/reference/operators/from_amazon_kinesis">
+
+```tql
+from_amazon_kinesis "security-events"
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="from_azure_blob_storage" description="Reads one or multiple files from Azure Blob Storage." href="/reference/operators/from_azure_blob_storage">
 
 ```tql
@@ -1866,6 +1882,14 @@ to_amazon_security_lake "s3://…"
 
 ```tql
 to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="to_amazon_kinesis" description="Sends records to an Amazon Kinesis data stream." href="/reference/operators/to_amazon_kinesis">
+
+```tql
+to_amazon_kinesis "security-events"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators/from_amazon_kinesis.mdx
+++ b/src/content/docs/reference/operators/from_amazon_kinesis.mdx
@@ -23,22 +23,22 @@ Kinesis data stream and emits one event per Kinesis record.
 
 The emitted events use the `tenzir.amazon_kinesis` schema with these fields:
 
-| Field                  | Type     | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `message`              | `blob`   | The raw Kinesis record payload.                  |
-| `stream`               | `string` | The stream name.                                 |
-| `shard_id`             | `string` | The shard that contained the record.             |
-| `sequence_number`      | `string` | The Kinesis sequence number.                     |
-| `partition_key`        | `string` | The record partition key.                        |
-| `arrival_time`         | `time`   | The approximate time when Kinesis received it.   |
-| `encryption_type`      | `string` | The server-side encryption type, when available. |
-| `millis_behind_latest` | `int`    | The shard lag reported by Kinesis.               |
+| Field             | Type       | Description                                      |
+| ----------------- | ---------- | ------------------------------------------------ |
+| `message`         | `blob`     | The raw Kinesis record payload.                  |
+| `stream`          | `string`   | The stream name.                                 |
+| `shard_id`        | `string`   | The shard that contained the record.             |
+| `sequence_number` | `string`   | The Kinesis sequence number.                     |
+| `partition_key`   | `string`   | The record partition key.                        |
+| `arrival_time`    | `time`     | The approximate time when Kinesis received it.   |
+| `encryption_type` | `string`   | The server-side encryption type, when available. |
+| `behind_latest`   | `duration` | The shard lag reported by Kinesis.               |
 
 The `arrival_time` and `encryption_type` fields are optional because Kinesis
 only returns them when they are present on the record.
 
-The operator lists shards once during startup. If the stream gains new shards
-while the pipeline is running, restart the pipeline to discover them. Pipeline
+The operator lists shards during startup and discovers new shards when an
+existing shard closes, such as after a resharding operation. Pipeline
 snapshots store the next sequence number per shard, and restarts resume with
 `AFTER_SEQUENCE_NUMBER`. This gives at-least-once restart behavior.
 

--- a/src/content/docs/reference/operators/from_amazon_kinesis.mdx
+++ b/src/content/docs/reference/operators/from_amazon_kinesis.mdx
@@ -91,7 +91,7 @@ Defaults to `1000`.
 
 How long to wait after a `GetRecords` request returns no records.
 
-The value must be non-negative.
+The value must be non-negative and less than `5min`.
 
 Defaults to `1s`.
 

--- a/src/content/docs/reference/operators/from_amazon_kinesis.mdx
+++ b/src/content/docs/reference/operators/from_amazon_kinesis.mdx
@@ -1,0 +1,166 @@
+---
+title: from_amazon_kinesis
+category: Inputs/Events
+example: 'from_amazon_kinesis "security-events", start="trim_horizon"'
+---
+
+import AWSIAMOptions from '@partials/operators/AWSIAMOptions.mdx';
+
+Receives records from an [Amazon Kinesis Data Streams][kinesis] stream.
+
+[kinesis]: https://aws.amazon.com/kinesis/data-streams/
+
+```tql
+from_amazon_kinesis stream:string, [start=string|time, count=int, exit=bool,
+                     records_per_call=int, poll_idle=duration,
+                     aws_region=string, aws_iam=record, endpoint=string]
+```
+
+## Description
+
+The `from_amazon_kinesis` operator reads records from the existing shards of a
+Kinesis data stream and emits one event per Kinesis record.
+
+The emitted events use the `tenzir.amazon_kinesis` schema with these fields:
+
+| Field                  | Type     | Description                                      |
+| ---------------------- | -------- | ------------------------------------------------ |
+| `message`              | `blob`   | The raw Kinesis record payload.                  |
+| `stream`               | `string` | The stream name.                                 |
+| `shard_id`             | `string` | The shard that contained the record.             |
+| `sequence_number`      | `string` | The Kinesis sequence number.                     |
+| `partition_key`        | `string` | The record partition key.                        |
+| `arrival_time`         | `time`   | The approximate time when Kinesis received it.   |
+| `encryption_type`      | `string` | The server-side encryption type, when available. |
+| `millis_behind_latest` | `int`    | The shard lag reported by Kinesis.               |
+
+The `arrival_time` and `encryption_type` fields are optional because Kinesis
+only returns them when they are present on the record.
+
+The operator lists shards once during startup. If the stream gains new shards
+while the pipeline is running, restart the pipeline to discover them. Pipeline
+snapshots store the next sequence number per shard, and restarts resume with
+`AFTER_SEQUENCE_NUMBER`. This gives at-least-once restart behavior.
+
+The operator requires these AWS permissions:
+
+- `kinesis:ListShards`
+- `kinesis:GetShardIterator`
+- `kinesis:GetRecords`
+
+### `stream: string`
+
+The name of the Kinesis data stream to receive records from.
+
+### `start = string | time (optional)`
+
+The position for the initial shard iterator when no snapshot is available.
+
+The value can be one of:
+
+- `"latest"`: start after the latest record
+- `"trim_horizon"`: start at the oldest available record
+- `<timestamp>`: start at the given timestamp
+
+Defaults to `"latest"`.
+
+### `count = int (optional)`
+
+Exit successfully after emitting `count` records.
+
+The value must be greater than zero.
+
+### `exit = bool (optional)`
+
+Exit successfully after the operator is caught up on all shards.
+
+Without this option, the operator waits for new records after consuming the
+currently available records.
+
+Defaults to `false`.
+
+### `records_per_call = int (optional)`
+
+The maximum number of records to fetch in one `GetRecords` request.
+
+The value must be between `1` and `10000`.
+
+Defaults to `1000`.
+
+### `poll_idle = duration (optional)`
+
+How long to wait after a `GetRecords` request returns no records.
+
+The value must be non-negative.
+
+Defaults to `1s`.
+
+### `aws_region = string (optional)`
+
+The AWS region for reading from the stream.
+
+If omitted, the operator uses the region from `aws_iam` when present. Otherwise,
+it uses the default AWS SDK region resolution.
+
+### `endpoint = string (optional)`
+
+A custom Kinesis endpoint URL.
+
+If omitted, the operator uses `AWS_ENDPOINT_URL_KINESIS` when set, then
+`AWS_ENDPOINT_URL`, then the default AWS SDK endpoint for the region.
+
+<AWSIAMOptions />
+
+## Examples
+
+### Read from the latest position
+
+```tql
+from_amazon_kinesis "security-events"
+```
+
+### Read from the oldest available record
+
+```tql
+from_amazon_kinesis "security-events", start="trim_horizon"
+```
+
+### Parse JSON payloads
+
+```tql
+from_amazon_kinesis "security-events", start="trim_horizon"
+this = string(message).parse_json()
+```
+
+### Read a bounded number of records
+
+```tql
+from_amazon_kinesis "security-events",
+  start="trim_horizon",
+  count=100,
+  exit=true
+```
+
+### Use explicit credentials
+
+```tql
+from_amazon_kinesis "security-events", aws_iam={
+  region: "us-east-1",
+  access_key_id: secret("aws-key"),
+  secret_access_key: secret("aws-secret")
+}
+```
+
+### Use a LocalStack endpoint
+
+```tql
+from_amazon_kinesis "security-events",
+  aws_region="us-east-1",
+  endpoint="http://127.0.0.1:4566"
+```
+
+## See Also
+
+- <Op>to_amazon_kinesis</Op>
+- <Guide>collecting/read-from-message-brokers</Guide>
+- <Integration>amazon/kinesis</Integration>

--- a/src/content/docs/reference/operators/from_amazon_kinesis.mdx
+++ b/src/content/docs/reference/operators/from_amazon_kinesis.mdx
@@ -19,7 +19,10 @@ from_amazon_kinesis stream:string, [start=string|time, count=int, exit=bool,
 ## Description
 
 The `from_amazon_kinesis` operator reads records from the existing shards of a
-Kinesis data stream and emits one event per Kinesis record.
+Kinesis data stream and emits one event per Kinesis record. All shards are
+read concurrently, so throughput scales with the shard count. Record order is
+preserved within a shard but interleaved across shards, matching the ordering
+guarantees of Kinesis itself.
 
 The emitted events use the `tenzir.amazon_kinesis` schema with these fields:
 

--- a/src/content/docs/reference/operators/to_amazon_kinesis.mdx
+++ b/src/content/docs/reference/operators/to_amazon_kinesis.mdx
@@ -28,13 +28,18 @@ the operator skips that event and emits a warning.
 
 If you omit `partition_key`, the operator generates a random UUID for each
 record. A partition key expression must produce non-empty strings up to 256
-bytes. Kinesis record payloads plus their partition key must be at most 10 MiB.
-Events that exceed these limits are skipped with a warning.
+characters. Kinesis record payloads plus their partition key must fit the
+stream's configured maximum record size, which defaults to 1 MiB and can be
+raised to 10 MiB. The operator discovers the limit at startup via
+`kinesis:DescribeStreamSummary`; without that permission it falls back to the
+10 MiB API maximum and lets the service enforce the effective limit. Events
+that exceed these limits are skipped with a warning.
 
 The operator retries failed `PutRecords` entries with exponential backoff before
 emitting an error.
 
-The operator requires the `kinesis:PutRecords` AWS permission.
+The operator requires the `kinesis:PutRecords` AWS permission and uses
+`kinesis:DescribeStreamSummary` when available.
 
 ### `stream: string`
 

--- a/src/content/docs/reference/operators/to_amazon_kinesis.mdx
+++ b/src/content/docs/reference/operators/to_amazon_kinesis.mdx
@@ -1,0 +1,155 @@
+---
+title: to_amazon_kinesis
+category: Outputs/Events
+example: 'to_amazon_kinesis "security-events"'
+---
+
+import AWSIAMOptions from '@partials/operators/AWSIAMOptions.mdx';
+
+Sends records to an [Amazon Kinesis Data Streams][kinesis] stream.
+
+[kinesis]: https://aws.amazon.com/kinesis/data-streams/
+
+```tql
+to_amazon_kinesis stream:string, [message=blob|string, partition_key=string,
+                   batch_size=int, batch_timeout=duration, parallel=int,
+                   aws_region=string, aws_iam=record, endpoint=string]
+```
+
+## Description
+
+The `to_amazon_kinesis` operator sends records to a Kinesis data stream with
+`PutRecords`.
+
+By default, `to_amazon_kinesis` serializes each input event as NDJSON with
+`this.print_ndjson()`. Use the `message` option to send a specific string or
+blob expression instead. If the expression evaluates to `null` or another type,
+the operator skips that event and emits a warning.
+
+If you omit `partition_key`, the operator generates a random UUID for each
+record. A partition key expression must produce non-empty strings up to 256
+bytes. Kinesis record payloads must be at most 1 MiB. Events that exceed these
+limits are skipped with a warning.
+
+The operator retries failed `PutRecords` entries with exponential backoff before
+emitting an error.
+
+The operator requires the `kinesis:PutRecords` AWS permission.
+
+### `stream: string`
+
+The name of the Kinesis data stream to send records to.
+
+### `message = blob | string (optional)`
+
+The expression that produces the Kinesis record payload for each event.
+
+Defaults to `this.print_ndjson()`.
+
+### `partition_key = string (optional)`
+
+The expression that produces the Kinesis partition key for each event.
+
+If omitted, the operator generates a random UUID per event.
+
+### `batch_size = int (optional)`
+
+The maximum number of records per `PutRecords` request.
+
+The value must be between `1` and `500`.
+
+Defaults to `500`.
+
+### `batch_timeout = duration (optional)`
+
+How long to wait before flushing a non-empty batch.
+
+The value must be positive.
+
+Defaults to `1s`.
+
+### `parallel = int (optional)`
+
+The number of parallel write slots.
+
+The value must be greater than zero.
+
+Defaults to `1`.
+
+### `aws_region = string (optional)`
+
+The AWS region for writing to the stream.
+
+If omitted, the operator uses the region from `aws_iam` when present. Otherwise,
+it uses the default AWS SDK region resolution.
+
+### `endpoint = string (optional)`
+
+A custom Kinesis endpoint URL.
+
+If omitted, the operator uses `AWS_ENDPOINT_URL_KINESIS` when set, then
+`AWS_ENDPOINT_URL`, then the default AWS SDK endpoint for the region.
+
+<AWSIAMOptions />
+
+## Examples
+
+### Send NDJSON events
+
+```tql
+subscribe "alerts"
+to_amazon_kinesis "security-events"
+```
+
+### Send a custom payload
+
+```tql
+from {payload: "security event detected", tenant: "acme"}
+to_amazon_kinesis "security-events",
+  message=payload,
+  partition_key=tenant
+```
+
+### Send JSON strings with an explicit partition key
+
+```tql
+subscribe "alerts"
+to_amazon_kinesis "security-events",
+  message=this.print_json(),
+  partition_key=string(src_ip)
+```
+
+### Configure batching
+
+```tql
+subscribe "alerts"
+to_amazon_kinesis "security-events",
+  batch_size=100,
+  batch_timeout=500ms
+```
+
+### Use explicit credentials
+
+```tql
+subscribe "alerts"
+to_amazon_kinesis "security-events", aws_iam={
+  region: "us-east-1",
+  access_key_id: secret("aws-key"),
+  secret_access_key: secret("aws-secret")
+}
+```
+
+### Use a LocalStack endpoint
+
+```tql
+from {alert: "test"}
+to_amazon_kinesis "security-events",
+  aws_region="us-east-1",
+  endpoint="http://127.0.0.1:4566"
+```
+
+## See Also
+
+- <Op>from_amazon_kinesis</Op>
+- <Guide>routing/send-to-destinations</Guide>
+- <Integration>amazon/kinesis</Integration>

--- a/src/content/docs/reference/operators/to_amazon_kinesis.mdx
+++ b/src/content/docs/reference/operators/to_amazon_kinesis.mdx
@@ -75,7 +75,12 @@ Defaults to `1s`.
 
 ### `parallel = int (optional)`
 
-The number of parallel write slots.
+The maximum number of concurrent `PutRecords` requests.
+
+Values greater than one overlap request round trips and multiply write
+throughput accordingly, but concurrent requests can complete out of order. If
+you use a fixed `partition_key` and depend on strict ordering within a shard,
+keep the default.
 
 The value must be greater than zero.
 

--- a/src/content/docs/reference/operators/to_amazon_kinesis.mdx
+++ b/src/content/docs/reference/operators/to_amazon_kinesis.mdx
@@ -28,8 +28,8 @@ the operator skips that event and emits a warning.
 
 If you omit `partition_key`, the operator generates a random UUID for each
 record. A partition key expression must produce non-empty strings up to 256
-bytes. Kinesis record payloads must be at most 1 MiB. Events that exceed these
-limits are skipped with a warning.
+bytes. Kinesis record payloads plus their partition key must be at most 10 MiB.
+Events that exceed these limits are skipped with a warning.
 
 The operator retries failed `PutRecords` entries with exponential backoff before
 emitting an error.

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -335,6 +335,7 @@ export const integrations = [
         collapsed: true,
         items: [
           "integrations/amazon",
+          "integrations/amazon/kinesis",
           "integrations/amazon/msk",
           "integrations/amazon/s3",
           "integrations/amazon/security-lake",

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -342,6 +342,7 @@ export const integrations = [
         items: [
           "integrations/amazon",
           "integrations/amazon/cloudwatch",
+          "integrations/amazon/kinesis",
           "integrations/amazon/msk",
           "integrations/amazon/s3",
           "integrations/amazon/security-lake",


### PR DESCRIPTION
## 🔍 Problem
The docs do not cover the Amazon Kinesis operators added in tenzir/tenzir#6188.

## 🛠️ Solution
- Add reference pages for `from_amazon_kinesis` and `to_amazon_kinesis`.
- Add an Amazon Kinesis integration page with read, write, IAM, parsing, and LocalStack endpoint examples.
- Link Kinesis from the Amazon integrations sidebar.

## 💬 Review
Focus on whether the Kinesis restart semantics, payload handling, and AWS endpoint precedence are clear enough for a first operator version.

<sub>
⚙️ Code PR: tenzir/tenzir#6188
</sub>
