### PR TITLE
Document auto_fill option for CSV/TSV/SSV/XSV readers

### DIFF
--- a/src/content/docs/reference/functions/parse_csv.mdx
+++ b/src/content/docs/reference/functions/parse_csv.mdx
@@ -9,7 +9,7 @@ Parses a string as CSV (Comma-Separated Values).
 ```tql
 parse_csv(input:string, header=list<string>|string,
          [list_separator=string, null_value=string,
-          auto_expand=bool, quotes=string, schema=string,
+          auto_expand=bool, auto_fill=bool, quotes=string, schema=string,
           selector=string, schema_only=bool, raw=bool,
           unflatten_separator=string]) -> record
 ```
@@ -43,6 +43,12 @@ The string denoting an absent value.
 
 Automatically add fields to the schema when encountering events with too many
 values instead of dropping the excess values.
+
+### `auto_fill = bool (optional)`
+
+Silently fill missing trailing values in a row with `null` instead of emitting
+a warning. The missing fields are already filled with `null` either way; this
+option only suppresses the warning.
 
 ### `quotes = string (optional)`
 

--- a/src/content/docs/reference/functions/parse_ssv.mdx
+++ b/src/content/docs/reference/functions/parse_ssv.mdx
@@ -9,7 +9,7 @@ Parses a string as space separated values.
 ```tql
 parse_ssv(input:string, header=list<string>|string,
          [list_separator:string, null_value:string,
-          auto_expand=bool, quotes=string, schema=string,
+          auto_expand=bool, auto_fill=bool, quotes=string, schema=string,
           selector=string, schema_only=bool, raw=bool,
           unflatten_separator=string]) -> record
 ```
@@ -43,6 +43,12 @@ The string denoting an absent value.
 
 Automatically add fields to the schema when encountering events with too many
 values instead of dropping the excess values.
+
+### `auto_fill = bool (optional)`
+
+Silently fill missing trailing values in a row with `null` instead of emitting
+a warning. The missing fields are already filled with `null` either way; this
+option only suppresses the warning.
 
 ### `quotes = string (optional)`
 

--- a/src/content/docs/reference/functions/parse_tsv.mdx
+++ b/src/content/docs/reference/functions/parse_tsv.mdx
@@ -9,7 +9,7 @@ Parses a string as tab separated values.
 ```tql
 parse_tsv(input:string, header=list<string>|string,
          [list_separator:string, null_value:string,
-          auto_expand=bool, quotes=string, schema=string,
+          auto_expand=bool, auto_fill=bool, quotes=string, schema=string,
           selector=string, schema_only=bool, raw=bool,
           unflatten_separator=string]) -> record
 ```
@@ -44,6 +44,12 @@ The string denoting an absent value.
 
 Automatically add fields to the schema when encountering events with too many
 values instead of dropping the excess values.
+
+### `auto_fill = bool (optional)`
+
+Silently fill missing trailing values in a row with `null` instead of emitting
+a warning. The missing fields are already filled with `null` either way; this
+option only suppresses the warning.
 
 ### `quotes = string (optional)`
 

--- a/src/content/docs/reference/functions/parse_xsv.mdx
+++ b/src/content/docs/reference/functions/parse_xsv.mdx
@@ -9,7 +9,7 @@ Parses a string as delimiter separated values.
 ```tql
 parse_xsv(input:string, field_separator=string, list_separator=string, null_value=string,
           header=list<string>|string,
-         [auto_expand=bool, quotes=string, schema=string,
+         [auto_expand=bool, auto_fill=bool, quotes=string, schema=string,
           selector=string, schema_only=bool, raw=bool,
           unflatten_separator=string]) -> record
 ```
@@ -53,6 +53,12 @@ The string denoting an absent value.
 
 Automatically add fields to the schema when encountering events with too many
 values instead of dropping the excess values.
+
+### `auto_fill = bool (optional)`
+
+Silently fill missing trailing values in a row with `null` instead of emitting
+a warning. The missing fields are already filled with `null` either way; this
+option only suppresses the warning.
 
 ### `quotes = string (optional)`
 

--- a/src/content/docs/reference/operators/read_csv.mdx
+++ b/src/content/docs/reference/operators/read_csv.mdx
@@ -8,7 +8,7 @@ Read CSV (Comma-Separated Values) from a byte stream.
 
 ```tql
 read_csv [list_separator=string, null_value=string, comments=bool, header=string,
-          quotes=string, auto_expand=bool,
+          quotes=string, auto_expand=bool, auto_fill=bool,
           schema=string, selector=string, schema_only=bool, raw=bool, unflatten_separator=string]
 ```
 
@@ -21,6 +21,12 @@ the bytes as [CSV](https://en.wikipedia.org/wiki/Comma-separated_values).
 
 Automatically add fields to the schema when encountering events with too many
 values instead of dropping the excess values.
+
+### `auto_fill = bool (optional)`
+
+Silently fill missing trailing values in a row with `null` instead of emitting
+a warning. The missing fields are already filled with `null` either way; this
+option only suppresses the warning.
 
 ### `comments = bool (optional)`
 

--- a/src/content/docs/reference/operators/read_ssv.mdx
+++ b/src/content/docs/reference/operators/read_ssv.mdx
@@ -8,7 +8,7 @@ Read SSV (Space-Separated Values) from a byte stream.
 
 ```tql
 read_ssv [list_separator=string, null_value=string, comments=bool, header=string,
-          quotes=string, auto_expand=bool,
+          quotes=string, auto_expand=bool, auto_fill=bool,
           schema=string, selector=string, schema_only=bool, raw=bool, unflatten_separator=string]
 ```
 
@@ -21,6 +21,12 @@ the bytes as SSV.
 
 Automatically add fields to the schema when encountering events with too many
 values instead of dropping the excess values.
+
+### `auto_fill = bool (optional)`
+
+Silently fill missing trailing values in a row with `null` instead of emitting
+a warning. The missing fields are already filled with `null` either way; this
+option only suppresses the warning.
 
 ### `comments = bool (optional)`
 

--- a/src/content/docs/reference/operators/read_tsv.mdx
+++ b/src/content/docs/reference/operators/read_tsv.mdx
@@ -8,7 +8,7 @@ Read TSV (Tab-Separated Values) from a byte stream.
 
 ```tql
 read_tsv [list_separator=string, null_value=string, comments=bool, header=string,
-          quotes=string, auto_expand=bool,
+          quotes=string, auto_expand=bool, auto_fill=bool,
           schema=string, selector=string, schema_only=bool, raw=bool, unflatten_separator=string]
 ```
 
@@ -21,6 +21,12 @@ the bytes as [TSV](https://en.wikipedia.org/wiki/Tab-separated_values).
 
 Automatically add fields to the schema when encountering events with too many
 values instead of dropping the excess values.
+
+### `auto_fill = bool (optional)`
+
+Silently fill missing trailing values in a row with `null` instead of emitting
+a warning. The missing fields are already filled with `null` either way; this
+option only suppresses the warning.
 
 ### `comments = bool (optional)`
 

--- a/src/content/docs/reference/operators/read_xsv.mdx
+++ b/src/content/docs/reference/operators/read_xsv.mdx
@@ -8,7 +8,7 @@ Read XSV from a byte stream.
 
 ```tql
 read_xsv field_separator=string, list_separator=string, null_value=string,
-        [comments=bool, header=string, auto_expand=bool, quotes=string,
+        [comments=bool, header=string, auto_expand=bool, auto_fill=bool, quotes=string,
          selector=string, schema_only=bool, raw=bool, unflatten_separator=string]
 ```
 
@@ -47,6 +47,12 @@ The string denoting an absent value.
 
 Automatically add fields to the schema when encountering events with too many
 values instead of dropping the excess values.
+
+### `auto_fill = bool (optional)`
+
+Silently fill missing trailing values in a row with `null` instead of emitting
+a warning. The missing fields are already filled with `null` either way; this
+option only suppresses the warning.
 
 ### `comments = bool (optional)`
 


### PR DESCRIPTION
## 🔍 Problem

The `read_csv`/`read_tsv`/`read_ssv`/`read_xsv` operators and their `parse_*` function counterparts gained a new `auto_fill` option (see code PR), but it is not yet documented.

## 🛠️ Solution

- Add `auto_fill` to the signature line and an `auto_fill = bool (optional)` section in all eight reference pages (4 operators, 4 functions).
- Wording mirrors the adjacent `auto_expand` entry for consistency.

## 💬 Review

- Eight near-identical insertions; check that wording and placement match across all pages.

<sub>
📎 Code PR: tenzir/tenzir#6199<br>
🎫 References TNZ-544
</sub>