### PR TITLE
Fix partial semantic links

### DIFF
--- a/scripts/verify-inline-partials.ts
+++ b/scripts/verify-inline-partials.ts
@@ -56,6 +56,20 @@ try {
     join(partialsDir, "SpreadRetainedReference.mdx"),
     "### `spread-retained = component`",
   );
+  writeFileSync(
+    join(partialsDir, "NestedRetainedReference.mdx"),
+    "### `nested-retained = component`",
+  );
+  writeFileSync(
+    join(partialsDir, "NestedRetainedWrapper.mdx"),
+    [
+      'import NestedRetainedReference from "./NestedRetainedReference.mdx";',
+      "",
+      "<NestedRetainedReference />",
+      "",
+      "<Slot {...{content: NestedRetainedReference}} />",
+    ].join("\n"),
+  );
   const semanticLinkPartial = "- <Op>{props.Operator}</Op>";
   const semanticLinkPartialPath = join(partialsDir, "WithSemanticLink.mdx");
   writeFileSync(semanticLinkPartialPath, semanticLinkPartial);
@@ -75,6 +89,7 @@ try {
     'import Wrapper from "@partials/Wrapper.mdx";',
     'import RetainedReference from "@partials/RetainedReference.mdx";',
     'import SpreadRetainedReference from "@partials/SpreadRetainedReference.mdx";',
+    'import NestedRetainedWrapper from "@partials/NestedRetainedWrapper.mdx";',
     'import WithSemanticLink from "@partials/WithSemanticLink.mdx";',
     "",
     "# Doc",
@@ -92,6 +107,8 @@ try {
     "<SpreadRetainedReference />",
     "",
     "<Slot {...{content: SpreadRetainedReference}} />",
+    "",
+    "<NestedRetainedWrapper />",
     "",
     '<WithSemanticLink Operator="where" />',
   ].join("\n");
@@ -115,6 +132,7 @@ try {
   assert(headingTexts.includes("Gadget"));
   assert(headingTexts.includes("retained = component"));
   assert(headingTexts.includes("spread-retained = component"));
+  assert(headingTexts.includes("nested-retained = component"));
   assert(!headingTexts.includes('"Gadget"'));
 
   const jsxNames: string[] = [];
@@ -128,6 +146,8 @@ try {
   assert(!jsxNames.includes("WithProps"));
   assert(!jsxNames.includes("RetainedReference"));
   assert(!jsxNames.includes("SpreadRetainedReference"));
+  assert(!jsxNames.includes("NestedRetainedWrapper"));
+  assert(!jsxNames.includes("NestedRetainedReference"));
 
   const importValues: string[] = [];
   visit(transformed, "mdxjsEsm", (node: { value?: string }) => {
@@ -148,6 +168,13 @@ try {
     importValues.some((value) =>
       value.includes(
         'SpreadRetainedReference from "@partials/SpreadRetainedReference.mdx"',
+      ),
+    ),
+  );
+  assert(
+    importValues.some((value) =>
+      value.includes(
+        'NestedRetainedReference from "@partials/NestedRetainedReference.mdx"',
       ),
     ),
   );

--- a/scripts/verify-inline-partials.ts
+++ b/scripts/verify-inline-partials.ts
@@ -48,6 +48,10 @@ try {
     join(partialsDir, "WithProps.mdx"),
     ["### {props.Name}"].join("\n"),
   );
+  writeFileSync(
+    join(partialsDir, "RetainedReference.mdx"),
+    "### `retained = component`",
+  );
   const semanticLinkPartial = "- <Op>{props.Operator}</Op>";
   const semanticLinkPartialPath = join(partialsDir, "WithSemanticLink.mdx");
   writeFileSync(semanticLinkPartialPath, semanticLinkPartial);
@@ -65,6 +69,7 @@ try {
     'import Child from "@partials/Child.mdx";',
     'import UsesComponent from "@partials/UsesComponent.mdx";',
     'import Wrapper from "@partials/Wrapper.mdx";',
+    'import RetainedReference from "@partials/RetainedReference.mdx";',
     'import WithSemanticLink from "@partials/WithSemanticLink.mdx";',
     "",
     "# Doc",
@@ -74,6 +79,10 @@ try {
     "<UsesComponent />",
     "",
     '<Wrapper Name="Gadget" />',
+    "",
+    "<RetainedReference />",
+    "",
+    "<Slot content={RetainedReference} />",
     "",
     '<WithSemanticLink Operator="where" />',
   ].join("\n");
@@ -95,6 +104,7 @@ try {
   assert(headingTexts.includes("child = number"));
   assert(headingTexts.includes("with svg"));
   assert(headingTexts.includes("Gadget"));
+  assert(headingTexts.includes("retained = component"));
   assert(!headingTexts.includes('"Gadget"'));
 
   const jsxNames: string[] = [];
@@ -106,6 +116,7 @@ try {
   assert(!jsxNames.includes("UsesComponent"));
   assert(!jsxNames.includes("Wrapper"));
   assert(!jsxNames.includes("WithProps"));
+  assert(!jsxNames.includes("RetainedReference"));
 
   const importValues: string[] = [];
   visit(transformed, "mdxjsEsm", (node: { value?: string }) => {
@@ -114,6 +125,13 @@ try {
 
   assert(
     importValues.some((value) => value.includes("@components/InlineSVG.astro")),
+  );
+  assert(
+    importValues.some((value) =>
+      value.includes(
+        'RetainedReference from "@partials/RetainedReference.mdx"',
+      ),
+    ),
   );
 
   const expressionValues: string[] = [];

--- a/scripts/verify-inline-partials.ts
+++ b/scripts/verify-inline-partials.ts
@@ -8,6 +8,7 @@ import remarkMdx from "remark-mdx";
 import { visit } from "unist-util-visit";
 import { VFile } from "vfile";
 import { remarkInlinePartials } from "../src/utils/remark-inline-partials";
+import { remarkSeeAlsoLinks } from "../src/utils/remark-see-also-links";
 
 // This script verifies that inline partials expand headings, hoist imports,
 // and substitute props so the TOC uses the final heading text. Run it after
@@ -47,6 +48,9 @@ try {
     join(partialsDir, "WithProps.mdx"),
     ["### {props.Name}"].join("\n"),
   );
+  const semanticLinkPartial = "- <Op>{props.Operator}</Op>";
+  const semanticLinkPartialPath = join(partialsDir, "WithSemanticLink.mdx");
+  writeFileSync(semanticLinkPartialPath, semanticLinkPartial);
   writeFileSync(
     join(partialsDir, "Wrapper.mdx"),
     [
@@ -61,6 +65,7 @@ try {
     'import Child from "@partials/Child.mdx";',
     'import UsesComponent from "@partials/UsesComponent.mdx";',
     'import Wrapper from "@partials/Wrapper.mdx";',
+    'import WithSemanticLink from "@partials/WithSemanticLink.mdx";',
     "",
     "# Doc",
     "",
@@ -69,11 +74,14 @@ try {
     "<UsesComponent />",
     "",
     '<Wrapper Name="Gadget" />',
+    "",
+    '<WithSemanticLink Operator="where" />',
   ].join("\n");
 
   const processor = remark()
     .use(remarkMdx)
-    .use(remarkInlinePartials, { partialsDir });
+    .use(remarkInlinePartials, { partialsDir })
+    .use(remarkSeeAlsoLinks);
   const file = new VFile({ path: docPath, value: docContent });
   const tree = processor.parse(file);
   const transformed = processor.runSync(tree, file);
@@ -117,6 +125,29 @@ try {
   });
 
   assert(expressionValues.every((value) => !value.includes("props.")));
+  assert(!expressionValues.includes('"where"'));
+
+  const dataHrefs: string[] = [];
+  visit(
+    transformed,
+    ["mdxJsxFlowElement", "mdxJsxTextElement"],
+    (node: {
+      attributes?: Array<{ name?: string; value?: string }>;
+      name?: string;
+    }) => {
+      if (node.name !== "Op") return;
+
+      const dataHref = node.attributes?.find(
+        (attribute) => attribute.name === "data-href",
+      );
+      if (typeof dataHref?.value === "string") {
+        dataHrefs.push(dataHref.value);
+      }
+    },
+  );
+
+  assert(dataHrefs.includes("/reference/operators/where"));
+  assert(dataHrefs.every((href) => !href.includes('"')));
 } finally {
   rmSync(rootDir, { recursive: true, force: true });
 }

--- a/scripts/verify-inline-partials.ts
+++ b/scripts/verify-inline-partials.ts
@@ -52,6 +52,10 @@ try {
     join(partialsDir, "RetainedReference.mdx"),
     "### `retained = component`",
   );
+  writeFileSync(
+    join(partialsDir, "SpreadRetainedReference.mdx"),
+    "### `spread-retained = component`",
+  );
   const semanticLinkPartial = "- <Op>{props.Operator}</Op>";
   const semanticLinkPartialPath = join(partialsDir, "WithSemanticLink.mdx");
   writeFileSync(semanticLinkPartialPath, semanticLinkPartial);
@@ -70,6 +74,7 @@ try {
     'import UsesComponent from "@partials/UsesComponent.mdx";',
     'import Wrapper from "@partials/Wrapper.mdx";',
     'import RetainedReference from "@partials/RetainedReference.mdx";',
+    'import SpreadRetainedReference from "@partials/SpreadRetainedReference.mdx";',
     'import WithSemanticLink from "@partials/WithSemanticLink.mdx";',
     "",
     "# Doc",
@@ -83,6 +88,10 @@ try {
     "<RetainedReference />",
     "",
     "<Slot content={RetainedReference} />",
+    "",
+    "<SpreadRetainedReference />",
+    "",
+    "<Slot {...{content: SpreadRetainedReference}} />",
     "",
     '<WithSemanticLink Operator="where" />',
   ].join("\n");
@@ -105,6 +114,7 @@ try {
   assert(headingTexts.includes("with svg"));
   assert(headingTexts.includes("Gadget"));
   assert(headingTexts.includes("retained = component"));
+  assert(headingTexts.includes("spread-retained = component"));
   assert(!headingTexts.includes('"Gadget"'));
 
   const jsxNames: string[] = [];
@@ -117,6 +127,7 @@ try {
   assert(!jsxNames.includes("Wrapper"));
   assert(!jsxNames.includes("WithProps"));
   assert(!jsxNames.includes("RetainedReference"));
+  assert(!jsxNames.includes("SpreadRetainedReference"));
 
   const importValues: string[] = [];
   visit(transformed, "mdxjsEsm", (node: { value?: string }) => {
@@ -130,6 +141,13 @@ try {
     importValues.some((value) =>
       value.includes(
         'RetainedReference from "@partials/RetainedReference.mdx"',
+      ),
+    ),
+  );
+  assert(
+    importValues.some((value) =>
+      value.includes(
+        'SpreadRetainedReference from "@partials/SpreadRetainedReference.mdx"',
       ),
     ),
   );

--- a/src/utils/remark-inline-partials.ts
+++ b/src/utils/remark-inline-partials.ts
@@ -27,6 +27,7 @@ interface InlinePartialsOptions {
 interface InlineResult {
   contentNodes: Content[];
   hoistedImports: MdxjsEsm[];
+  inlinedComponents: Set<string>;
 }
 
 interface CachedPartial {
@@ -87,7 +88,23 @@ export const remarkInlinePartials: Plugin<[InlinePartialsOptions?], Root> = (
       }
     }
 
-    const { hoistedImports } = inlineTree(tree, file.path, state, [], false);
+    const { hoistedImports, inlinedComponents } = inlineTree(
+      tree,
+      file.path,
+      state,
+      [],
+      false,
+    );
+
+    if (inlinedComponents.size > 0) {
+      removeInlinedPartialImports(
+        tree.children as Content[],
+        file.path,
+        state.partialsDir,
+        inlinedComponents,
+        state.report,
+      );
+    }
 
     if (hoistedImports.length === 0) return;
 
@@ -135,6 +152,7 @@ function inlineTree(
 ): InlineResult {
   const importMap = collectPartialImports(tree, filePath, state.partialsDir);
   const hoistedImports: MdxjsEsm[] = [];
+  const inlinedComponents = new Set<string>();
 
   visit(tree, "mdxJsxFlowElement", (node: MdxJsxFlowElement, index, parent) => {
     if (!parent || typeof index !== "number") return;
@@ -147,6 +165,7 @@ function inlineTree(
     const result = loadPartial(partialPath, state, stack, propsMap);
     if (!result) return;
 
+    inlinedComponents.add(node.name);
     hoistedImports.push(...result.hoistedImports);
     parent.children.splice(index, 1, ...result.contentNodes);
 
@@ -166,7 +185,7 @@ function inlineTree(
     tree.children = contentNodes as Content[];
   }
 
-  return { contentNodes, hoistedImports };
+  return { contentNodes, hoistedImports, inlinedComponents };
 }
 
 function loadPartial(
@@ -214,6 +233,7 @@ function loadPartial(
   return {
     contentNodes: result.contentNodes,
     hoistedImports: result.hoistedImports,
+    inlinedComponents: result.inlinedComponents,
   };
 }
 
@@ -274,7 +294,79 @@ function extractImportNodes(
     }
   }
 
-  return { contentNodes, hoistedImports };
+  return { contentNodes, hoistedImports, inlinedComponents: new Set() };
+}
+
+function removeInlinedPartialImports(
+  nodes: Content[],
+  filePath: string,
+  partialsDir: string,
+  inlinedComponents: Set<string>,
+  report: (message: string) => void,
+): void {
+  for (let index = nodes.length - 1; index >= 0; index--) {
+    const node = nodes[index];
+    if (node.type !== "mdxjsEsm") continue;
+
+    const mdxNode = node as MdxjsEsm;
+    const code = typeof mdxNode.value === "string" ? mdxNode.value : "";
+    if (!isImportOnly(code)) continue;
+
+    const { code: nextCode, removed } = removeInlinedImportStatements(
+      code,
+      filePath,
+      partialsDir,
+      inlinedComponents,
+    );
+    if (!removed) continue;
+
+    if (nextCode.trim().length === 0) {
+      nodes.splice(index, 1);
+      continue;
+    }
+
+    const estree = parseEstree(nextCode, report, filePath);
+    if (!estree) continue;
+
+    mdxNode.value = nextCode;
+    setEstree(mdxNode, estree);
+  }
+}
+
+function removeInlinedImportStatements(
+  code: string,
+  filePath: string,
+  partialsDir: string,
+  inlinedComponents: Set<string>,
+): { code: string; removed: boolean } {
+  let removed = false;
+  const importStatementRegex =
+    /(^|\n)([ \t]*import\s+([\w$]+)\s+from\s+['"]([^'"]+)['"];?)/g;
+
+  const nextCode = code.replace(
+    importStatementRegex,
+    (
+      match,
+      prefix: string,
+      _statement: string,
+      name: string,
+      source: string,
+    ) => {
+      const resolvedPath = resolvePartialPath(source, filePath, partialsDir);
+      if (
+        !inlinedComponents.has(name) ||
+        !resolvedPath ||
+        !isWithinPartials(resolvedPath, partialsDir)
+      ) {
+        return match;
+      }
+
+      removed = true;
+      return prefix;
+    },
+  );
+
+  return { code: nextCode.replace(/\n{3,}/g, "\n\n"), removed };
 }
 
 type ImportDisposition = "drop" | "hoist" | "keep";
@@ -445,25 +537,24 @@ function applyPropsSubstitutions(
         if (result.updated) {
           const estree = parseEstree(result.value, report, partialPath);
           if (estree) {
-            if (node.type === "mdxTextExpression") {
-              const staticText = extractStaticText(estree);
-              if (
-                staticText != null &&
-                parent &&
-                typeof index === "number" &&
-                "children" in parent &&
-                Array.isArray(parent.children)
-              ) {
-                const replacement: Content = {
-                  type: "text",
-                  value: staticText,
-                };
-                const position = (node as { position?: Content["position"] })
-                  .position;
-                if (position) replacement.position = position;
-                parent.children[index] = replacement;
-                return index;
-              }
+            const staticText = extractStaticText(estree);
+            if (
+              staticText != null &&
+              canReplaceExpressionWithText(node, parent) &&
+              parent &&
+              typeof index === "number" &&
+              "children" in parent &&
+              Array.isArray(parent.children)
+            ) {
+              const replacement: Content = {
+                type: "text",
+                value: staticText,
+              };
+              const position = (node as { position?: Content["position"] })
+                .position;
+              if (position) replacement.position = position;
+              parent.children[index] = replacement;
+              return index;
             }
 
             exprNode.value = result.value;
@@ -515,6 +606,16 @@ function applyPropsSubstitutions(
       }
     }
   });
+}
+
+function canReplaceExpressionWithText(
+  node: { type: string },
+  parent: { type?: string } | undefined,
+): boolean {
+  if (node.type === "mdxTextExpression") return true;
+  return (
+    parent?.type === "mdxJsxFlowElement" || parent?.type === "mdxJsxTextElement"
+  );
 }
 
 function parseEstree(

--- a/src/utils/remark-inline-partials.ts
+++ b/src/utils/remark-inline-partials.ts
@@ -28,7 +28,7 @@ interface InlinePartialsOptions {
 interface InlineResult {
   contentNodes: Content[];
   hoistedImports: MdxjsEsm[];
-  inlinedComponents: Set<string>;
+  consumedPartialImports: Set<string>;
 }
 
 interface CachedPartial {
@@ -42,9 +42,58 @@ interface InlineState {
   report: (message: string) => void;
 }
 
-interface ImportInfo {
-  name: string;
+interface PartialImportBinding {
+  id: string;
+  resolvedPath: string;
+}
+
+interface ImportDeclarationInfo {
   source: string;
+  resolvedPath: string | null;
+  isPartial: boolean;
+  defaultLocalName: string | null;
+  localNames: string[];
+  start: number;
+  end: number;
+  sourceStart: number;
+  sourceEnd: number;
+}
+
+interface ExistingImports {
+  values: Set<string>;
+  keys: Set<string>;
+}
+
+interface ImportSpecifierLike {
+  type?: string;
+  local?: {
+    name?: string;
+  };
+}
+
+interface ImportDeclarationLike {
+  type?: string;
+  source?: {
+    value?: unknown;
+    start?: number;
+    end?: number;
+  };
+  specifiers?: ImportSpecifierLike[];
+  start?: number;
+  end?: number;
+}
+
+interface ProgramLike {
+  type?: string;
+  body?: unknown[];
+}
+
+interface NodeLike {
+  type?: string;
+  name?: string;
+  computed?: boolean;
+  shorthand?: boolean;
+  [key: string]: unknown;
 }
 
 interface PropsMap {
@@ -77,43 +126,16 @@ export const remarkInlinePartials: Plugin<[InlinePartialsOptions?], Root> = (
     };
 
     const state: InlineState = { partialsDir, cache, report };
-    const existingImportValues = new Set<string>();
-    const existingImportKeys = new Set<string>();
-
-    for (const child of tree.children) {
-      if (child.type === "mdxjsEsm" && typeof child.value === "string") {
-        existingImportValues.add(child.value);
-        for (const entry of extractDefaultImports(child.value)) {
-          existingImportKeys.add(`${entry.name}::${entry.source}`);
-        }
-      }
-    }
-
-    const { hoistedImports, inlinedComponents } = inlineTree(
-      tree,
-      file.path,
-      state,
-      [],
-      false,
-    );
-
-    if (inlinedComponents.size > 0) {
-      const removableInlinedComponents = new Set(
-        [...inlinedComponents].filter(
-          (name) => !hasRemainingIdentifierReference(tree, name, state.report),
-        ),
-      );
-      removeInlinedPartialImports(
-        tree.children as Content[],
-        file.path,
-        state.partialsDir,
-        removableInlinedComponents,
-        state.report,
-      );
-    }
+    const { hoistedImports } = inlineTree(tree, file.path, state, [], false);
 
     if (hoistedImports.length === 0) return;
 
+    const existingImports = collectExistingImports(
+      tree.children as Content[],
+      file.path,
+      state.partialsDir,
+      state.report,
+    );
     const uniqueImports: MdxjsEsm[] = [];
     for (const node of hoistedImports) {
       const value = node.value;
@@ -122,20 +144,14 @@ export const remarkInlinePartials: Plugin<[InlinePartialsOptions?], Root> = (
         continue;
       }
 
-      const entries = extractDefaultImports(value);
-      if (entries.length > 0) {
-        const hasDuplicate = entries.some((entry) =>
-          existingImportKeys.has(`${entry.name}::${entry.source}`),
-        );
-        if (hasDuplicate) continue;
-
-        for (const entry of entries) {
-          existingImportKeys.add(`${entry.name}::${entry.source}`);
-        }
+      const importKeys = collectImportKeys(value, file.path, state.partialsDir);
+      if (importKeys.some((key) => existingImports.keys.has(key))) continue;
+      for (const key of importKeys) {
+        existingImports.keys.add(key);
       }
 
-      if (existingImportValues.has(value)) continue;
-      existingImportValues.add(value);
+      if (existingImports.values.has(value)) continue;
+      existingImports.values.add(value);
       uniqueImports.push(node);
     }
 
@@ -156,42 +172,66 @@ function inlineTree(
   stack: string[],
   extractImports: boolean,
 ): InlineResult {
-  const importMap = collectPartialImports(tree, filePath, state.partialsDir);
+  const importMap = collectPartialImports(
+    tree,
+    filePath,
+    state.partialsDir,
+    state.report,
+  );
   const hoistedImports: MdxjsEsm[] = [];
-  const inlinedComponents = new Set<string>();
+  const consumedPartialImports = new Set<string>();
 
   visit(tree, "mdxJsxFlowElement", (node: MdxJsxFlowElement, index, parent) => {
     if (!parent || typeof index !== "number") return;
     if (!node.name) return;
 
-    const partialPath = importMap.get(node.name);
-    if (!partialPath) return;
+    const partialImport = importMap.get(node.name);
+    if (!partialImport) return;
 
     const propsMap = extractProps(node);
-    const result = loadPartial(partialPath, state, stack, propsMap);
+    const result = loadPartial(
+      partialImport.resolvedPath,
+      state,
+      stack,
+      propsMap,
+    );
     if (!result) return;
 
-    inlinedComponents.add(node.name);
+    consumedPartialImports.add(partialImport.id);
     hoistedImports.push(...result.hoistedImports);
     parent.children.splice(index, 1, ...result.contentNodes);
 
     return index + result.contentNodes.length;
   });
 
+  if (consumedPartialImports.size > 0) {
+    pruneConsumedPartialImports(
+      tree.children as Content[],
+      filePath,
+      state.partialsDir,
+      consumedPartialImports,
+      collectLiveReferences(tree, state.report),
+      state.report,
+    );
+  }
+
   let contentNodes = tree.children as Content[];
 
   if (extractImports) {
+    const liveReferences = collectLiveReferences(tree, state.report);
     const extracted = extractImportNodes(
       contentNodes,
       filePath,
       state.partialsDir,
+      liveReferences,
+      state.report,
     );
     contentNodes = extracted.contentNodes;
     hoistedImports.push(...extracted.hoistedImports);
     tree.children = contentNodes as Content[];
   }
 
-  return { contentNodes, hoistedImports, inlinedComponents };
+  return { contentNodes, hoistedImports, consumedPartialImports };
 }
 
 function loadPartial(
@@ -239,7 +279,7 @@ function loadPartial(
   return {
     contentNodes: result.contentNodes,
     hoistedImports: result.hoistedImports,
-    inlinedComponents: result.inlinedComponents,
+    consumedPartialImports: result.consumedPartialImports,
   };
 }
 
@@ -247,22 +287,36 @@ function collectPartialImports(
   tree: Root,
   filePath: string,
   partialsDir: string,
-): Map<string, string> {
-  const imports = new Map<string, string>();
+  report: (message: string) => void,
+): Map<string, PartialImportBinding> {
+  const imports = new Map<string, PartialImportBinding>();
 
   visit(tree, "mdxjsEsm", (node: MdxjsEsm) => {
     const code = typeof node.value === "string" ? node.value : "";
-    const entries = extractDefaultImports(code);
+    const declarations = collectImportDeclarations(
+      code,
+      filePath,
+      partialsDir,
+      report,
+    );
+    if (!declarations) return;
 
-    for (const entry of entries) {
-      const resolvedPath = resolvePartialPath(
-        entry.source,
-        filePath,
-        partialsDir,
-      );
-      if (!resolvedPath) continue;
-      if (!isWithinPartials(resolvedPath, partialsDir)) continue;
-      imports.set(entry.name, resolvedPath);
+    for (const declaration of declarations) {
+      if (
+        !declaration.defaultLocalName ||
+        !declaration.resolvedPath ||
+        !declaration.isPartial
+      ) {
+        continue;
+      }
+
+      imports.set(declaration.defaultLocalName, {
+        id: importBindingId(
+          declaration.defaultLocalName,
+          declaration.resolvedPath,
+        ),
+        resolvedPath: declaration.resolvedPath,
+      });
     }
   });
 
@@ -273,6 +327,8 @@ function extractImportNodes(
   nodes: Content[],
   filePath: string,
   partialsDir: string,
+  liveReferences: Set<string>,
+  report: (message: string) => void,
 ): InlineResult {
   const contentNodes: Content[] = [];
   const hoistedImports: MdxjsEsm[] = [];
@@ -285,29 +341,45 @@ function extractImportNodes(
 
     const mdxNode = node as MdxjsEsm;
     const code = typeof mdxNode.value === "string" ? mdxNode.value : "";
-    if (!isImportOnly(code)) {
+    const declarations = collectImportDeclarations(
+      code,
+      filePath,
+      partialsDir,
+      report,
+    );
+    if (!declarations) {
       contentNodes.push(mdxNode);
       continue;
     }
 
-    const disposition = getImportDisposition(code, filePath, partialsDir);
-    if (disposition === "keep") {
-      contentNodes.push(mdxNode);
+    const hoistedDeclarations = declarations.filter((declaration) =>
+      shouldHoistExtractedImport(declaration, liveReferences),
+    );
+    if (hoistedDeclarations.length === 0) {
       continue;
     }
-    if (disposition === "hoist") {
-      hoistedImports.push(mdxNode);
-    }
+
+    hoistedImports.push(
+      cloneImportNodeWithDeclarations(
+        mdxNode,
+        code,
+        hoistedDeclarations,
+        partialsDir,
+        report,
+        filePath,
+      ),
+    );
   }
 
-  return { contentNodes, hoistedImports, inlinedComponents: new Set() };
+  return { contentNodes, hoistedImports, consumedPartialImports: new Set() };
 }
 
-function removeInlinedPartialImports(
+function pruneConsumedPartialImports(
   nodes: Content[],
   filePath: string,
   partialsDir: string,
-  inlinedComponents: Set<string>,
+  consumedPartialImports: Set<string>,
+  liveReferences: Set<string>,
   report: (message: string) => void,
 ): void {
   for (let index = nodes.length - 1; index >= 0; index--) {
@@ -316,151 +388,39 @@ function removeInlinedPartialImports(
 
     const mdxNode = node as MdxjsEsm;
     const code = typeof mdxNode.value === "string" ? mdxNode.value : "";
-    if (!isImportOnly(code)) continue;
-
-    const { code: nextCode, removed } = removeInlinedImportStatements(
+    const declarations = collectImportDeclarations(
       code,
       filePath,
       partialsDir,
-      inlinedComponents,
+      report,
     );
-    if (!removed) continue;
+    if (!declarations) continue;
 
-    if (nextCode.trim().length === 0) {
+    const keptDeclarations = declarations.filter((declaration) =>
+      shouldKeepImportDeclaration(
+        declaration,
+        consumedPartialImports,
+        liveReferences,
+      ),
+    );
+    if (keptDeclarations.length === declarations.length) continue;
+
+    if (keptDeclarations.length === 0) {
       nodes.splice(index, 1);
       continue;
     }
 
+    const nextCode = renderImportDeclarations(
+      code,
+      keptDeclarations,
+      partialsDir,
+    );
     const estree = parseEstree(nextCode, report, filePath);
     if (!estree) continue;
 
     mdxNode.value = nextCode;
     setEstree(mdxNode, estree);
   }
-}
-
-function removeInlinedImportStatements(
-  code: string,
-  filePath: string,
-  partialsDir: string,
-  inlinedComponents: Set<string>,
-): { code: string; removed: boolean } {
-  let removed = false;
-  const importStatementRegex =
-    /(^|\n)([ \t]*import\s+([\w$]+)\s+from\s+['"]([^'"]+)['"];?)/g;
-
-  const nextCode = code.replace(
-    importStatementRegex,
-    (
-      match,
-      prefix: string,
-      _statement: string,
-      name: string,
-      source: string,
-    ) => {
-      const resolvedPath = resolvePartialPath(source, filePath, partialsDir);
-      if (
-        !inlinedComponents.has(name) ||
-        !resolvedPath ||
-        !isWithinPartials(resolvedPath, partialsDir)
-      ) {
-        return match;
-      }
-
-      removed = true;
-      return prefix;
-    },
-  );
-
-  return { code: nextCode.replace(/\n{3,}/g, "\n\n"), removed };
-}
-
-function hasRemainingIdentifierReference(
-  tree: Root,
-  name: string,
-  report: (message: string) => void,
-): boolean {
-  let found = false;
-
-  visit(tree, (node) => {
-    if (found) return false;
-
-    if (
-      (node.type === "mdxJsxFlowElement" ||
-        node.type === "mdxJsxTextElement") &&
-      (node as MdxJsxFlowElement | MdxJsxTextElement).name === name
-    ) {
-      found = true;
-      return false;
-    }
-
-    if (node.type === "mdxjsEsm") {
-      const code = (node as MdxjsEsm).value;
-      if (typeof code !== "string" || isImportOnly(code)) return;
-
-      const estree = parseEstree(code, report, "MDX module");
-      if (estree && estreeHasIdentifierReference(estree, name)) {
-        found = true;
-        return false;
-      }
-      return;
-    }
-
-    if (
-      node.type === "mdxTextExpression" ||
-      node.type === "mdxFlowExpression"
-    ) {
-      const value = (node as { value?: string }).value;
-      if (typeof value !== "string") return;
-
-      const estree = parseEstree(value, report, "MDX expression");
-      if (estree && estreeHasIdentifierReference(estree, name)) {
-        found = true;
-        return false;
-      }
-      return;
-    }
-
-    if (
-      node.type === "mdxJsxFlowElement" ||
-      node.type === "mdxJsxTextElement"
-    ) {
-      const jsxNode = node as MdxJsxFlowElement | MdxJsxTextElement;
-      for (const attribute of jsxNode.attributes ?? []) {
-        if (attribute.type === "mdxJsxExpressionAttribute") {
-          const estree = getExpressionAttributeEstree(
-            attribute as MdxJsxExpressionAttribute,
-            report,
-          );
-          if (estree && estreeHasIdentifierReference(estree, name)) {
-            found = true;
-            return false;
-          }
-          continue;
-        }
-
-        if (
-          attribute.type !== "mdxJsxAttribute" ||
-          typeof attribute.value === "string" ||
-          !attribute.value
-        ) {
-          continue;
-        }
-
-        const estree = parseEstree(
-          attribute.value.value,
-          report,
-          "MDX attribute expression",
-        );
-        if (estree && estreeHasIdentifierReference(estree, name)) {
-          found = true;
-          return false;
-        }
-      }
-    }
-  });
-
-  return found;
 }
 
 function getExpressionAttributeEstree(
@@ -481,26 +441,104 @@ function getExpressionAttributeEstree(
   return parseEstree(value, report, "MDX expression attribute");
 }
 
-function estreeHasIdentifierReference(estree: unknown, name: string): boolean {
-  const stack: unknown[] = [estree];
+function collectLiveReferences(
+  tree: Root,
+  report: (message: string) => void,
+): Set<string> {
+  const references = new Set<string>();
+
+  visit(tree, (node) => {
+    if (
+      (node.type === "mdxJsxFlowElement" ||
+        node.type === "mdxJsxTextElement") &&
+      (node as MdxJsxFlowElement | MdxJsxTextElement).name
+    ) {
+      references.add(
+        (node as MdxJsxFlowElement | MdxJsxTextElement).name ?? "",
+      );
+    }
+
+    if (node.type === "mdxjsEsm") {
+      const code = (node as MdxjsEsm).value;
+      if (typeof code !== "string") return;
+
+      const estree = parseEstree(code, report, "MDX module");
+      if (estree) addEstreeIdentifierReferences(estree, references);
+      return;
+    }
+
+    if (
+      node.type === "mdxTextExpression" ||
+      node.type === "mdxFlowExpression"
+    ) {
+      const value = (node as { value?: string }).value;
+      if (typeof value !== "string") return;
+
+      const estree = parseEstree(value, report, "MDX expression");
+      if (estree) addEstreeIdentifierReferences(estree, references);
+      return;
+    }
+
+    if (
+      node.type === "mdxJsxFlowElement" ||
+      node.type === "mdxJsxTextElement"
+    ) {
+      const jsxNode = node as MdxJsxFlowElement | MdxJsxTextElement;
+      for (const attribute of jsxNode.attributes ?? []) {
+        if (attribute.type === "mdxJsxExpressionAttribute") {
+          const estree = getExpressionAttributeEstree(
+            attribute as MdxJsxExpressionAttribute,
+            report,
+          );
+          if (estree) addEstreeIdentifierReferences(estree, references);
+          continue;
+        }
+
+        if (
+          attribute.type !== "mdxJsxAttribute" ||
+          typeof attribute.value === "string" ||
+          !attribute.value
+        ) {
+          continue;
+        }
+
+        const estree = parseEstree(
+          attribute.value.value,
+          report,
+          "MDX attribute expression",
+        );
+        if (estree) addEstreeIdentifierReferences(estree, references);
+      }
+    }
+  });
+
+  references.delete("");
+  return references;
+}
+
+function addEstreeIdentifierReferences(
+  estree: unknown,
+  references: Set<string>,
+): void {
+  const stack: Array<{ node: unknown; parent?: NodeLike; key?: string }> = [
+    { node: estree },
+  ];
 
   while (stack.length > 0) {
-    const current = stack.pop();
+    const currentEntry = stack.pop();
+    if (!currentEntry) continue;
+    const current = currentEntry.node;
     if (!current || typeof current !== "object") continue;
 
-    const node = current as {
-      type?: string;
-      name?: string;
-      [key: string]: unknown;
-    };
+    const node = current as NodeLike;
+    if (node.type === "ImportDeclaration") continue;
+
     if (
       (node.type === "Identifier" || node.type === "JSXIdentifier") &&
-      node.name === name
+      node.name &&
+      isReferenceIdentifier(node, currentEntry.parent, currentEntry.key)
     ) {
-      return true;
-    }
-    if (node.type === "ImportDeclaration") {
-      continue;
+      references.add(node.name);
     }
 
     for (const [key, value] of Object.entries(node)) {
@@ -514,71 +552,269 @@ function estreeHasIdentifierReference(estree: unknown, name: string): boolean {
         continue;
       }
       if (Array.isArray(value)) {
-        stack.push(...value);
+        for (const item of value) {
+          stack.push({ node: item, parent: node, key });
+        }
       } else if (value && typeof value === "object") {
-        stack.push(value);
+        stack.push({ node: value, parent: node, key });
       }
     }
   }
-
-  return false;
 }
 
-type ImportDisposition = "drop" | "hoist" | "keep";
+function isReferenceIdentifier(
+  node: NodeLike,
+  parent: NodeLike | undefined,
+  key: string | undefined,
+): boolean {
+  if (!parent) return true;
+  if (key === "id" && isBindingParent(parent)) return false;
+  if (key === "params") return false;
+  if (key === "local" && parent.type?.startsWith("Import")) return false;
+  if (key === "label") return false;
+  if (key === "property" && parent.type === "MemberExpression") {
+    return parent.computed === true;
+  }
+  if (key === "key" && parent.computed !== true) {
+    return parent.shorthand === true && node.type === "Identifier";
+  }
+  return true;
+}
 
-function getImportDisposition(
-  code: string,
+function isBindingParent(parent: NodeLike): boolean {
+  return (
+    parent.type === "VariableDeclarator" ||
+    parent.type === "FunctionDeclaration" ||
+    parent.type === "FunctionExpression" ||
+    parent.type === "ClassDeclaration" ||
+    parent.type === "ClassExpression"
+  );
+}
+
+function shouldKeepImportDeclaration(
+  declaration: ImportDeclarationInfo,
+  consumedPartialImports: Set<string>,
+  liveReferences: Set<string>,
+): boolean {
+  if (
+    !declaration.isPartial ||
+    !declaration.defaultLocalName ||
+    !declaration.resolvedPath
+  ) {
+    return true;
+  }
+
+  if (declaration.localNames.length > 1) return true;
+
+  const id = importBindingId(
+    declaration.defaultLocalName,
+    declaration.resolvedPath,
+  );
+  if (!consumedPartialImports.has(id)) return true;
+  return liveReferences.has(declaration.defaultLocalName);
+}
+
+function shouldHoistExtractedImport(
+  declaration: ImportDeclarationInfo,
+  liveReferences: Set<string>,
+): boolean {
+  if (!declaration.isPartial) return true;
+  return declaration.localNames.some((name) => liveReferences.has(name));
+}
+
+function collectExistingImports(
+  nodes: Content[],
   filePath: string,
   partialsDir: string,
-): ImportDisposition {
-  const sources = extractImportSources(code);
-  if (sources.length === 0) return "keep";
+  report: (message: string) => void,
+): ExistingImports {
+  const values = new Set<string>();
+  const keys = new Set<string>();
 
-  for (const source of sources) {
-    const resolvedPath = resolvePartialPath(source, filePath, partialsDir);
-    if (!resolvedPath || !isWithinPartials(resolvedPath, partialsDir)) {
-      return "hoist";
+  for (const node of nodes) {
+    if (node.type !== "mdxjsEsm") continue;
+    const value = (node as MdxjsEsm).value;
+    if (typeof value !== "string") continue;
+
+    values.add(value);
+    for (const key of collectImportKeys(value, filePath, partialsDir, report)) {
+      keys.add(key);
     }
   }
 
-  return "drop";
+  return { values, keys };
 }
 
-function extractDefaultImports(code: string): ImportInfo[] {
-  const imports: ImportInfo[] = [];
-  const regex = /import\s+([\w$]+)\s+from\s+['"]([^'"]+)['"]/g;
+function collectImportKeys(
+  code: string,
+  filePath: string,
+  partialsDir: string,
+  report?: (message: string) => void,
+): string[] {
+  const declarations = collectImportDeclarations(
+    code,
+    filePath,
+    partialsDir,
+    report,
+  );
+  if (!declarations) return [];
 
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(code)) !== null) {
-    imports.push({ name: match[1], source: match[2] });
-  }
-
-  return imports;
+  return declarations.flatMap((declaration) => {
+    const importTarget = declaration.resolvedPath ?? declaration.source;
+    if (declaration.localNames.length === 0) {
+      return [`bare::${importTarget}`];
+    }
+    return declaration.localNames.map(
+      (localName) => `${localName}::${importTarget}`,
+    );
+  });
 }
 
-function extractImportSources(code: string): string[] {
-  const sources: string[] = [];
-  const fromRegex = /import\s+[\s\S]*?\s+from\s+['"]([^'"]+)['"]/g;
-  const bareRegex = /import\s+['"]([^'"]+)['"]/g;
+function collectImportDeclarations(
+  code: string,
+  filePath: string,
+  partialsDir: string,
+  report?: (message: string) => void,
+): ImportDeclarationInfo[] | null {
+  if (!code.trim().startsWith("import")) return null;
 
-  let match: RegExpExecArray | null;
-  while ((match = fromRegex.exec(code)) !== null) {
-    sources.push(match[1]);
+  const estree = report
+    ? parseEstree(code, report, filePath)
+    : parseEstreeQuietly(code);
+  if (!estree || typeof estree !== "object") return null;
+
+  const program = estree as ProgramLike;
+  if (program.type !== "Program" || !Array.isArray(program.body)) return null;
+  if (program.body.length === 0) return null;
+  if (
+    program.body.some(
+      (statement) =>
+        !statement ||
+        typeof statement !== "object" ||
+        (statement as ImportDeclarationLike).type !== "ImportDeclaration",
+    )
+  ) {
+    return null;
   }
 
-  while ((match = bareRegex.exec(code)) !== null) {
-    sources.push(match[1]);
+  const declarations: ImportDeclarationInfo[] = [];
+  for (const statement of program.body) {
+    const declaration = createImportDeclarationInfo(
+      statement as ImportDeclarationLike,
+      filePath,
+      partialsDir,
+    );
+    if (!declaration) return null;
+    declarations.push(declaration);
   }
 
-  return sources;
+  return declarations;
 }
 
-function isImportOnly(code: string): boolean {
-  const trimmed = code.trim();
-  if (!trimmed.startsWith("import")) return false;
+function createImportDeclarationInfo(
+  declaration: ImportDeclarationLike,
+  filePath: string,
+  partialsDir: string,
+): ImportDeclarationInfo | null {
+  const source =
+    typeof declaration.source?.value === "string"
+      ? declaration.source.value
+      : null;
+  if (
+    !source ||
+    typeof declaration.start !== "number" ||
+    typeof declaration.end !== "number" ||
+    typeof declaration.source.start !== "number" ||
+    typeof declaration.source.end !== "number"
+  ) {
+    return null;
+  }
 
-  const stripped = trimmed.replace(/^import[\s\S]*?;?$/gm, "");
-  return stripped.trim().length === 0;
+  const localNames: string[] = [];
+  let defaultLocalName: string | null = null;
+  for (const specifier of declaration.specifiers ?? []) {
+    const localName = specifier.local?.name;
+    if (!localName) continue;
+    localNames.push(localName);
+    if (specifier.type === "ImportDefaultSpecifier") {
+      defaultLocalName = localName;
+    }
+  }
+
+  const resolvedPath = resolvePartialPath(source, filePath, partialsDir);
+  const isPartial = Boolean(
+    resolvedPath && isWithinPartials(resolvedPath, partialsDir),
+  );
+
+  return {
+    source,
+    resolvedPath,
+    isPartial,
+    defaultLocalName,
+    localNames,
+    start: declaration.start,
+    end: declaration.end,
+    sourceStart: declaration.source.start,
+    sourceEnd: declaration.source.end,
+  };
+}
+
+function cloneImportNodeWithDeclarations(
+  node: MdxjsEsm,
+  code: string,
+  declarations: ImportDeclarationInfo[],
+  partialsDir: string,
+  report: (message: string) => void,
+  filePath: string,
+): MdxjsEsm {
+  const clone = cloneValue(node) as MdxjsEsm;
+  const nextCode = renderImportDeclarations(code, declarations, partialsDir);
+  clone.value = nextCode;
+
+  const estree = parseEstree(nextCode, report, filePath);
+  if (estree) setEstree(clone, estree);
+
+  return clone;
+}
+
+function renderImportDeclarations(
+  code: string,
+  declarations: ImportDeclarationInfo[],
+  partialsDir: string,
+): string {
+  return declarations
+    .map((declaration) => {
+      const rawDeclaration = code.slice(declaration.start, declaration.end);
+      const hoistedSource = getHoistedImportSource(declaration, partialsDir);
+      if (!hoistedSource || hoistedSource === declaration.source) {
+        return rawDeclaration;
+      }
+
+      const sourceStart = declaration.sourceStart - declaration.start;
+      const sourceEnd = declaration.sourceEnd - declaration.start;
+      return [
+        rawDeclaration.slice(0, sourceStart),
+        JSON.stringify(hoistedSource),
+        rawDeclaration.slice(sourceEnd),
+      ].join("");
+    })
+    .join("\n");
+}
+
+function getHoistedImportSource(
+  declaration: ImportDeclarationInfo,
+  partialsDir: string,
+): string | null {
+  if (!declaration.isPartial || !declaration.resolvedPath) return null;
+  const relativePath = relative(partialsDir, declaration.resolvedPath).replace(
+    /\\/g,
+    "/",
+  );
+  return `@partials/${relativePath}`;
+}
+
+function importBindingId(localName: string, resolvedPath: string): string {
+  return `${localName}::${resolvedPath}`;
 }
 
 function resolvePartialPath(
@@ -789,6 +1025,17 @@ function parseEstree(
         error instanceof Error ? error.message : String(error)
       }`,
     );
+    return null;
+  }
+}
+
+function parseEstreeQuietly(value: string): unknown | null {
+  try {
+    return AcornParser.parse(value, {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    });
+  } catch {
     return null;
   }
 }

--- a/src/utils/remark-inline-partials.ts
+++ b/src/utils/remark-inline-partials.ts
@@ -8,6 +8,7 @@ import type { MdxjsEsm } from "mdast-util-mdx";
 import type {
   MdxJsxAttribute,
   MdxJsxAttributeValueExpression,
+  MdxJsxExpressionAttribute,
   MdxJsxFlowElement,
   MdxJsxTextElement,
 } from "mdast-util-mdx-jsx";
@@ -426,6 +427,18 @@ function hasRemainingIdentifierReference(
     ) {
       const jsxNode = node as MdxJsxFlowElement | MdxJsxTextElement;
       for (const attribute of jsxNode.attributes ?? []) {
+        if (attribute.type === "mdxJsxExpressionAttribute") {
+          const estree = getExpressionAttributeEstree(
+            attribute as MdxJsxExpressionAttribute,
+            report,
+          );
+          if (estree && estreeHasIdentifierReference(estree, name)) {
+            found = true;
+            return false;
+          }
+          continue;
+        }
+
         if (
           attribute.type !== "mdxJsxAttribute" ||
           typeof attribute.value === "string" ||
@@ -448,6 +461,24 @@ function hasRemainingIdentifierReference(
   });
 
   return found;
+}
+
+function getExpressionAttributeEstree(
+  attribute: MdxJsxExpressionAttribute,
+  report: (message: string) => void,
+): unknown | null {
+  if (attribute.data?.estree) {
+    return attribute.data.estree;
+  }
+
+  const value = attribute.value.trim();
+  if (value.length === 0) return null;
+
+  if (value.startsWith("...")) {
+    return parseEstree(`({${value}})`, report, "MDX spread attribute");
+  }
+
+  return parseEstree(value, report, "MDX expression attribute");
 }
 
 function estreeHasIdentifierReference(estree: unknown, name: string): boolean {

--- a/src/utils/remark-inline-partials.ts
+++ b/src/utils/remark-inline-partials.ts
@@ -97,11 +97,16 @@ export const remarkInlinePartials: Plugin<[InlinePartialsOptions?], Root> = (
     );
 
     if (inlinedComponents.size > 0) {
+      const removableInlinedComponents = new Set(
+        [...inlinedComponents].filter(
+          (name) => !hasRemainingIdentifierReference(tree, name, state.report),
+        ),
+      );
       removeInlinedPartialImports(
         tree.children as Content[],
         file.path,
         state.partialsDir,
-        inlinedComponents,
+        removableInlinedComponents,
         state.report,
       );
     }
@@ -367,6 +372,125 @@ function removeInlinedImportStatements(
   );
 
   return { code: nextCode.replace(/\n{3,}/g, "\n\n"), removed };
+}
+
+function hasRemainingIdentifierReference(
+  tree: Root,
+  name: string,
+  report: (message: string) => void,
+): boolean {
+  let found = false;
+
+  visit(tree, (node) => {
+    if (found) return false;
+
+    if (
+      (node.type === "mdxJsxFlowElement" ||
+        node.type === "mdxJsxTextElement") &&
+      (node as MdxJsxFlowElement | MdxJsxTextElement).name === name
+    ) {
+      found = true;
+      return false;
+    }
+
+    if (node.type === "mdxjsEsm") {
+      const code = (node as MdxjsEsm).value;
+      if (typeof code !== "string" || isImportOnly(code)) return;
+
+      const estree = parseEstree(code, report, "MDX module");
+      if (estree && estreeHasIdentifierReference(estree, name)) {
+        found = true;
+        return false;
+      }
+      return;
+    }
+
+    if (
+      node.type === "mdxTextExpression" ||
+      node.type === "mdxFlowExpression"
+    ) {
+      const value = (node as { value?: string }).value;
+      if (typeof value !== "string") return;
+
+      const estree = parseEstree(value, report, "MDX expression");
+      if (estree && estreeHasIdentifierReference(estree, name)) {
+        found = true;
+        return false;
+      }
+      return;
+    }
+
+    if (
+      node.type === "mdxJsxFlowElement" ||
+      node.type === "mdxJsxTextElement"
+    ) {
+      const jsxNode = node as MdxJsxFlowElement | MdxJsxTextElement;
+      for (const attribute of jsxNode.attributes ?? []) {
+        if (
+          attribute.type !== "mdxJsxAttribute" ||
+          typeof attribute.value === "string" ||
+          !attribute.value
+        ) {
+          continue;
+        }
+
+        const estree = parseEstree(
+          attribute.value.value,
+          report,
+          "MDX attribute expression",
+        );
+        if (estree && estreeHasIdentifierReference(estree, name)) {
+          found = true;
+          return false;
+        }
+      }
+    }
+  });
+
+  return found;
+}
+
+function estreeHasIdentifierReference(estree: unknown, name: string): boolean {
+  const stack: unknown[] = [estree];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || typeof current !== "object") continue;
+
+    const node = current as {
+      type?: string;
+      name?: string;
+      [key: string]: unknown;
+    };
+    if (
+      (node.type === "Identifier" || node.type === "JSXIdentifier") &&
+      node.name === name
+    ) {
+      return true;
+    }
+    if (node.type === "ImportDeclaration") {
+      continue;
+    }
+
+    for (const [key, value] of Object.entries(node)) {
+      if (
+        key === "loc" ||
+        key === "range" ||
+        key === "start" ||
+        key === "end" ||
+        key === "position"
+      ) {
+        continue;
+      }
+      if (Array.isArray(value)) {
+        stack.push(...value);
+      } else if (value && typeof value === "object") {
+        stack.push(value);
+      }
+    }
+  }
+
+  return false;
 }
 
 type ImportDisposition = "drop" | "hoist" | "keep";


### PR DESCRIPTION
## 🔍 Problem

- Link-checked builds fail when reusable MDX partials with semantic links are also compiled with unresolved props.
- Prop substitution can leave quoted string expressions or `props.*` targets visible to link validation instead of the final page content.

## 🛠️ Solution

- Normalize static string prop substitutions into text nodes during partial expansion.
- Remove imports for partial components after inlining so validation runs against expanded page content.
- Add regression coverage for semantic links inside inlined partials.

## 💬 Review

- Focus on the `remark-inline-partials` AST handling around import removal and expression-to-text normalization.
- Tested with `bun run test:inline-partials`, targeted Biome, pre-push hooks, and the full link-checked Astro build.
