### PR TITLE
Rename Graph integration page

### DIFF
--- a/src/content/docs/integrations/microsoft/graph.mdx
+++ b/src/content/docs/integrations/microsoft/graph.mdx
@@ -1,5 +1,5 @@
 ---
-title: Microsoft Graph
+title: Graph
 ---
 
 Microsoft Graph is the unified API for Microsoft 365, Microsoft Entra ID, and


### PR DESCRIPTION
## 🔍 Problem

- The Microsoft integration sidebar already provides the vendor context.
- The Graph page title repeated the vendor prefix unlike the surrounding pages.

## 🛠️ Solution

- Rename the integration page title to `Graph`.
- Keep product references in prose as `Microsoft Graph` where they describe the API.

## 💬 Review

- Confirm the navigation label now matches the integration naming pattern.