### PR TITLE
Fix `every` operator docs to reflect input stopping

### DIFF
--- a/src/content/docs/reference/operators/every.mdx
+++ b/src/content/docs/reference/operators/every.mdx
@@ -15,16 +15,18 @@ every interval:duration { … }
 The `every` operator repeats running a pipeline indefinitely at a fixed
 interval. The first run starts directly when the outer pipeline itself starts.
 
-Every `interval`, the executor spawns a new sub-pipeline that runs to
-completion. If the sub-pipeline runs longer than `interval`, the next run
-starts immediately.
+Every `interval`, the executor spawns a new sub-pipeline. When the interval
+elapses, `every` stops the inputs of the running sub-pipeline, waits for it to
+finish processing, and then starts a new one. This means sub-pipelines with
+sink operators work as expected — events flow in for the duration of the
+interval, then the sub-pipeline flushes and restarts. Sub-pipelines without
+inputs (pure sources) must terminate on their own; if they run longer than
+`interval`, the next run starts immediately after.
 
-:::caution[Sub-pipelines must terminate on their own]
-`every` never stops a sub-pipeline — it only waits for it to finish. Operators
-that run indefinitely, such as <Op>summarize</Op> without a `frequency` option,
-will block `every` from ever starting the next iteration. For periodic
-aggregation use the `options={frequency}` parameter of <Op>summarize</Op>
-directly instead of wrapping it inside `every`.
+:::caution[Source sub-pipelines must terminate on their own]
+`every` stops inputs to a sub-pipeline but cannot stop operators that produce
+data indefinitely on their own. Source operators like <Op>subscribe</Op> inside
+an `every` block will prevent the next iteration from starting.
 :::
 
 ## Examples
@@ -46,18 +48,34 @@ enumerate
 // … continues like this
 ```
 
-### Aggregate metrics periodically with `summarize`
-
-Using `every` with <Op>summarize</Op> does not work as expected because
-`summarize` never terminates on its own — `every` would wait forever and the
-aggregation would never emit results.
-
-Instead, use the `options={frequency}` parameter of <Op>summarize</Op>:
+### Periodically flush buffered events to an HTTP endpoint
 
 ```tql
-from_tcp "127.0.0.1:5432" { read_json }
-summarize events=count(data), options={frequency: 5m}
+subscribe "event-stream"
+every 30s {
+  batch
+  to_http "https://example.org/api/ingest" {
+    write_json
+  }
+}
 ```
+
+Events flow into the sub-pipeline continuously. Every 30 seconds, `every` stops
+the input, causing <Op>batch</Op> to flush and <Op>to_http</Op> to send the
+accumulated batch. Then a new sub-pipeline starts.
+
+### Aggregate metrics periodically with `summarize`
+
+```tql
+subscribe "event-stream"
+every 5min {
+  summarize events=count(data)
+}
+```
+
+When the interval elapses, `every` stops the input, which causes
+<Op>summarize</Op> to emit its result. Then the sub-pipeline restarts for the
+next interval.
 
 ### Fetch the results from an API every 10 minutes
 

--- a/src/content/docs/reference/operators/to_http.mdx
+++ b/src/content/docs/reference/operators/to_http.mdx
@@ -149,6 +149,7 @@ a separate HTTP request:
 ```tql
 subscribe "stream-of-events"
 every 1m {
+  batch
   to_http "https://example.com/ingest" {
     write_ndjson
   }


### PR DESCRIPTION
## 🔍 Problem

The `every` operator documentation incorrectly stated that it "never stops a sub-pipeline." In reality, `every` stops the inputs of a running sub-pipeline when the interval elapses, making it usable with sink operators like `batch | to_http` and `summarize`.

## 🛠️ Solution

- Updated the description to explain that `every` stops inputs and waits for the sub-pipeline to finish before restarting.
- Narrowed the caution box to only warn about source sub-pipelines that produce data indefinitely.
- Added examples showing `every` with `batch | to_http` and `summarize`, prefixed with `subscribe` as a realistic event source.
- Removed inline `summarize`/`to_http` references from the parameter description prose.

## 💬 Review

Straightforward docs correction. The key behavioral distinction is: `every` stops *inputs* but cannot stop operators that *produce* data on their own.

<sub>
🎫 References TNZ-640
</sub>