### PR TITLE
Document `watch` taking a duration on arrow-fs operators

### DIFF
--- a/src/content/docs/reference/operators/from_azure_blob_storage.mdx
+++ b/src/content/docs/reference/operators/from_azure_blob_storage.mdx
@@ -9,7 +9,7 @@ import FromFileCommonParams from '@partials/operators/FromFileCommonParams.mdx';
 Reads one or multiple files from Azure Blob Storage.
 
 ```tql
-from_azure_blob_storage url:string, [account_key=string, watch=bool,
+from_azure_blob_storage url:string, [account_key=string, watch=duration,
   remove=bool, rename=string->string, max_age=duration] { … }
 ```
 
@@ -56,7 +56,7 @@ command-line arguments.
 
 Account key for authenticating with Azure Blob Storage.
 
-<FromFileCommonParams removeNote={true} />
+<FromFileCommonParams removeNote={true} watchAsDuration={true} />
 
 ## Examples
 
@@ -75,7 +75,7 @@ from_azure_blob_storage "abfs://container/data.csv", account_key="your-account-k
 ### Read Suricata EVE JSON logs continuously
 
 ```tql
-from_azure_blob_storage "abfs://logs/suricata/**.json", watch=true {
+from_azure_blob_storage "abfs://logs/suricata/**.json", watch=10s {
   read_suricata
 }
 ```

--- a/src/content/docs/reference/operators/from_google_cloud_storage.mdx
+++ b/src/content/docs/reference/operators/from_google_cloud_storage.mdx
@@ -9,8 +9,8 @@ import FromFileCommonParams from '@partials/operators/FromFileCommonParams.mdx';
 Reads one or multiple files from Google Cloud Storage.
 
 ```tql
-from_google_cloud_storage url:string, [anonymous=bool, watch=bool, remove=bool,
-  rename=string->string, max_age=duration] { … }
+from_google_cloud_storage url:string, [anonymous=bool, watch=duration,
+  remove=bool, rename=string->string, max_age=duration] { … }
 ```
 
 ## Description
@@ -49,7 +49,7 @@ works for publicly readable buckets and objects.
 
 Defaults to `false`.
 
-<FromFileCommonParams />
+<FromFileCommonParams watchAsDuration={true} />
 
 ## Examples
 
@@ -68,7 +68,7 @@ from_google_cloud_storage "gs://public-dataset/data.csv", anonymous=true
 ### Read Zeek logs continuously
 
 ```tql
-from_google_cloud_storage "gs://logs/zeek/**.log", watch=true {
+from_google_cloud_storage "gs://logs/zeek/**.log", watch=10s {
   read_zeek_tsv
 }
 ```

--- a/src/content/docs/reference/operators/from_s3.mdx
+++ b/src/content/docs/reference/operators/from_s3.mdx
@@ -10,7 +10,7 @@ import AWSIAMOptions from '@partials/operators/AWSIAMOptions.mdx';
 Reads one or multiple files from Amazon S3.
 
 ```tql
-from_s3 url:string, [anonymous=bool, aws_iam=record, watch=bool,
+from_s3 url:string, [anonymous=bool, aws_iam=record, watch=duration,
   remove=bool, rename=string->string, max_age=duration] { … }
 ```
 
@@ -55,7 +55,7 @@ Defaults to `false`.
 
 <AWSIAMOptions />
 
-<FromFileCommonParams removeNote={true} />
+<FromFileCommonParams removeNote={true} watchAsDuration={true} />
 
 ## Examples
 
@@ -83,7 +83,7 @@ from_s3 "s3://my-bucket/data/**.json?endpoint_override=minio.example.com:9000&sc
 ### Read files continuously and assume IAM role
 
 ```tql
-from_s3 "s3://logs/application/**.json", watch=true, aws_iam={
+from_s3 "s3://logs/application/**.json", watch=10s, aws_iam={
   assume_role: "arn:aws:iam::123456789012:role/LogReaderRole"
 }
 ```

--- a/src/partials/operators/FromFileCommonParams.mdx
+++ b/src/partials/operators/FromFileCommonParams.mdx
@@ -1,3 +1,16 @@
+{props.watchAsDuration ? (
+<>
+### `watch = duration (optional)`
+
+In addition to processing all existing files, this option keeps the operator
+running, watching for new files that also match the given URL. The duration
+specifies the interval between filesystem scans. For example, `watch=30s` polls
+every 30 seconds.
+
+Disabled by default.
+</>
+) : (
+<>
 ### `watch = bool (optional)`
 
 In addition to processing all existing files, this option keeps the operator
@@ -5,6 +18,8 @@ running, watching for new files that also match the given URL. Currently, this
 scans the filesystem up to every 10s.
 
 Defaults to `false`.
+</>
+)}
 
 ### `remove = bool (optional)`
 


### PR DESCRIPTION
The `watch` option on `from_s3`, `from_google_cloud_storage`, and
`from_azure_blob_storage` now takes a duration that controls the poll
interval, replacing the previous boolean flag with the fixed 10-second
pause.