### PR TITLE
Document idiomatic TQL string patterns

### DIFF
--- a/src/content/docs/explanations/secrets/index.mdx
+++ b/src/content/docs/explanations/secrets/index.mdx
@@ -54,22 +54,13 @@ secret are identical, so no lookup occurs.
 
 ### Supported Operations
 
-#### Concatenation
-
-You can concatenate secrets with other secrets or strings using the `+` operator:
-
-```tql
-auth = "Bearer " + secret("my-secret")
-url = $base_url + secret("user-name") + ":" + secret("password")
-```
-
 #### Format Strings
 
 You can use secrets in [format strings](/reference/expressions#format-strings-f-strings).
 Unlike other types, which create strings with values formatted as if using the
 `string` function, a format string containing a secret yields a secret.
 
-You can write the above concatenations using format strings:
+Use format strings when you combine secrets with other values:
 
 ```tql
 auth = f"Bearer {secret("my-secret")}"
@@ -78,6 +69,11 @@ url = f"{$base_url}{secret("user-name")}:{secret("password")}"
 
 Format strings turn secrets nested in a structured value (`record`, `list`) into
 the string `"***"`.
+
+#### Concatenation
+
+You can concatenate secrets with other secrets or strings using the `+` operator,
+but prefer format strings for assembled headers, URLs, and other text.
 
 #### Encoding & Decoding
 

--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -105,7 +105,7 @@ containing key-value pairs:
 
 ```tql
 let $headers = {
-  "Authorization": "Bearer " + secret("YOUR_BEARER_TOKEN")
+  "Authorization": f"Bearer {secret("YOUR_BEARER_TOKEN")}"
 }
 from_http "https://api.example.com/data", headers=$headers {
   read_json
@@ -216,7 +216,7 @@ automatically:
 ```tql
 from_http "https://graph.microsoft.com/v1.0/users",
   headers={
-    "Authorization": "Bearer " + secret("MICROSOFT_GRAPH_TOKEN"),
+    "Authorization": f"Bearer {secret("MICROSOFT_GRAPH_TOKEN")}",
     "ConsistencyLevel": "eventual",
   },
   paginate="odata" {

--- a/src/content/docs/guides/collecting/index.mdx
+++ b/src/content/docs/guides/collecting/index.mdx
@@ -44,7 +44,7 @@ Fetch data from web APIs with authentication, pagination, and retry handling:
 
 ```tql
 from_http "https://api.example.com/events",
-  headers={"Authorization": "Bearer " + secret("API_TOKEN")}
+  headers={"Authorization": f"Bearer {secret("API_TOKEN")}"}
 ```
 
 See the [HTTP and API guide](/guides/collecting/fetch-via-http-and-apis) for

--- a/src/content/docs/guides/packages/add-operators.mdx
+++ b/src/content/docs/guides/packages/add-operators.mdx
@@ -138,7 +138,7 @@ args:
       default: ""
 ---
 
-$field = $prefix + $value
+$field = f"{$prefix}{$value}"
 ```
 
 Call this operator with both positional and named arguments:
@@ -166,7 +166,7 @@ args:
       default: "World"
 ---
 
-greeting = "Hello, " + $name + "!"
+greeting = f"Hello, {$name}!"
 ```
 
 Calling the operator without arguments uses the default value:
@@ -284,7 +284,7 @@ args:
 ---
 
 if $suffix != null {
-  $field = $field + $suffix
+  $field = f"{$field}{$suffix}"
 }
 ```
 

--- a/src/content/docs/guides/routing/load-balance-pipelines.mdx
+++ b/src/content/docs/guides/routing/load-balance-pipelines.mdx
@@ -69,7 +69,7 @@ let $cfg = [
 
 subscribe "input"
 load_balance $cfg {
-  let $endpoint = string($cfg.ip) + ":8088"
+  let $endpoint = f"{$cfg.ip}:8088"
   to_splunk $endpoint, hec_token=$cfg.token
 }
 ```

--- a/src/content/docs/guides/transformation/manipulate-strings.mdx
+++ b/src/content/docs/guides/transformation/manipulate-strings.mdx
@@ -522,9 +522,9 @@ from {
   dept: "engineering",
   id: 42
 }
-full_name = first.capitalize() + " " + last.to_upper()
-email = first + "." + last + "@company.com"
-badge = dept.to_upper().slice(begin=0, end=3) + "-" + id.string()
+full_name = f"{first.capitalize()} {last.to_upper()}"
+email = f"{first}.{last}@company.com"
+badge = f"{dept.to_upper().slice(begin=0, end=3)}-{id}"
 ```
 
 ```tql

--- a/src/content/docs/guides/transformation/transform-values.mdx
+++ b/src/content/docs/guides/transformation/transform-values.mdx
@@ -30,12 +30,13 @@ quantity = quantity.float()
 
 ### Convert to strings
 
-Use <Fn>string</Fn> to convert any value to its string representation:
+Use format strings to build strings from values. TQL formats each embedded
+expression as if you had called <Fn>string</Fn>:
 
 ```tql
 from {status: 200, ratio: 0.95},
      {status: 404, ratio: 0.05}
-message = status.string() + " - " + (ratio * 100).string() + "%"
+message = f"{status} - {ratio * 100}%"
 ```
 
 ```tql

--- a/src/content/docs/guides/transformation/work-with-time.mdx
+++ b/src/content/docs/guides/transformation/work-with-time.mdx
@@ -535,7 +535,7 @@ iso_time = iso.time()
 apache_time = apache.parse_time("%d/%b/%Y:%H:%M:%S %z")
 nginx_time = nginx.parse_time("%Y/%m/%d %H:%M:%S")
 // For syslog, we need to add the year
-syslog_time = ("2024 " + syslog).parse_time("%Y %b %d %H:%M:%S")
+syslog_time = f"2024 {syslog}".parse_time("%Y %b %d %H:%M:%S")
 ```
 
 ```tql

--- a/src/content/docs/integrations/wazuh.mdx
+++ b/src/content/docs/integrations/wazuh.mdx
@@ -76,16 +76,20 @@ raw archived events in `wazuh-archives-*` indices. You can query these indices
 through the Wazuh indexer API with <Op>from_http</Op>:
 
 ```tql
+let $auth = f"{secret("WAZUH_INDEXER_USER")}:{secret("WAZUH_INDEXER_PASSWORD")}"
+let $headers = {
+  "Authorization": f"Basic {$auth.encode_base64()}",
+  "Content-Type": "application/json",
+}
+let $body = {
+  size: 100,
+  query: {match_all: {}},
+  sort: [{"@timestamp": {order: "desc"}}],
+}
+
 from_http "https://wazuh-indexer.example.com:9200/wazuh-alerts-*/_search",
-  headers={
-    "Authorization": "Basic " + f"{secret("WAZUH_INDEXER_USER")}:{secret("WAZUH_INDEXER_PASSWORD")}".encode_base64(),
-    "Content-Type": "application/json",
-  },
-  body={
-    size: 100,
-    query: {match_all: {}},
-    sort: [{"@timestamp": {order: "desc"}}],
-  } {
+  headers=$headers,
+  body=$body {
   read_json
 }
 unroll hits.hits

--- a/src/content/docs/integrations/zeromq.mdx
+++ b/src/content/docs/integrations/zeromq.mdx
@@ -53,7 +53,7 @@ accept_zmq "tcp://0.0.0.0:5555", prefix="alerts/" {
 
 ```tql
 export
-serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"
+serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=f"{kind}/"
 ```
 
 ### Connect and publish JSON

--- a/src/content/docs/reference/expressions.mdx
+++ b/src/content/docs/reference/expressions.mdx
@@ -338,7 +338,7 @@ pass string literals directly to operators that accept secrets:
 
 ```tql
 // Using managed secret
-auth_header = "Bearer " + secret("api-token")
+auth_header = f"Bearer {secret("api-token")}"
 
 // Using format string (produces a secret)
 connection = f"https://{secret("user")}:{secret("pass")}@api.example.com"

--- a/src/content/docs/reference/functions/print_cef.mdx
+++ b/src/content/docs/reference/functions/print_cef.mdx
@@ -77,7 +77,7 @@ r = extension.print_cef(
     cef_version="0",
     device_vendor="Tenzir", device_product="Tenzir Node", device_version="5.5.0",
     signature_id=signature_id, severity=severity,
-    name= signature_id + " written by Tenzir"
+    name=f"{signature_id} written by Tenzir"
 )
 select r
 write_lines

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -653,7 +653,7 @@ operators:
     path: 'reference/operators/to_azure_log_analytics'
   - name: 'to_zmq'
     description: 'Connects to a remote ZeroMQ subscriber endpoint and sends events.'
-    example: 'to_zmq "tcp://collector.example.com:5555", encoding="json", prefix=kind + "/"'
+    example: 'to_zmq "tcp://collector.example.com:5555", encoding="json", prefix=f"{kind}/"'
     path: 'reference/operators/to_zmq'
   - name: 'to_clickhouse'
     description: 'Sends events to a ClickHouse table.'
@@ -693,7 +693,7 @@ operators:
     path: 'reference/operators/to_google_secops'
   - name: 'serve_zmq'
     description: 'Listens on a ZeroMQ endpoint and sends events.'
-    example: 'serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"'
+    example: 'serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=f"{kind}/"'
     path: 'reference/operators/serve_zmq'
   - name: 'to_hive'
     description: 'Writes events to a URI using hive partitioning.'
@@ -1865,7 +1865,7 @@ serve_tcp "0.0.0.0:8090" { write_json }
 <ReferenceCard title="serve_zmq" description="Listens on a ZeroMQ endpoint and sends events." href="/reference/operators/serve_zmq">
 
 ```tql
-serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"
+serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=f"{kind}/"
 ```
 
 </ReferenceCard>
@@ -2081,7 +2081,7 @@ to_udp "127.0.0.1:514"
 <ReferenceCard title="to_zmq" description="Connects to a remote ZeroMQ subscriber endpoint and sends events." href="/reference/operators/to_zmq">
 
 ```tql
-to_zmq "tcp://collector.example.com:5555", encoding="json", prefix=kind + "/"
+to_zmq "tcp://collector.example.com:5555", encoding="json", prefix=f"{kind}/"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators/from_azure_blob_storage.mdx
+++ b/src/content/docs/reference/operators/from_azure_blob_storage.mdx
@@ -84,7 +84,7 @@ from_azure_blob_storage "abfs://logs/suricata/**.json", watch=true {
 
 ```tql
 from_azure_blob_storage "abfs://input/**.json",
-  rename=(path => "/archive/" + path)
+  rename=(path => f"/archive/{path}")
 ```
 
 ### Add source path to events

--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -202,7 +202,7 @@ as Microsoft Graph:
 ```tql
 from_http "https://graph.microsoft.com/v1.0/users",
   headers={
-    "Authorization": "Bearer " + secret("MICROSOFT_GRAPH_TOKEN"),
+    "Authorization": f"Bearer {secret("MICROSOFT_GRAPH_TOKEN")}",
     "ConsistencyLevel": "eventual",
   },
   paginate="odata" {

--- a/src/content/docs/reference/operators/from_s3.mdx
+++ b/src/content/docs/reference/operators/from_s3.mdx
@@ -92,7 +92,7 @@ from_s3 "s3://logs/application/**.json", watch=true, aws_iam={
 
 ```tql
 from_s3 "s3://input-bucket/**.json",
-  rename=(path => "archive/" + path)
+  rename=(path => f"archive/{path}")
 ```
 
 ### Add source path to events

--- a/src/content/docs/reference/operators/load_balance.mdx
+++ b/src/content/docs/reference/operators/load_balance.mdx
@@ -66,7 +66,7 @@ let $cfg = [{
 
 subscribe "input"
 load_balance $cfg {
-  let $endpoint = string($cfg.ip) + ":8080"
+  let $endpoint = f"{$cfg.ip}:8080"
   to_splunk $endpoint, hec_token=$cfg.token
 }
 ```

--- a/src/content/docs/reference/operators/serve_zmq.mdx
+++ b/src/content/docs/reference/operators/serve_zmq.mdx
@@ -1,7 +1,7 @@
 ---
 title: serve_zmq
 category: Outputs/Events
-example: 'serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"'
+example: 'serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=f"{kind}/"'
 ---
 
 import Op from '@components/see-also/Op.astro';
@@ -64,7 +64,7 @@ serve_zmq "tcp://0.0.0.0:5555", encoding="json"
 
 ```tql
 export
-serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=kind + "/"
+serve_zmq "tcp://0.0.0.0:5555", encoding="json", prefix=f"{kind}/"
 ```
 
 ## See Also

--- a/src/content/docs/reference/operators/to_zmq.mdx
+++ b/src/content/docs/reference/operators/to_zmq.mdx
@@ -1,7 +1,7 @@
 ---
 title: to_zmq
 category: Outputs/Events
-example: 'to_zmq "tcp://collector.example.com:5555", encoding="json", prefix=kind + "/"'
+example: 'to_zmq "tcp://collector.example.com:5555", encoding="json", prefix=f"{kind}/"'
 ---
 
 import Op from '@components/see-also/Op.astro';
@@ -62,7 +62,7 @@ to_zmq "tcp://collector.example.com:5555", encoding="json"
 
 ```tql
 export
-to_zmq "tcp://collector.example.com:5555", encoding="ndjson", prefix=source + "/"
+to_zmq "tcp://collector.example.com:5555", encoding="ndjson", prefix=f"{source}/"
 ```
 
 ## See Also

--- a/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
+++ b/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
@@ -192,6 +192,52 @@ comma) or use a backslash to continue.
 - Inside `()`, `[]`, `{}`: newlines don't end the statement
   :::
 
+### Extract bulky arguments before subpipelines
+
+Operators that take a subpipeline often also take record or list arguments. When
+those arguments span multiple lines, the record braces and subpipeline braces can
+be hard to distinguish. Move bulky configuration values into `let` bindings so
+the operator call stays compact and the subpipeline remains visually clear.
+This pattern is common with <Op>from_http</Op>, where request records can sit
+directly before a parsing subpipeline such as <Op>read_json</Op>.
+
+❌ Hard to scan:
+
+```tql
+from_http "https://api.example.com/search",
+  headers={
+    "Authorization": f"Bearer {secret("API_TOKEN")}",
+    "Content-Type": "application/json",
+  },
+  body={
+    query: "severity:high",
+    limit: 100,
+  } {
+  read_json
+}
+```
+
+✅ Clear separation between configuration and parsing:
+
+```tql
+let $headers = {
+  "Authorization": f"Bearer {secret("API_TOKEN")}",
+  "Content-Type": "application/json",
+}
+let $body = {
+  query: "severity:high",
+  limit: 100,
+}
+
+from_http "https://api.example.com/search", headers=$headers, body=$body {
+  read_json
+}
+```
+
+Use this pattern for readability, even when you don't reuse the value. Keep
+short scalar arguments inline, but extract multi-line records or lists when they
+would otherwise sit directly before `{ ... }`.
+
 ## Expression style
 
 ### Avoid unnecessary parentheses

--- a/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
+++ b/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
@@ -271,6 +271,34 @@ Use parentheses only when they clarify precedence in complex expressions:
 where (a > 1 and b < 2) or c == 3
 ```
 
+### Use format strings for string composition
+
+Use format strings (f-strings) when embedding values in a larger string. They
+keep separators, literals, and conversions in one template.
+
+✅ Readable string composition:
+
+```tql
+message = f"{status} - {ratio * 100}%"
+endpoint = f"{host}:{port}"
+```
+
+F-strings also work with secrets. When a format string contains a secret, the
+result is a secret:
+
+```tql
+let $headers = {
+  "Authorization": f"Bearer {secret("API_TOKEN")}",
+}
+```
+
+❌ Avoid building formatted strings with `+`:
+
+```tql
+message = status.string() + " - " + (ratio * 100).string() + "%"
+endpoint = string(host) + ":" + port.string()
+```
+
 ### Use inline ternary for simple binary choices
 
 TQL supports `value if condition else other` as an inline expression. Use it


### PR DESCRIPTION
## 🔍 Problem

- Multi-line records directly before subpipelines make TQL harder to scan because record braces and subpipeline braces look similar.
- Docs examples mixed `+` string concatenation and f-strings for assembled strings, which weakened the idiomatic guidance.

## 🛠️ Solution

- Document extracting bulky operator arguments into `let` bindings before subpipelines.
- Add explicit idiomatic guidance for f-strings in TQL.
- Update incidental string-building examples to use f-strings while leaving `+` where the docs intentionally explain concatenation.

## 💬 Review

- Check that the examples remain valid TQL.
- Check whether the remaining `+` examples are limited to reference or anti-pattern contexts.