### PR TITLE
Document from_http pagination request records

### DIFF
--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -259,6 +259,54 @@ from_http f"{$base}?category=security&page=1",
 }
 ```
 
+For APIs that put pagination state in the request body, return a request record
+from the lambda. Missing fields inherit from the current request. This
+OpenSearch example keeps using the same `POST` request and replaces only the
+body with a `search_after` cursor from the previous page:
+
+```tql
+from_http "https://opensearch.example.com/logs/_search",
+  method="post",
+  body={
+    size: 500,
+    sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
+    query: {match_all: {}},
+  },
+  headers={"Authorization": "Bearer " + secret("OPENSEARCH_TOKEN")},
+  paginate=(x => {
+    body: {
+      size: 500,
+      sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
+      query: {match_all: {}},
+      search_after: x.hits.hits[-1].sort,
+    },
+  } if x.hits.hits != []) {
+  read_json
+}
+```
+
+Scroll-style APIs can change the URL and body for the next request while
+keeping the method and headers:
+
+```tql
+let $search = "https://opensearch.example.com/logs/_search?scroll=1m"
+let $scroll = "https://opensearch.example.com/_search/scroll"
+
+from_http $search,
+  method="post",
+  body={size: 500, query: {match_all: {}}},
+  headers={"Authorization": "Bearer " + secret("OPENSEARCH_TOKEN")},
+  paginate=(x => {
+    url: $scroll,
+    body: {
+      scroll: "1m",
+      scroll_id: x._scroll_id,
+    },
+  } if x.hits.hits != []) {
+  read_json
+}
+```
+
 ### Rate limiting
 
 Control request frequency by configuring `paginate_delay` to add delays between

--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -260,9 +260,10 @@ from_http f"{$base}?category=security&page=1",
 ```
 
 For APIs that put pagination state in the request body, return a request record
-from the lambda. Missing fields inherit from the current request. This is useful
-for OpenSearch-compatible APIs, including OpenSearch, Elasticsearch, and the
-Wazuh indexer, that use a `search_after` cursor in the request body.
+from the lambda. Each request record patches the request that produced the
+current page. This is useful for OpenSearch-compatible APIs, including
+OpenSearch, Elasticsearch, and the Wazuh indexer, that use a `search_after`
+cursor in the request body.
 
 Keep the `from_http` subpipeline focused on parsing the response envelope. Move
 operators such as `unroll` after `from_http`, because the pagination lambda

--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -260,22 +260,29 @@ from_http f"{$base}?category=security&page=1",
 ```
 
 For APIs that put pagination state in the request body, return a request record
-from the lambda. Missing fields inherit from the current request. This
-OpenSearch example keeps using the same `POST` request and replaces only the
-body with a `search_after` cursor from the previous page:
+from the lambda. Missing fields inherit from the current request. This is useful
+for OpenSearch and Elasticsearch APIs that use a `search_after` cursor in the
+request body.
+
+Keep the `from_http` subpipeline focused on parsing the response envelope. Move
+operators such as `unroll` after `from_http`, because the pagination lambda
+receives the parsed page envelope.
 
 ```tql
-from_http "https://opensearch.example.com/logs/_search",
-  method="post",
+let $headers = {
+  "Authorization": f"Bearer {secret("OPENSEARCH_TOKEN")}",
+}
+
+from_http "https://opensearch.example.com/logs-*/_search",
+  headers=$headers,
   body={
-    size: 500,
+    size: 1000,
     sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
     query: {match_all: {}},
   },
-  headers={"Authorization": "Bearer " + secret("OPENSEARCH_TOKEN")},
   paginate=(x => {
     body: {
-      size: 500,
+      size: 1000,
       sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
       query: {match_all: {}},
       search_after: x.hits.hits[-1].sort,
@@ -283,19 +290,27 @@ from_http "https://opensearch.example.com/logs/_search",
   } if x.hits.hits != []) {
   read_json
 }
+unroll hits.hits
+this = hits.hits._source
 ```
 
-Scroll-style APIs can change the URL and body for the next request while
-keeping the method and headers:
+The first request uses `POST` because it has a body. Follow-up requests inherit
+that method and the configured headers. The returned request record replaces
+only the body.
+
+Scroll-style APIs can change the URL and body for the next request while they
+keep the method and headers:
 
 ```tql
 let $search = "https://opensearch.example.com/logs/_search?scroll=1m"
 let $scroll = "https://opensearch.example.com/_search/scroll"
+let $headers = {
+  "Authorization": f"Bearer {secret("OPENSEARCH_TOKEN")}",
+}
 
 from_http $search,
-  method="post",
-  body={size: 500, query: {match_all: {}}},
-  headers={"Authorization": "Bearer " + secret("OPENSEARCH_TOKEN")},
+  headers=$headers,
+  body={size: 1000, query: {match_all: {}}},
   paginate=(x => {
     url: $scroll,
     body: {
@@ -305,7 +320,12 @@ from_http $search,
   } if x.hits.hits != []) {
   read_json
 }
+unroll hits.hits
+this = hits.hits._source
 ```
+
+See the [OpenSearch integration](/integrations/opensearch) for more
+search-backend examples that use the same pagination pattern.
 
 ### Rate limiting
 

--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -261,8 +261,8 @@ from_http f"{$base}?category=security&page=1",
 
 For APIs that put pagination state in the request body, return a request record
 from the lambda. Missing fields inherit from the current request. This is useful
-for OpenSearch and Elasticsearch APIs that use a `search_after` cursor in the
-request body.
+for OpenSearch-compatible APIs, including OpenSearch, Elasticsearch, and the
+Wazuh indexer, that use a `search_after` cursor in the request body.
 
 Keep the `from_http` subpipeline focused on parsing the response envelope. Move
 operators such as `unroll` after `from_http`, because the pagination lambda
@@ -324,8 +324,9 @@ unroll hits.hits
 this = hits.hits._source
 ```
 
-See the [OpenSearch integration](/integrations/opensearch) for more
-search-backend examples that use the same pagination pattern.
+See the [OpenSearch integration](/integrations/opensearch) and the
+[Wazuh integration](/integrations/wazuh) for more search-backend examples that
+use the same pagination pattern.
 
 ### Rate limiting
 

--- a/src/content/docs/integrations/opensearch.mdx
+++ b/src/content/docs/integrations/opensearch.mdx
@@ -20,4 +20,5 @@ import SearchBackend from "@partials/integrations/SearchBackend.mdx";
 
 ## See Also
 
+- <Guide>collecting/fetch-via-http-and-apis</Guide>
 - <Integration>elasticsearch</Integration>

--- a/src/content/docs/integrations/wazuh.mdx
+++ b/src/content/docs/integrations/wazuh.mdx
@@ -100,6 +100,43 @@ Replace `wazuh-indexer.example.com` with the Wazuh indexer host and store the
 indexer credentials as Tenzir secrets. See the Wazuh documentation for
 [index names][wazuh-indices] and [indexer API authentication][wazuh-indexer-api].
 
+For larger exports, use the same request-record pagination pattern as
+OpenSearch. The Wazuh indexer response includes the `sort` values for each hit
+when you request a stable sort. Return a request record from `paginate` to add
+`search_after` for the next page:
+
+```tql
+let $auth = f"{secret("WAZUH_INDEXER_USER")}:{secret("WAZUH_INDEXER_PASSWORD")}"
+let $headers = {
+  "Authorization": f"Basic {$auth.encode_base64()}",
+  "Content-Type": "application/json",
+}
+
+from_http "https://wazuh-indexer.example.com:9200/wazuh-alerts-*/_search",
+  headers=$headers,
+  body={
+    size: 1000,
+    query: {match_all: {}},
+    sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
+  },
+  paginate=(x => {
+    body: {
+      size: 1000,
+      query: {match_all: {}},
+      sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
+      search_after: x.hits.hits[-1].sort,
+    },
+  } if x.hits.hits != []) {
+  read_json
+}
+unroll hits.hits
+this = hits.hits._source
+```
+
+Keep `unroll` after <Op>from_http</Op> so the pagination lambda can inspect the
+whole search response. Follow-up requests inherit the `POST` method and
+headers from the first request and replace only the request body.
+
 [wazuh-indices]: https://documentation.wazuh.com/current/user-manual/wazuh-indexer/wazuh-indexer-indices.html
 [wazuh-indexer-api]: https://documentation.wazuh.com/current/user-manual/indexer-api/getting-started.html
 
@@ -127,5 +164,6 @@ events as incoming log data.
 - <Op>to_opensearch</Op>
 - <Op>to_tcp</Op>
 - <Op>write_syslog</Op>
+- <Guide>collecting/fetch-via-http-and-apis</Guide>
 - <Integration>opensearch</Integration>
 - <Integration>syslog</Integration>

--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -12,7 +12,7 @@ Sends an HTTP/1.1 request and returns the response as events.
 
 ```tql
 from_http url:string, [method=string, body=record|string|blob, encode=string,
-          headers=record, error_field=field, paginate=string,
+          headers=record, error_field=field, paginate=string|lambda,
           paginate_delay=duration, connection_timeout=duration,
           max_retry_count=int, retry_delay=duration, tls=record]
           [{ … }]
@@ -72,14 +72,41 @@ Specifies how to encode `record` bodies. Supported values:
 
 Defaults to `json`.
 
-### `paginate = record -> string | string (optional)`
+### `paginate = record -> string | record | null | string (optional)`
 
 Controls automatic pagination of HTTP responses.
 
 **Lambda mode**: A lambda expression to evaluate against the parsed result of a
-request. If the expression evaluates successfully and returns a non-null
+request. The lambda receives one parsed page envelope. If the parser emits
+multiple events for one page, Tenzir emits a warning and stops pagination.
+
+If the lambda returns `null`, pagination stops. If it returns a non-null
 string, Tenzir uses that string as the URL for a new `GET` request with the
 same headers.
+
+If the lambda returns a record, Tenzir patches the next request. The record
+supports these fields:
+
+- `url`: The next URL as a `string`. Relative URLs are resolved against the
+  current request URL.
+- `method`: The next HTTP method as a `string`.
+- `headers`: A record of request headers. Header names are matched
+  case-insensitively. String values set or replace headers, and `null` values
+  delete headers.
+- `body`: The next request body as a `blob`, `record`, or `string`. Set this
+  field to `null` to clear the body.
+
+Missing record fields inherit from the current effective request. Setting
+`body` does not change the method. Set `method` explicitly if the next request
+must use a different method. If `body` is a record, the `encode` option also
+applies to paginated request bodies.
+
+Unknown fields, empty request records, and invalid field values emit a
+diagnostic and stop pagination after the current page.
+
+This request-record pagination behavior applies to <Op>from_http</Op> only. It
+does not change <Op>http</Op>, <Op>to_http</Op>, <Op>accept_http</Op>, or
+<Op>serve_http</Op>.
 
 **Link mode**: The string `"link"` to automatically follow pagination links in
 the HTTP `Link` response header as defined in [RFC
@@ -245,6 +272,56 @@ operator emits each object from `value`, follows a top-level string
 `@odata.nextLink` as an opaque URL, and stops when the field is absent or not a
 string. Follow-up requests use `GET` with the same headers as the initial
 request.
+
+### Paginate with request records
+
+Use a request record when an API expects pagination state in the request body
+instead of the URL. This OpenSearch example uses `search_after` from the last
+hit in the previous page. The next request inherits the URL, method, and
+headers, but replaces the body:
+
+```tql
+from_http "https://opensearch.example.com/logs/_search",
+  method="post",
+  body={
+    size: 500,
+    sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
+    query: {match_all: {}},
+  },
+  headers={"Authorization": "Bearer " + secret("OPENSEARCH_TOKEN")},
+  paginate=(x => {
+    body: {
+      size: 500,
+      sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
+      query: {match_all: {}},
+      search_after: x.hits.hits[-1].sort,
+    },
+  } if x.hits.hits != []) {
+  read_json
+}
+```
+
+For scroll-style APIs, return both a new URL and a new body. The next request
+keeps the configured method and headers:
+
+```tql
+let $search = "https://opensearch.example.com/logs/_search?scroll=1m"
+let $scroll = "https://opensearch.example.com/_search/scroll"
+
+from_http $search,
+  method="post",
+  body={size: 500, query: {match_all: {}}},
+  headers={"Authorization": "Bearer " + secret("OPENSEARCH_TOKEN")},
+  paginate=(x => {
+    url: $scroll,
+    body: {
+      scroll: "1m",
+      scroll_id: x._scroll_id,
+    },
+  } if x.hits.hits != []) {
+  read_json
+}
+```
 
 ### Retry Failed Requests
 

--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -281,17 +281,20 @@ hit in the previous page. The next request inherits the URL, method, and
 headers, but replaces the body:
 
 ```tql
-from_http "https://opensearch.example.com/logs/_search",
-  method="post",
+let $headers = {
+  "Authorization": f"Bearer {secret("OPENSEARCH_TOKEN")}",
+}
+
+from_http "https://opensearch.example.com/logs-*/_search",
+  headers=$headers,
   body={
-    size: 500,
+    size: 1000,
     sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
     query: {match_all: {}},
   },
-  headers={"Authorization": "Bearer " + secret("OPENSEARCH_TOKEN")},
   paginate=(x => {
     body: {
-      size: 500,
+      size: 1000,
       sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
       query: {match_all: {}},
       search_after: x.hits.hits[-1].sort,
@@ -299,6 +302,8 @@ from_http "https://opensearch.example.com/logs/_search",
   } if x.hits.hits != []) {
   read_json
 }
+unroll hits.hits
+this = hits.hits._source
 ```
 
 For scroll-style APIs, return both a new URL and a new body. The next request
@@ -307,11 +312,13 @@ keeps the configured method and headers:
 ```tql
 let $search = "https://opensearch.example.com/logs/_search?scroll=1m"
 let $scroll = "https://opensearch.example.com/_search/scroll"
+let $headers = {
+  "Authorization": f"Bearer {secret("OPENSEARCH_TOKEN")}",
+}
 
 from_http $search,
-  method="post",
-  body={size: 500, query: {match_all: {}}},
-  headers={"Authorization": "Bearer " + secret("OPENSEARCH_TOKEN")},
+  headers=$headers,
+  body={size: 1000, query: {match_all: {}}},
   paginate=(x => {
     url: $scroll,
     body: {
@@ -321,7 +328,13 @@ from_http $search,
   } if x.hits.hits != []) {
   read_json
 }
+unroll hits.hits
+this = hits.hits._source
 ```
+
+Keep operators such as <Op>unroll</Op> after <Op>from_http</Op> for these
+pagination styles. The pagination lambda receives the parsed page envelope, so
+the parsing subpipeline must emit one event for the whole response.
 
 ### Retry Failed Requests
 

--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -96,13 +96,10 @@ supports these fields:
 - `body`: The next request body as a `blob`, `record`, or `string`. Set this
   field to `null` to clear the body.
 
-Missing record fields inherit from the current effective request. Setting
-`body` does not change the method. Set `method` explicitly if the next request
-must use a different method. If `body` is a record, the `encode` option also
-applies to paginated request bodies.
-
-Unknown fields, empty request records, and invalid field values emit a
-diagnostic and stop pagination after the current page.
+Each request record is a patch against the request that produced the current
+page. Setting `body` does not change the method. Set `method` explicitly if the
+next request must use a different method. If `body` is a record, the `encode`
+option also applies to paginated request bodies.
 
 This request-record pagination behavior applies to <Op>from_http</Op> only. It
 does not change <Op>http</Op>, <Op>to_http</Op>, <Op>accept_http</Op>, or

--- a/src/partials/integrations/SearchBackend.mdx
+++ b/src/partials/integrations/SearchBackend.mdx
@@ -1,3 +1,5 @@
+import { Code } from "@astrojs/starlight/components";
+
 <a href={props.url}>{props.Name}</a> is a search and observability suite for
 unstructured data. Tenzir can send events to {props.Name} and emulate a
 {props.Name}-compatible Bulk API endpoint.
@@ -44,56 +46,82 @@ this = hits.hits._source
 Add an `Authorization` header if your {props.Name} cluster requires
 authentication.
 
+### Export large result sets with `search_after`
+
+For larger exports, prefer `search_after` with a stable sort. Return a request
+record from `paginate` to replace the request body for each next page. The next
+request keeps the same URL, method, and headers unless the request record
+changes them.
+
+Keep only the response parser inside the <code>from_http</code> subpipeline.
+Operators such as <code>unroll</code> belong after <code>from_http</code>, so
+the pagination lambda receives the whole search response envelope.
+
+export const searchAfter = `
+from_http "https://localhost:9200/main/_search",
+  body={
+    size: 1000,
+    query: {match_all: {}},
+    sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
+  },
+  paginate=(x => {
+    body: {
+      size: 1000,
+      query: {match_all: {}},
+      sort: [{"@timestamp": "asc"}, {"_id": "asc"}],
+      search_after: x.hits.hits[-1].sort,
+    },
+  } if x.hits.hits != []) {
+  read_json
+}
+unroll hits.hits
+this = hits.hits._source
+`;
+
+<Code code={searchAfter} lang="tql" />
+
+Add an `Authorization` header if your {props.Name} cluster requires
+authentication.
+
 ### Export large result sets with scroll
 
-For larger exports, use the <a href={props.scrollApiUrl}>Scroll API</a>. Start
-with a search request that includes a `scroll` query parameter and a batch size:
+Use the <a href={props.scrollApiUrl}>Scroll API</a> when you need a server-side
+search context for a long-running export. Start with a search request that
+includes a `scroll` query parameter, then return a request record that switches
+the next URL to `/_search/scroll` and sends the latest `_scroll_id` in the body:
 
-export const startScroll = `
-from_http "https://localhost:9200/main/_search?scroll=10m",
+export const scrollPages = `
+let $search = "https://localhost:9200/main/_search?scroll=10m"
+let $scroll = "https://localhost:9200/_search/scroll"
+
+from_http $search,
   body={
     size: 10000,
     query: {match_all: {}},
-  } {
+  },
+  paginate=(x => {
+    url: $scroll,
+    body: {
+      scroll: "10m",
+      scroll_id: x._scroll_id,
+    },
+  } if x.hits.hits != []) {
   read_json
 }
 unroll hits.hits
-hits.hits._source._scroll_id = this._scroll_id
 this = hits.hits._source
 `;
 
-<Code code={startScroll} lang="tql" />
+<Code code={scrollPages} lang="tql" />
 
-The response also contains an `_scroll_id`. Use that value with
-`/_search/scroll` to fetch the next batch:
-
-export const continueScroll = `
-let $scroll_id = "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAUW..."
-
-from_http "https://localhost:9200/_search/scroll",
-  body={
-    scroll: "10m",
-    scroll_id: $scroll_id,
-  } {
-  read_json
-}
-unroll hits.hits
-hits.hits._source._scroll_id = this._scroll_id
-this = hits.hits._source
-`;
-
-<Code code={continueScroll} lang="tql" />
-
-Each emitted event includes the response `_scroll_id`. Repeat the scroll request
-with the latest `_scroll_id` until the response contains no hits. Close the
-scroll context when the export is complete, because {props.Name} keeps the
-search context alive until the scroll timeout expires.
+The paginated request inherits the `POST` method from the initial request
+because the initial request has a body. It also keeps the configured headers.
+Close the scroll context when the export is complete, because {props.Name}
+keeps the search context alive until the scroll timeout expires.
 
 ### Send events to a {props.Name} index
 
 Send an example event to the `main` index:
-
-import { Code } from "@astrojs/starlight/components";
 
 export const sendToMainIndex = `
 from {event: "example"}


### PR DESCRIPTION
## 🔍 Problem

- The `from_http` reference and HTTP collection guide only described URL-based pagination.
- Users need examples for APIs that carry pagination state in request bodies or headers.
- The search backend integration pages should show the new pagination shape where OpenSearch is the primary example.
- Wazuh users need the same pattern because the Wazuh indexer exposes an OpenSearch-compatible search API.

## 🛠️ Solution

- Document `paginate` lambdas that return request records with `url`, `method`, `headers`, and `body` patches.
- Explain inheritance, header merge/delete behavior, `body: null`, and invalid-record diagnostics.
- Add OpenSearch `search_after` and scroll-style pagination examples to the `from_http` reference and REST API collection guide.
- Update the shared OpenSearch/Elasticsearch integration content to export large search result sets with request-record pagination.
- Add a paginated Wazuh indexer export example and cross-link it from the REST API collection guide.

## 💬 Review

- Focus on whether the request-record semantics are concise and match the code PR.
- Check that the OpenSearch and Wazuh examples keep the parsed page envelope available to the pagination lambda before unrolling hits.

<sub>
⚙️ Code PR: tenzir/tenzir#6193
</sub>