### PR TITLE
Document operator metrics retention

### DIFF
--- a/src/content/docs/reference/operators/metrics.mdx
+++ b/src/content/docs/reference/operators/metrics.mdx
@@ -17,13 +17,25 @@ events are collected every second.
 
 :::tip[Retention Policy]
 Set the `tenzir.retention.metrics` configuration option to change how long
-Tenzir Nodes store metrics:
+Tenzir Nodes store general metrics:
 
 ```yaml
 tenzir:
   retention:
     metrics: 7d
 ```
+
+Operator metrics use the separate `tenzir.retention.operator-metrics` setting:
+
+```yaml
+tenzir:
+  retention:
+    operator-metrics: 0s
+```
+
+With `0s`, Tenzir does not persist `tenzir.metrics.operator` or
+`tenzir.metrics.operator_profile` events, but live subscribers can still receive
+them.
 
 :::
 

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -32,6 +32,12 @@ tenzir:
     # pipeline activity in the Tenzir Platform.
     #metrics: 7d
 
+    # How long to keep per-operator metrics for. This covers
+    # tenzir.metrics.operator and tenzir.metrics.operator_profile. Set to 0s to
+    # avoid storing these heavy metrics while still making live metrics
+    # available.
+    #operator-metrics: 0s
+
     # How long to keep diagnostics for. Set to 0s to disable diagnostics
     # retention entirely.
     # WARNING: A low retention period may negatively impact the usability of


### PR DESCRIPTION
## 🔍 Problem

- The metrics reference only documents `tenzir.retention.metrics`.
- Per-operator metrics use `tenzir.retention.operator-metrics`, including `tenzir.metrics.operator_profile` after tenzir/tenzir#6196.

## 🛠️ Solution

- Clarify that general metrics and per-operator metrics use separate retention settings.
- Add `operator-metrics` to `tenzir.yaml.example`.

## 💬 Review

- Check that the retention wording is precise about `0s`: the metrics are not persisted, but live subscribers can still receive them.

<sub>
⚙️ Code PR: tenzir/tenzir#6196<br>
🎫 References TNZ-580
</sub>