### PR TITLE
Document drop_matching and select_matching

### DIFF
--- a/src/content/docs/guides/transformation/filter-and-select-data.mdx
+++ b/src/content/docs/guides/transformation/filter-and-select-data.mdx
@@ -162,6 +162,29 @@ select price, tax=price * tax_rate, total=price * (1 + tax_rate)
 {price: 50, tax: 4.0, total: 54.0}
 ```
 
+### Selecting fields by name pattern
+
+The <Op>select</Op> operator requires explicit field names. When you need to
+shape a record value by matching field names, use <Fn>select_matching</Fn>:
+
+```tql
+from {
+  user_id: "u-123",
+  session_id: "s-456",
+  message: "login",
+}
+select identifiers = this.select_matching("_id$")
+```
+
+```tql
+{
+  identifiers: {
+    user_id: "u-123",
+    session_id: "s-456",
+  },
+}
+```
+
 ## Remove unwanted fields
 
 The <Op>drop</Op> operator removes specified fields,
@@ -195,6 +218,30 @@ drop internal_id, debug
 ```tql
 {id: 1, name: "alice"}
 {id: 2, name: "bob"}
+```
+
+### Dropping fields by name pattern
+
+Use <Fn>drop_matching</Fn> when you want to remove top-level fields from a
+record based on a regular expression:
+
+```tql
+from {
+  message: "login",
+  debug_trace: "abc",
+  debug_flags: ["verbose"],
+  user: "alice",
+}
+select cleaned = this.drop_matching("^debug_")
+```
+
+```tql
+{
+  cleaned: {
+    message: "login",
+    user: "alice",
+  },
+}
 ```
 
 ## Add computed fields
@@ -341,6 +388,8 @@ select method, path, duration = duration_ms.milliseconds()
 
 ## See also
 
+- <Fn>drop_matching</Fn>
+- <Fn>select_matching</Fn>
 - <Guide>transformation/transform-values</Guide>
 - <Guide>optimization/slice-and-sample-data</Guide>
 - <Guide>transformation/reshape-complex-data</Guide>

--- a/src/content/docs/guides/transformation/shape-records.mdx
+++ b/src/content/docs/guides/transformation/shape-records.mdx
@@ -111,7 +111,8 @@ with_tax = {
 
 ## Filter record fields
 
-Keep only specific fields:
+Keep explicit fields by constructing a new record. Use <Fn>select_matching</Fn>
+and <Fn>drop_matching</Fn> when field names follow a pattern:
 
 ```tql
 from {
@@ -123,8 +124,6 @@ from {
     api_key: "xyz123"
   }
 }
-// Note: filter_keys and select functions are not available
-// Manual field selection:
 public_info = {
   id: user.id,
   name: user.name,
@@ -134,6 +133,8 @@ contact = {
   name: user.name,
   email: user.email
 }
+credentials = user.select_matching("(password|api_key)$")
+safe_user = user.drop_matching("(password|api_key)$")
 ```
 
 ```tql
@@ -153,12 +154,28 @@ contact = {
   contact: {
     name: "Alice",
     email: "alice@example.com"
+  },
+  credentials: {
+    password: "secret",
+    api_key: "xyz123"
+  },
+  safe_user: {
+    id: 123,
+    name: "Alice",
+    email: "alice@example.com"
   }
 }
 ```
 
+The matching functions inspect only top-level field names on the record you
+call them on. They don't recurse into nested records.
+
 ## See Also
 
+- <Fn>drop_matching</Fn>
+- <Fn>keys</Fn>
+- <Fn>merge</Fn>
+- <Fn>select_matching</Fn>
 - <Guide>transformation/shape-lists</Guide>
 - <Guide>transformation/filter-and-select-data</Guide>
 - <Guide>transformation/transform-values</Guide>

--- a/src/content/docs/reference/functions.mdx
+++ b/src/content/docs/reference/functions.mdx
@@ -543,6 +543,10 @@ functions:
     description: 'Unflattens nested data.'
     example: 'unflatten(this)'
     path: 'reference/functions/unflatten'
+  - name: 'drop_matching'
+    description: 'Removes top-level fields from a record when their names match a regular expression.'
+    example: 'record.drop_matching("^debug_")'
+    path: 'reference/functions/drop_matching'
   - name: 'get'
     description: 'Gets a field from a record or an element from a list'
     example: 'xs.get(index, fallback)'
@@ -559,6 +563,10 @@ functions:
     description: 'Combines two records into a single record by merging their fields.'
     example: 'merge(foo, bar)'
     path: 'reference/functions/merge'
+  - name: 'select_matching'
+    description: 'Selects top-level fields from a record when their names match a regular expression.'
+    example: 'record.select_matching("^src_")'
+    path: 'reference/functions/select_matching'
   - name: 'sort'
     description: 'Sorts lists and record fields.'
     example: 'xs.sort()'
@@ -1695,6 +1703,14 @@ record.print_yaml()
 
 <CardGrid>
 
+<ReferenceCard title="drop_matching" description="Removes top-level fields from a record when their names match a regular expression." href="/reference/functions/drop_matching">
+
+```tql
+record.drop_matching("^debug_")
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="get" description="Gets a field from a record or an element from a list" href="/reference/functions/get">
 
 ```tql
@@ -1723,6 +1739,14 @@ record.keys()
 
 ```tql
 merge(foo, bar)
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="select_matching" description="Selects top-level fields from a record when their names match a regular expression." href="/reference/functions/select_matching">
+
+```tql
+record.select_matching("^src_")
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/functions/drop_matching.mdx
+++ b/src/content/docs/reference/functions/drop_matching.mdx
@@ -1,0 +1,87 @@
+---
+title: drop_matching
+category: Record
+example: 'record.drop_matching("^debug_")'
+---
+
+Removes top-level fields from a record when their names match a regular expression.
+
+```tql
+drop_matching(x:record, regex:string) -> record
+```
+
+## Description
+
+The `drop_matching` function returns a record with every top-level field from
+`x` whose field name does not match `regex`.
+
+Matching is partial by default. Use `^` and `$` anchors to match whole field
+names or prefixes. The function does not recurse into nested records; call it
+on the nested record if you want to drop fields there.
+
+The supported regular expression syntax is
+[RE2](https://github.com/google/re2/wiki/Syntax).
+
+### `x: record`
+
+The record whose fields you want to filter.
+
+### `regex: string`
+
+The regular expression to match against field names.
+
+## Examples
+
+### Remove fields by name
+
+```tql
+from {
+  name: "Alice",
+  email: "alice@example.com",
+  password: "secret",
+  api_key: "xyz123",
+}
+select public = this.drop_matching("^(password|api_key)$")
+```
+
+```tql
+{
+  public: {
+    name: "Alice",
+    email: "alice@example.com",
+  },
+}
+```
+
+### Separate matching fields from the rest
+
+```tql
+from {
+  foo: 1,
+  bar: 2,
+  baz: 3,
+}
+let $pattern = "^ba"
+select moved = this.select_matching($pattern),
+       rest = this.drop_matching($pattern)
+```
+
+```tql
+{
+  moved: {
+    bar: 2,
+    baz: 3,
+  },
+  rest: {
+    foo: 1,
+  },
+}
+```
+
+## See Also
+
+- <Op>drop</Op>
+- <Fn>select_matching</Fn>
+- <Fn>match_regex</Fn>
+- <Guide>transformation/shape-records</Guide>
+- <Guide>transformation/filter-and-select-data</Guide>

--- a/src/content/docs/reference/functions/select_matching.mdx
+++ b/src/content/docs/reference/functions/select_matching.mdx
@@ -1,0 +1,85 @@
+---
+title: select_matching
+category: Record
+example: 'record.select_matching("^src_")'
+---
+
+Selects top-level fields from a record when their names match a regular expression.
+
+```tql
+select_matching(x:record, regex:string) -> record
+```
+
+## Description
+
+The `select_matching` function returns a record with every top-level field from
+`x` whose field name matches `regex`.
+
+Matching is partial by default. Use `^` and `$` anchors to match whole field
+names or prefixes. The function does not recurse into nested records; call it
+on the nested record if you want to select fields there.
+
+The supported regular expression syntax is
+[RE2](https://github.com/google/re2/wiki/Syntax).
+
+### `x: record`
+
+The record whose fields you want to filter.
+
+### `regex: string`
+
+The regular expression to match against field names.
+
+## Examples
+
+### Select fields by prefix
+
+```tql
+from {
+  src_ip: 1.2.3.4,
+  src_port: 443,
+  dst_ip: 5.6.7.8,
+  dst_port: 80,
+  proto: "tcp",
+}
+select endpoints = this.select_matching("^(src|dst)_")
+```
+
+```tql
+{
+  endpoints: {
+    src_ip: 1.2.3.4,
+    src_port: 443,
+    dst_ip: 5.6.7.8,
+    dst_port: 80,
+  },
+}
+```
+
+### Select fields by suffix
+
+```tql
+from {
+  user_id: "u-123",
+  session_id: "s-456",
+  message: "login",
+}
+select identifiers = this.select_matching("_id$")
+```
+
+```tql
+{
+  identifiers: {
+    user_id: "u-123",
+    session_id: "s-456",
+  },
+}
+```
+
+## See Also
+
+- <Op>select</Op>
+- <Fn>drop_matching</Fn>
+- <Fn>match_regex</Fn>
+- <Guide>transformation/shape-records</Guide>
+- <Guide>transformation/filter-and-select-data</Guide>


### PR DESCRIPTION
## 🔍 Problem

- `drop_matching` and `select_matching` exist in TQL but had no function reference pages.
- Related transformation guides still steered users toward manual record filtering.

## 🛠️ Solution

- Document both record functions, including partial RE2 field-name matching and top-level scope.
- Add function overview cards and update record/filtering guides with pattern-based examples.

## 💬 Review

- Focus on whether the examples describe the exact top-level matching semantics from the implementation.