### PR TITLE
Document operator profile retention

### DIFF
--- a/src/content/docs/reference/operators/metrics.mdx
+++ b/src/content/docs/reference/operators/metrics.mdx
@@ -25,7 +25,8 @@ tenzir:
     metrics: 7d
 ```
 
-Operator metrics use the separate `tenzir.retention.operator-metrics` setting:
+Legacy operator metrics use the separate
+`tenzir.retention.operator-metrics` setting:
 
 ```yaml
 tenzir:
@@ -33,9 +34,18 @@ tenzir:
     operator-metrics: 0s
 ```
 
-With `0s`, Tenzir does not persist `tenzir.metrics.operator` or
-`tenzir.metrics.operator_profile` events, but live subscribers can still receive
-them.
+Operator profile metrics use
+`tenzir.retention.operator-profile-metrics`:
+
+```yaml
+tenzir:
+  retention:
+    operator-profile-metrics: 1d
+```
+
+Set either option to `0s` to disable persistence for the corresponding
+`tenzir.metrics.operator` or `tenzir.metrics.operator_profile` events. Live
+subscribers can still receive them.
 
 :::
 

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -32,11 +32,13 @@ tenzir:
     # pipeline activity in the Tenzir Platform.
     #metrics: 7d
 
-    # How long to keep per-operator metrics for. This covers
-    # tenzir.metrics.operator and tenzir.metrics.operator_profile. Set to 0s to
-    # avoid storing these heavy metrics while still making live metrics
-    # available.
+    # How long to keep legacy operator metrics for. Set to 0s to avoid storing
+    # these heavy metrics while still making live metrics available.
     #operator-metrics: 0s
+
+    # How long to keep operator profile metrics for. Set to 0s to avoid storing
+    # these heavy metrics while still making live metrics available.
+    #operator-profile-metrics: 1d
 
     # How long to keep diagnostics for. Set to 0s to disable diagnostics
     # retention entirely.


### PR DESCRIPTION
## 🔍 Problem

- tenzir/docs#339 documented one `operator-metrics` setting for both legacy operator metrics and operator profile metrics.
- The code now keeps those retention policies separate: legacy operator metrics stay disabled by default, while operator profile metrics are retained for one day.

## 🛠️ Solution

- Document `tenzir.retention.operator-metrics: 0s` for `tenzir.metrics.operator`.
- Document `tenzir.retention.operator-profile-metrics: 1d` for `tenzir.metrics.operator_profile`.
- Keep `0s` documented as the explicit opt-out for persistence for either metric family.

## 💬 Review

- Check that the docs match tenzir/tenzir#6196.

<sub>
⚙️ Code PR: tenzir/tenzir#6196<br>
📎 Follows up: tenzir/docs#339<br>
🎫 References TNZ-580
</sub>