### PR TITLE
Document Elasticsearch operator aliases

### DIFF
--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -327,6 +327,10 @@ operators:
     description: 'Shows a snapshot of open sockets.'
     example: 'sockets'
     path: 'reference/operators/sockets'
+  - name: 'accept_elasticsearch'
+    description: 'Accepts incoming Elasticsearch-compatible Bulk API requests and forwards them as events.'
+    example: 'accept_elasticsearch "0.0.0.0:9200"'
+    path: 'reference/operators/accept_elasticsearch'
   - name: 'accept_http'
     description: 'Accepts incoming HTTP requests and forwards them as events.'
     example: 'accept_http "0.0.0.0:8080" { read_json }'
@@ -655,6 +659,10 @@ operators:
     description: 'Sends events to a ClickHouse table.'
     example: 'to_clickhouse table="my_table"'
     path: 'reference/operators/to_clickhouse'
+  - name: 'to_elasticsearch'
+    description: 'Sends events to an Elasticsearch-compatible Bulk API.'
+    example: 'to_elasticsearch "localhost:9200", …'
+    path: 'reference/operators/to_elasticsearch'
   - name: 'to_file'
     description: 'Writes events to one or multiple files on a filesystem.'
     example: 'to_file "/tmp/out.json" { write_ndjson }'
@@ -1374,6 +1382,14 @@ sockets
 
 <CardGrid>
 
+<ReferenceCard title="accept_elasticsearch" description="Accepts incoming Elasticsearch-compatible Bulk API requests and forwards them as events." href="/reference/operators/accept_elasticsearch">
+
+```tql
+accept_elasticsearch "0.0.0.0:9200"
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="accept_http" description="Accepts incoming HTTP requests and forwards them as events." href="/reference/operators/accept_http">
 
 ```tql
@@ -1890,6 +1906,14 @@ to_azure_log_analytics tenant_id="...", workspace_id="..."
 
 ```tql
 to_clickhouse table="my_table"
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="to_elasticsearch" description="Sends events to an Elasticsearch-compatible Bulk API." href="/reference/operators/to_elasticsearch">
+
+```tql
+to_elasticsearch "localhost:9200", …
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators/accept_elasticsearch.mdx
+++ b/src/content/docs/reference/operators/accept_elasticsearch.mdx
@@ -1,0 +1,17 @@
+---
+title: accept_elasticsearch
+category: Inputs/Events
+example: 'accept_elasticsearch "0.0.0.0:9200"'
+---
+
+Accepts incoming Elasticsearch-compatible Bulk API requests and forwards them as
+events.
+
+`accept_elasticsearch` is an alias for <Op>accept_opensearch</Op>. It supports
+the same options and behavior.
+
+## See Also
+
+- <Op>accept_opensearch</Op>
+- <Integration>elasticsearch</Integration>
+- <Integration>opensearch</Integration>

--- a/src/content/docs/reference/operators/accept_opensearch.mdx
+++ b/src/content/docs/reference/operators/accept_opensearch.mdx
@@ -17,6 +17,8 @@ The `accept_opensearch` operator starts an OpenSearch-compatible HTTP server and
 accepts bulk ingestion requests on `/_bulk` and `/{index}/_bulk`. Elasticsearch
 clients can also use this endpoint.
 
+You can also use `accept_elasticsearch` as an alias.
+
 For each bulk request, the operator buffers the request body in memory, up to
 `max_request_size`, optionally decompresses it based on the HTTP
 `Content-Encoding` header, parses the NDJSON payload, and emits the resulting

--- a/src/content/docs/reference/operators/to_elasticsearch.mdx
+++ b/src/content/docs/reference/operators/to_elasticsearch.mdx
@@ -1,0 +1,16 @@
+---
+title: to_elasticsearch
+category: Outputs/Events
+example: 'to_elasticsearch "localhost:9200", …'
+---
+
+Sends events to an Elasticsearch-compatible Bulk API.
+
+`to_elasticsearch` is an alias for <Op>to_opensearch</Op>. It supports the same
+options and behavior.
+
+## See Also
+
+- <Op>to_opensearch</Op>
+- <Integration>elasticsearch</Integration>
+- <Integration>opensearch</Integration>

--- a/src/content/docs/reference/operators/to_opensearch.mdx
+++ b/src/content/docs/reference/operators/to_opensearch.mdx
@@ -17,6 +17,8 @@ to_opensearch url:string, action=string, [index=string, id=string, doc=record,
 The `to_opensearch` operator sends events to an [OpenSearch-compatible Bulk
 API][api], including Elasticsearch.
 
+You can also use `to_elasticsearch` as an alias.
+
 [api]: https://opensearch.org/docs/latest/api-reference/document-apis/bulk/
 
 The operator appends `/_bulk` to the URL if the path doesn't already end with

--- a/src/partials/integrations/OpenSearch.mdx
+++ b/src/partials/integrations/OpenSearch.mdx
@@ -13,7 +13,7 @@ single API call. You can control batching behavior with the `max_content_length`
 and `buffer_timeout` options.
 
 Use `to_opensearch` for both OpenSearch and Elasticsearch-compatible Bulk API
-endpoints. There is no separate `to_elasticsearch` operator.
+endpoints. You can also use `to_elasticsearch` as an alias.
 
 For more details, see the documentation for the
 [`to_opensearch`](/reference/operators/to_opensearch) operator.
@@ -72,7 +72,8 @@ This pipeline accepts data on port 9200 and publishes all received events on
 the <code>{props.Name.toLowerCase()}</code> topic for further processing by
 other pipelines.
 
-Use `accept_opensearch` for new pipelines that receive bulk ingestion data.
+Use `accept_opensearch` for new pipelines that receive bulk ingestion data. You
+can also use `accept_elasticsearch` as an alias.
 
 Setting `keep_actions=true` causes action objects to remain in the stream, like
 this:


### PR DESCRIPTION
## 🔍 Problem

- The docs still said there was no `to_elasticsearch` operator.
- The restored Elasticsearch alias names had no reference pages.

## 🛠️ Solution

- Add concise reference pages for `accept_elasticsearch` and `to_elasticsearch`.
- List the aliases in the operator reference index.
- Update the OpenSearch and Elasticsearch integration wording to mention both aliases.

## 💬 Review

- Check whether the alias pages should stay concise or duplicate the full OpenSearch option reference.

<sub>
⚙️ Code PR: tenzir/tenzir#6192
</sub>