### PR TITLE
Fix changelog sidebar generation

### DIFF
--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -12,6 +12,7 @@ import remarkHtml from "remark-html";
 // Load shared project config (icons defined once, used by both sync and topics.ts)
 const require = createRequire(import.meta.url);
 const changelogProjects = require("../src/changelog-projects.json");
+const CHANGELOG_EXPORT_MAX_BUFFER = 64 * 1024 * 1024;
 
 /**
  * Sync changelog from tenzir/news repository.
@@ -339,6 +340,7 @@ async function readAllReleases(newsRepoPath, changelogPath, projectName) {
       {
         cwd: fullChangelogPath,
         encoding: "utf-8",
+        maxBuffer: CHANGELOG_EXPORT_MAX_BUFFER,
         stdio: ["pipe", "pipe", "pipe"],
       },
     ).trim();
@@ -398,10 +400,7 @@ async function readAllReleases(newsRepoPath, changelogPath, projectName) {
       }
     }
   } catch (err) {
-    // Fallback: return empty if bulk export fails
-    console.warn(
-      `  Warning: Bulk export failed for ${changelogPath}: ${err.message}`,
-    );
+    throw new Error(`Bulk export failed for ${changelogPath}: ${err.message}`);
   }
 
   // Sort releases by version (newest first, unreleased at top due to Infinity)

--- a/src/plugins/starlight-site-navigation/index.ts
+++ b/src/plugins/starlight-site-navigation/index.ts
@@ -276,8 +276,8 @@ function resolveSiteNavigation(config: SiteNavigationSectionConfig[]) {
     const normalizedPaths = (section.paths ?? []).map(normalizePathPattern);
     const childIds: string[] = [];
 
-    const currentSidebarIndex = section.sidebar?.length ? sidebarIndex++ : null;
-    if (section.sidebar?.length) {
+    const currentSidebarIndex = section.sidebar ? sidebarIndex++ : null;
+    if (section.sidebar) {
       sidebar.push({
         label: id,
         items: section.sidebar,


### PR DESCRIPTION
## 🔍 Problem

- The Tenzir Node changelog export now exceeds Node's default 1 MiB child-process buffer.
- The generator swallowed that `ENOBUFS` failure and published the project with zero releases, which left the changelog route showing the wrong sidebar.

## 🛠️ Solution

- Give the changelog JSON export enough buffer headroom for the full Tenzir Node release history.
- Fail changelog generation on export errors instead of silently publishing empty project data.
- Keep generated sidebar sections addressable even if a topic has no items, so an empty topic cannot leak the global docs sidebar.

## 💬 Review

- Focus on whether failing generation is preferable to publishing partial changelog data.
- Verified with `bun run generate:changelog`, targeted `bun run lint:files`, and a local dev request to `/changelog/tenzir/`.
