### PR TITLE
Add CloudWatch integration diagram

### DIFF
--- a/src/content/docs/integrations/amazon/cloudwatch.excalidraw
+++ b/src/content/docs/integrations/amazon/cloudwatch.excalidraw
@@ -1,0 +1,1344 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://app.excalidraw.com",
+  "elements": [
+    {
+      "id": "rWT_aBpm6H5IV7MRz-pAB",
+      "type": "rectangle",
+      "x": 200,
+      "y": 560,
+      "width": 480,
+      "height": 240,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a0",
+      "roundness": null,
+      "seed": 910361425,
+      "version": 84,
+      "versionNonce": 1253649869,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "kFiNfoOTB5BA6QbRC7pJx"
+        }
+      ],
+      "updated": 1779275367397,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "kFiNfoOTB5BA6QbRC7pJx",
+      "type": "text",
+      "x": 267.9920196533203,
+      "y": 657.5,
+      "width": 344.0159606933594,
+      "height": 45,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a1",
+      "roundness": null,
+      "seed": 243822897,
+      "version": 120,
+      "versionNonce": 206302253,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779275367397,
+      "link": null,
+      "locked": false,
+      "text": "Amazon CloudWatch",
+      "fontSize": 36,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "rWT_aBpm6H5IV7MRz-pAB",
+      "originalText": "Amazon CloudWatch",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "type": "line",
+      "version": 11736,
+      "versionNonce": 79736451,
+      "index": "a2",
+      "isDeleted": true,
+      "id": "AraGYEXKAeN26ihRSvBlb",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 345.82835146847526,
+      "y": 654.0480133250035,
+      "strokeColor": "#000000",
+      "backgroundColor": "#e9ecef",
+      "width": 198.75038370286006,
+      "height": 104.90595206269951,
+      "seed": 2074419985,
+      "groupIds": [
+        "sv95OmN9tmDa0URZ_VBC_",
+        "TumEEEun7tLK1aJu31Jvw",
+        "EbjRNajUoYX4YTF8m0M8e",
+        "pHq3OHCVezQYadnc8BMTM"
+      ],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1779267232715,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -1.324836952554575,
+          39.37643332425167
+        ],
+        [
+          0.6513602504468881,
+          79.28734997084817
+        ],
+        [
+          0.03048213062829698,
+          88.31387046278067
+        ],
+        [
+          10.173352925160723,
+          92.21411834840423
+        ],
+        [
+          45.49539437067648,
+          95.51499096057685
+        ],
+        [
+          105.19964999846019,
+          96.54283338237994
+        ],
+        [
+          162.24311811682784,
+          94.9017323940509
+        ],
+        [
+          192.5507327299915,
+          90.97706906198576
+        ],
+        [
+          196.82521165854416,
+          87.6685367019091
+        ],
+        [
+          197.4255467503055,
+          80.4013508784451
+        ],
+        [
+          196.9543535096789,
+          6.651766113779976
+        ],
+        [
+          195.89213269809275,
+          -0.3162108072027902
+        ],
+        [
+          183.2085630283219,
+          -4.210658945181955
+        ],
+        [
+          156.49967208850467,
+          -6.466117234366914
+        ],
+        [
+          95.63371834175977,
+          -8.363118680319575
+        ],
+        [
+          46.834660150849146,
+          -7.231932446637444
+        ],
+        [
+          8.454532295650141,
+          -3.395086763947891
+        ],
+        [
+          -0.106803801208671,
+          -0.04764089633563165
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "polygon": false
+    },
+    {
+      "type": "ellipse",
+      "version": 12369,
+      "versionNonce": 667529005,
+      "index": "a3",
+      "isDeleted": true,
+      "id": "XsiZCVwRb_vrajOPdVe6M",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 343.20703125,
+      "y": 645.2578125,
+      "strokeColor": "#000000",
+      "backgroundColor": "#f8f9fa",
+      "width": 198.29166275118362,
+      "height": 20.55742599590228,
+      "seed": 1779472625,
+      "groupIds": [
+        "sv95OmN9tmDa0URZ_VBC_",
+        "TumEEEun7tLK1aJu31Jvw",
+        "EbjRNajUoYX4YTF8m0M8e",
+        "pHq3OHCVezQYadnc8BMTM"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779267232715,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "DgRoqtpiQcF_Bl7lX8Vpk",
+      "type": "text",
+      "x": 378.26107699893214,
+      "y": 680.921621301758,
+      "width": 131.17987060546875,
+      "height": 50,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dashed",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "pHq3OHCVezQYadnc8BMTM"
+      ],
+      "frameId": null,
+      "index": "a4",
+      "roundness": null,
+      "seed": 1263686353,
+      "version": 438,
+      "versionNonce": 1447945763,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1779267232715,
+      "link": null,
+      "locked": false,
+      "text": "Security Lake\nS3 Bucket",
+      "fontSize": 20,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Security Lake\nS3 Bucket",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "QnPb2rn9AmY4Cn_QmRiZ-",
+      "type": "arrow",
+      "x": -36.70790112187427,
+      "y": 682.480689669964,
+      "width": 170.87852050331384,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a5",
+      "roundness": null,
+      "seed": 1946276017,
+      "version": 173,
+      "versionNonce": 622196803,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "wiAK7qM9YE7tq2T8sOOhF"
+        }
+      ],
+      "updated": 1779275341664,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          170.87852050331384,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "shgqL_IKC5U5kcOYxMG8Q",
+        "mode": "orbit",
+        "fixedPoint": [
+          -0.27499999354838706,
+          0.5001
+        ]
+      },
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false,
+      "moveMidPointsWithElement": false
+    },
+    {
+      "id": "wiAK7qM9YE7tq2T8sOOhF",
+      "type": "text",
+      "x": 19.832824411492226,
+      "y": 632.4796584995781,
+      "width": 57.71200180053711,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a5V",
+      "roundness": null,
+      "seed": 904162115,
+      "version": 16,
+      "versionNonce": 380142755,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779275341550,
+      "link": null,
+      "locked": false,
+      "text": "HTTPS",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "QnPb2rn9AmY4Cn_QmRiZ-",
+      "originalText": "HTTPS",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "type": "line",
+      "version": 1312,
+      "versionNonce": 1304197389,
+      "isDeleted": false,
+      "id": "cFw57s37QVaadds4StMsU",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -200,
+      "y": 640.3778754933726,
+      "strokeColor": "#000000",
+      "backgroundColor": "#e9ecef",
+      "width": 160,
+      "height": 80,
+      "seed": 969314961,
+      "groupIds": [
+        "P5AuvkcSpnmakrjCxiLR1"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779275332613,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          39.67197250080198
+        ],
+        [
+          -1.4210854715202004e-14,
+          80
+        ],
+        [
+          160,
+          80
+        ],
+        [
+          160,
+          0
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "index": "a6",
+      "polygon": false
+    },
+    {
+      "type": "image",
+      "version": 3765,
+      "versionNonce": 1429023299,
+      "index": "a7",
+      "isDeleted": false,
+      "id": "b5yhlEZO9p6Lcz3Ruo-2E",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -133.8876101857578,
+      "y": 654.2008703228182,
+      "strokeColor": "transparent",
+      "backgroundColor": "#ffc9c9",
+      "width": 61.54214099463984,
+      "height": 50.681763172056336,
+      "seed": 1364727921,
+      "groupIds": [
+        "glbHC98h6UNykwZI8KNF2",
+        "P5AuvkcSpnmakrjCxiLR1"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779275332613,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "oFpAgVjMYs35NmakDi2h6",
+      "type": "image",
+      "x": 643.20703125,
+      "y": 525.2578125,
+      "width": 80,
+      "height": 80,
+      "angle": 0,
+      "strokeColor": "transparent",
+      "backgroundColor": "transparent",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a8",
+      "roundness": null,
+      "seed": 1820189265,
+      "version": 29,
+      "versionNonce": 1383190193,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1779105165102,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "742d5d90ef0c66f0eb94ebe98bc3e0e4bd7f64bc15be1a75044ab386ffccf0f9db2321e6d711ad071a8f0ed88c227264",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "NPU7HdSSPMZns7CSJiVhP",
+      "type": "arrow",
+      "x": 203.20703061286324,
+      "y": 681.6919068030336,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "186Kfu1utk7tfCFTkEAi_"
+      ],
+      "frameId": null,
+      "index": "a8V",
+      "roundness": null,
+      "seed": 2082590705,
+      "version": 373,
+      "versionNonce": 2001764611,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779275314414,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "shgqL_IKC5U5kcOYxMG8Q",
+      "type": "ellipse",
+      "x": 139.6706192524073,
+      "y": 672.4786896699641,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "186Kfu1utk7tfCFTkEAi_"
+      ],
+      "frameId": null,
+      "index": "a9",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 337947089,
+      "version": 358,
+      "versionNonce": 1152795821,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "id": "QnPb2rn9AmY4Cn_QmRiZ-",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1779275314414,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "3VlJS4wuacu2GVPf6osnY",
+      "type": "text",
+      "x": 94.64346467399315,
+      "y": 753.0086343753073,
+      "width": 70.1760025024414,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#ffec99",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "aB",
+      "roundness": null,
+      "seed": 1047611313,
+      "version": 107,
+      "versionNonce": 369086595,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1779267273548,
+      "link": null,
+      "locked": false,
+      "text": "Bulk API",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Bulk API",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "6w9z9-6yUUf5J1WGs1MoT",
+      "type": "arrow",
+      "x": 688.0938338719036,
+      "y": 681.471030445309,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "xMgREeWwwIqQ5W8eqGNtS"
+      ],
+      "frameId": null,
+      "index": "aC",
+      "roundness": null,
+      "seed": 1156170321,
+      "version": 437,
+      "versionNonce": 365204973,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779275302702,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "s-b-eDkm1hheDruD9We9K",
+      "type": "ellipse",
+      "x": 731.6302452323596,
+      "y": 672.2578133122395,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "xMgREeWwwIqQ5W8eqGNtS"
+      ],
+      "frameId": null,
+      "index": "aD",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 939479089,
+      "version": 422,
+      "versionNonce": 115985251,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "id": "ccbL8bQSbk-Lef02y9z40",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1779275302702,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "XZuvCanA0bu1nBmHds5eh",
+      "type": "image",
+      "x": 641.0497837567171,
+      "y": 523.7640617419906,
+      "width": 80,
+      "height": 80,
+      "angle": 0,
+      "strokeColor": "transparent",
+      "backgroundColor": "#a5d8ff",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "aE",
+      "roundness": null,
+      "seed": 498413137,
+      "version": 51,
+      "versionNonce": 2061415839,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779105651697,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "1e93f8048a3a2cc99ffc75709c25cfe0b713dac0c4f89c0258b9f49a18122d7b9356ced86cd49adea279bbd745be756c",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "NDKE0TKE34LAq0IcE79x6",
+      "type": "arrow",
+      "x": 197.05459573509611,
+      "y": 648.0514079681946,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "jykvW8VIz32CpdK54ntEg"
+      ],
+      "frameId": null,
+      "index": "aF",
+      "roundness": null,
+      "seed": 1554812493,
+      "version": 425,
+      "versionNonce": 1443674413,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1779274330567,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "Kx_sXqNo8Btnrj-UbbA84",
+      "type": "ellipse",
+      "x": 133.51818437464019,
+      "y": 638.838190835125,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "jykvW8VIz32CpdK54ntEg"
+      ],
+      "frameId": null,
+      "index": "aG",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 973028525,
+      "version": 410,
+      "versionNonce": 1763212323,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1779274330567,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "xJ1CfU-NAJW7Fdg5sTii8",
+      "type": "arrow",
+      "x": 195.66409174333748,
+      "y": 615.2787520493604,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "u7E7lyzftRuUmAJCWTt9Z"
+      ],
+      "frameId": null,
+      "index": "aH",
+      "roundness": null,
+      "seed": 837510445,
+      "version": 474,
+      "versionNonce": 802622349,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1779274330567,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "kiBOk5JdUKQ5MyHnWKBYT",
+      "type": "ellipse",
+      "x": 132.12768038288155,
+      "y": 606.0655349162909,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "u7E7lyzftRuUmAJCWTt9Z"
+      ],
+      "frameId": null,
+      "index": "aI",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 1929394061,
+      "version": 459,
+      "versionNonce": 630915011,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1779274330567,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "BwrwWugBzy7X77D9WXOZr",
+      "type": "arrow",
+      "x": 192.00357770142872,
+      "y": 581.1303324637688,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "yAgNcTYza4RSpr10sEDtN"
+      ],
+      "frameId": null,
+      "index": "aJ",
+      "roundness": null,
+      "seed": 1776369507,
+      "version": 462,
+      "versionNonce": 1432883693,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1779274330567,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "ZseZIpJnSUR58PBRjFhMn",
+      "type": "ellipse",
+      "x": 128.4671663409728,
+      "y": 571.9171153306993,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "yAgNcTYza4RSpr10sEDtN"
+      ],
+      "frameId": null,
+      "index": "aK",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 1860786947,
+      "version": 447,
+      "versionNonce": 575410019,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1779274330567,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "8VDOOxqmZlvSy10kM57Qi",
+      "type": "text",
+      "x": 116.5586127388708,
+      "y": 701.5503955891206,
+      "width": 75.72463550672902,
+      "height": 70.69140801138415,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "aL",
+      "roundness": null,
+      "seed": 1903831811,
+      "version": 187,
+      "versionNonce": 886984013,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779275424911,
+      "link": null,
+      "locked": false,
+      "text": "1. HLC\n2. NDJSON\n3. JSON\n4. Put",
+      "fontSize": 14.138281602276832,
+      "fontFamily": 5,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "1. HLC\n2. NDJSON\n3. JSON\n4. Put",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "hkZcWr6zhqqcp930UeD0J",
+      "type": "text",
+      "x": 698.6118165141231,
+      "y": 698.6652466199803,
+      "width": 64.92298922552175,
+      "height": 53.01855600853812,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "aM",
+      "roundness": null,
+      "seed": 2091669293,
+      "version": 359,
+      "versionNonce": 415783843,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779275429042,
+      "link": null,
+      "locked": false,
+      "text": "1. Live\n2. Search\n3. Replay",
+      "fontSize": 14.138281602276834,
+      "fontFamily": 5,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "1. Live\n2. Search\n3. Replay",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "type": "line",
+      "version": 1332,
+      "versionNonce": 1066760131,
+      "isDeleted": false,
+      "id": "SQf2vF_JGxTK8sVj_an8q",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 921.4896611218807,
+      "y": 640.0606515156895,
+      "strokeColor": "#000000",
+      "backgroundColor": "#e9ecef",
+      "width": 160,
+      "height": 80,
+      "seed": 1292785635,
+      "groupIds": [
+        "G9ZOnIRiEbfwpinL9rwGO"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779275387722,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -1.4896611218806584,
+          80
+        ],
+        [
+          118.51033887811936,
+          79.99999999999999
+        ],
+        [
+          158.51033887811934,
+          40.000000000000014
+        ],
+        [
+          118.51033887811934,
+          -7.105427357601002e-15
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "index": "aN",
+      "polygon": false
+    },
+    {
+      "type": "image",
+      "version": 3939,
+      "versionNonce": 104302435,
+      "index": "aO",
+      "isDeleted": false,
+      "id": "JKfYOaxSgHmIfXOZr_ky_",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 960.2153557774851,
+      "y": 652.9542268082345,
+      "strokeColor": "transparent",
+      "backgroundColor": "#ffc9c9",
+      "width": 61.54214099463984,
+      "height": 50.681763172056336,
+      "seed": 232743811,
+      "groupIds": [
+        "evh6qDuDiMBZrGuId3cHK",
+        "G9ZOnIRiEbfwpinL9rwGO"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779275387722,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "hMF-qIDcE7T9oLY7eho6R",
+      "type": "text",
+      "x": 929.8978266786733,
+      "y": 621.8452548399971,
+      "width": 79.20000457763672,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#a5d8ff",
+      "fillStyle": "cross-hatch",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "aP",
+      "roundness": null,
+      "seed": 332266275,
+      "version": 316,
+      "versionNonce": 1118541475,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1779275379449,
+      "link": null,
+      "locked": false,
+      "text": "from_http",
+      "fontSize": 16,
+      "fontFamily": 8,
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "from_http",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "ccbL8bQSbk-Lef02y9z40",
+      "type": "arrow",
+      "x": 757.1300788533498,
+      "y": 682.1859960328297,
+      "width": 162.8699211466502,
+      "height": 2.1859960328297348,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "aQ",
+      "roundness": null,
+      "seed": 637406509,
+      "version": 275,
+      "versionNonce": 1945891299,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "vibmeZeWxh8ZoD3fDo1bc"
+        }
+      ],
+      "updated": 1779275394712,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          162.8699211466502,
+          -2.1859960328297348
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": {
+        "elementId": "s-b-eDkm1hheDruD9We9K",
+        "mode": "orbit",
+        "fixedPoint": [
+          1,
+          0.5001
+        ]
+      },
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false,
+      "moveMidPointsWithElement": false
+    },
+    {
+      "id": "vibmeZeWxh8ZoD3fDo1bc",
+      "type": "text",
+      "x": 836.6257931614922,
+      "y": 700,
+      "width": 57.71200180053711,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "aR",
+      "roundness": null,
+      "seed": 511565709,
+      "version": 14,
+      "versionNonce": 373226339,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779274869857,
+      "link": null,
+      "locked": false,
+      "text": "HTTPS",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "ccbL8bQSbk-Lef02y9z40",
+      "originalText": "HTTPS",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "SwFhmnXtZuZ1KHReIsv3s",
+      "type": "line",
+      "x": 679.1692673292011,
+      "y": 638.9208150122315,
+      "width": 240,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "aS",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 1724686797,
+      "version": 32,
+      "versionNonce": 1534340973,
+      "isDeleted": true,
+      "boundElements": null,
+      "updated": 1779275381471,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          240,
+          0
+        ]
+      ],
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "polygon": false
+    }
+  ],
+  "appState": {
+    "gridSize": 20,
+    "gridStep": 5,
+    "gridModeEnabled": false,
+    "viewBackgroundColor": "#ffffff",
+    "lockedMultiSelections": {}
+  },
+  "files": {
+    "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf": {
+      "mimeType": "image/svg+xml",
+      "id": "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf",
+      "dataURL": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4NSIgaGVpZ2h0PSI3MCIgdmlld0JveD0iMCAwIDg1IDcwIiBmaWxsPSJub25lIj4KPHBhdGggZD0iTTI5LjQ1IDQ0LjQyTDQyLjc3IDEyLjkzQzQyLjgyNjkgMTIuODA1OCA0Mi44NTc4IDEyLjY3MTMgNDIuODYwNyAxMi41MzQ4QzQyLjg2MzYgMTIuMzk4MiA0Mi44Mzg2IDEyLjI2MjUgNDIuNzg3IDEyLjEzNkM0Mi43MzU1IDEyLjAwOTUgNDIuNjU4NiAxMS44OTQ5IDQyLjU2MTEgMTEuNzk5M0M0Mi40NjM1IDExLjcwMzcgNDIuMzQ3NSAxMS42MjkgNDIuMjIgMTEuNThDNDIuMDkyOCAxMS41Mjg2IDQxLjk1NzEgMTEuNTAxNSA0MS44MiAxMS41SDkuMjc5OTlDOS4wNzYzMiAxMS40OTU4IDguODc2MjEgMTEuNTUzOCA4LjcwNjQzIDExLjY2NjRDOC41MzY2NiAxMS43NzkgOC40MDUzMiAxMS45NDA3IDguMzI5OTkgMTIuMTNMMy4xMDk5OSAyNC42M0MzLjA1IDI0Ljc1NTggMy4wMTY5NSAyNC44OTI3IDMuMDEyOTggMjUuMDMyQzMuMDA5MDEgMjUuMTcxMyAzLjAzNDE5IDI1LjMwOTkgMy4wODY5MiAyNS40Mzg5QzMuMTM5NjUgMjUuNTY3OSAzLjIxODc1IDI1LjY4NDQgMy4zMTkxNiAyNS43ODExQzMuNDE5NTcgMjUuODc3NyAzLjUzOTA3IDI1Ljk1MjMgMy42Njk5OSAyNkMzLjc5MzMxIDI2LjA1MjUgMy45MjU5NCAyNi4wNzk3IDQuMDU5OTkgMjYuMDhIMTkuODJDMjAuMDg1MiAyNi4wOCAyMC4zMzk2IDI2LjE4NTQgMjAuNTI3MSAyNi4zNzI5QzIwLjcxNDYgMjYuNTYwNCAyMC44MiAyNi44MTQ4IDIwLjgyIDI3LjA4QzIwLjgxODUgMjcuMjE3MiAyMC43OTE0IDI3LjM1MjggMjAuNzQgMjcuNDhMNy41OTk5OSA1OS4wN0M3LjU0MzMyIDU5LjE5NDggNy41MTI5MiA1OS4zMjk5IDcuNTEwNjUgNTkuNDY2OUM3LjUwODM5IDU5LjYwNCA3LjUzNDMyIDU5Ljc0IDcuNTg2ODMgNTkuODY2NkM3LjYzOTM1IDU5Ljk5MzIgNy43MTczMiA2MC4xMDc3IDcuODE1OTIgNjAuMjAyOUM3LjkxNDUyIDYwLjI5OCA4LjAzMTYzIDYwLjM3MiA4LjE1OTk5IDYwLjQyQzguMjgzMzEgNjAuNDcyNSA4LjQxNTk0IDYwLjQ5OTcgOC41NDk5OSA2MC41SDQzQzQzLjIxMzIgNjAuNTE0MSA0My40MjUzIDYwLjQ1OTYgNDMuNjA1MiA2MC4zNDQ1QzQzLjc4NTIgNjAuMjI5MyA0My45MjM1IDYwLjA1OTUgNDQgNTkuODZMNDkuMjIgNDcuMjhDNDkuMjc2NyA0Ny4xNTUyIDQ5LjMwNzEgNDcuMDIwMSA0OS4zMDkzIDQ2Ljg4MzFDNDkuMzExNiA0Ni43NDYgNDkuMjg1NyA0Ni42MSA0OS4yMzMxIDQ2LjQ4MzRDNDkuMTgwNiA0Ni4zNTY4IDQ5LjEwMjcgNDYuMjQyNCA0OS4wMDQxIDQ2LjE0NzJDNDguOTA1NSA0Ni4wNTIgNDguNzg4MyA0NS45NzggNDguNjYgNDUuOTNDNDguNTM2NyA0NS44Nzc1IDQ4LjQwNCA0NS44NTAzIDQ4LjI3IDQ1Ljg1SDMwLjRDMzAuMTM0OCA0NS44NSAyOS44ODA0IDQ1Ljc0NDYgMjkuNjkyOSA0NS41NTcxQzI5LjUwNTMgNDUuMzY5NiAyOS40IDQ1LjExNTIgMjkuNCA0NC44NUMyOS4zODggNDQuNzA0OCAyOS40MDUgNDQuNTU4NiAyOS40NSA0NC40MloiIGZpbGw9IiMxMjEyMTIiLz4KPHBhdGggZD0iTTM3LjE3IDQxLjU4SDUwLjg4QzUxLjA4MzcgNDEuNTg0MyA1MS4yODM4IDQxLjUyNjIgNTEuNDUzNSA0MS40MTM2QzUxLjYyMzMgNDEuMzAxIDUxLjc1NDcgNDEuMTM5MyA1MS44MyA0MC45NUw1Ny44MyAyNi42OUM1Ny45MDUzIDI2LjUwMDcgNTguMDM2NyAyNi4zMzkgNTguMjA2NCAyNi4yMjY0QzU4LjM3NjIgMjYuMTEzOCA1OC41NzYzIDI2LjA1NTcgNTguNzggMjYuMDZINzYuNDFDNzYuNjIyIDI2LjA3NDkgNzYuODMzMiAyNi4wMjE4IDc3LjAxMyAyNS45MDg1Qzc3LjE5MjggMjUuNzk1MyA3Ny4zMzE5IDI1LjYyNzYgNzcuNDEgMjUuNDNMODIuNjMgMTIuOTNDODIuNjg1MiAxMi44MDA3IDgyLjcxMjYgMTIuNjYxMyA4Mi43MTAzIDEyLjUyMDdDODIuNzA3OSAxMi4zODAxIDgyLjY3NiAxMi4yNDE2IDgyLjYxNjYgMTIuMTE0M0M4Mi41NTcxIDExLjk4NjkgODIuNDcxNSAxMS44NzM0IDgyLjM2NTIgMTEuNzgxNEM4Mi4yNTkgMTEuNjg5MyA4Mi4xMzQ1IDExLjYyMDcgODIgMTEuNThDODEuODc2NyAxMS41Mjc1IDgxLjc0NCAxMS41MDAzIDgxLjYxIDExLjVINDguODJDNDguNjA4IDExLjQ4NTEgNDguMzk2OCAxMS41MzgyIDQ4LjIxNyAxMS42NTE1QzQ4LjAzNzEgMTEuNzY0NyA0Ny44OTgxIDExLjkzMjQgNDcuODIgMTIuMTNMMzYuMTcgNDAuMTNDMzYuMTEzMSA0MC4yNTQyIDM2LjA4MjIgNDAuMzg4NyAzNi4wNzkzIDQwLjUyNTJDMzYuMDc2MyA0MC42NjE4IDM2LjEwMTQgNDAuNzk3NSAzNi4xNTI5IDQwLjkyNEMzNi4yMDQ1IDQxLjA1MDUgMzYuMjgxNCA0MS4xNjUxIDM2LjM3ODkgNDEuMjYwN0MzNi40NzY0IDQxLjM1NjMgMzYuNTkyNSA0MS40MzEgMzYuNzIgNDEuNDhDMzYuODYxMiA0MS41NDQ3IDM3LjAxNDYgNDEuNTc4OCAzNy4xNyA0MS41OFoiIGZpbGw9IiMxMjEyMTIiLz4KPC9zdmc+",
+      "created": 1684733732697
+    },
+    "1e93f8048a3a2cc99ffc75709c25cfe0b713dac0c4f89c0258b9f49a18122d7b9356ced86cd49adea279bbd745be756c": {
+      "mimeType": "image/svg+xml",
+      "id": "1e93f8048a3a2cc99ffc75709c25cfe0b713dac0c4f89c0258b9f49a18122d7b9356ced86cd49adea279bbd745be756c",
+      "dataURL": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iODBweCIgaGVpZ2h0PSI4MHB4IiB2aWV3Qm94PSIwIDAgODAgODAiIHZlcnNpb249IjEuMSI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDY0ICg5MzUzNykgLSBodHRwczovL3NrZXRjaC5jb20gLS0+CiAgICA8dGl0bGU+SWNvbi1BcmNoaXRlY3R1cmUvNjQvQXJjaF9BbWF6b24tQ2xvdWRXYXRjaF82NDwvdGl0bGU+CiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4KICAgIDxkZWZzPgogICAgICAgIDxsaW5lYXJHcmFkaWVudCB4MT0iMCUiIHkxPSIxMDAlIiB4Mj0iMTAwJSIgeTI9IjAlIiBpZD0ibGluZWFyR3JhZGllbnQtMSI+CiAgICAgICAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiNCMDA4NEQiIG9mZnNldD0iMCUiLz4KICAgICAgICAgICAgPHN0b3Agc3RvcC1jb2xvcj0iI0ZGNEY4QiIgb2Zmc2V0PSIxMDAlIi8+CiAgICAgICAgPC9saW5lYXJHcmFkaWVudD4KICAgIDwvZGVmcz4KICAgIDxnIGlkPSJJY29uLUFyY2hpdGVjdHVyZS82NC9BcmNoX0FtYXpvbi1DbG91ZFdhdGNoXzY0IiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iSWNvbi1BcmNoaXRlY3R1cmUtQkcvNjQvTWFuYWdlbWVudC1Hb3Zlcm5hbmNlIiBmaWxsPSJ1cmwoI2xpbmVhckdyYWRpZW50LTEpIj4KICAgICAgICAgICAgPHJlY3QgaWQ9IlJlY3RhbmdsZSIgeD0iMCIgeT0iMCIgd2lkdGg9IjgwIiBoZWlnaHQ9IjgwIi8+CiAgICAgICAgPC9nPgogICAgICAgIDxwYXRoIGQ9Ik01NS4wNTkyMzE1LDQ2Ljc3NzM3MDcgQzU1LjA1OTIzMTUsNDIuODY4MDI4MSA1MS44NTc1NTg4LDM5LjY4NzYzMDUgNDcuOTIyMDY0NiwzOS42ODc2MzA1IEM0My45ODY1NzA1LDM5LjY4NzYzMDUgNDAuNzg1OTAzLDQyLjg2ODAyODEgNDAuNzg1OTAzLDQ2Ljc3NzM3MDcgQzQwLjc4NTkwMyw1MC42ODY3MTMzIDQzLjk4NjU3MDUsNTMuODY3MTEwOCA0Ny45MjIwNjQ2LDUzLjg2NzExMDggQzUxLjg1NzU1ODgsNTMuODY3MTEwOCA1NS4wNTkyMzE1LDUwLjY4NjcxMzMgNTUuMDU5MjMxNSw0Ni43NzczNzA3IE01Ny4wNjk3MDExLDQ2Ljc3NzM3MDcgQzU3LjA2OTcwMTEsNTEuNzg4MTE5NCA1Mi45NjYzMzI3LDU1Ljg2NDIyMDcgNDcuOTIyMDY0Niw1NS44NjQyMjA3IEM0Mi44Nzg4MDE4LDU1Ljg2NDIyMDcgMzguNzc1NDMzNCw1MS43ODgxMTk0IDM4Ljc3NTQzMzQsNDYuNzc3MzcwNyBDMzguNzc1NDMzNCw0MS43NjY2MjE5IDQyLjg3ODgwMTgsMzcuNjkwNTIwNiA0Ny45MjIwNjQ2LDM3LjY5MDUyMDYgQzUyLjk2NjMzMjcsMzcuNjkwNTIwNiA1Ny4wNjk3MDExLDQxLjc2NjYyMTkgNTcuMDY5NzAxMSw0Ni43NzczNzA3IE02NS41MDk2NTIyLDYwLjQ3MzU1MDQgTDU4LjUwMTE1NTQsNTQuMjAyNjI1MyBDNTcuOTM1MjA4Miw1NC45OTQ0Nzk0IDU3LjI4MDgwMDQsNTUuNzE3NDMzMiA1Ni41NTQwMTU2LDU2LjM2MzQ5ODIgTDYzLjU1MjQ2MDEsNjIuNjMzNDI0OCBDNjQuMTQ5NTY5Niw2My4xNjg2NTAyIDY1LjA3ODQwNjUsNjMuMTE4NzIyNSA2NS42MTgyMTc2LDYyLjUyNTU4MDggQzY2LjE1NTAxMyw2MS45MzI0MzkyIDY2LjEwNjc2MTcsNjEuMDEwNzczIDY1LjUwOTY1MjIsNjAuNDczNTUwNCBNNDcuOTIyMDY0Niw1Ny42NjE2MTk3IEM1My45NjQ1MzA5LDU3LjY2MTYxOTcgNTguODgwMTI4OSw1Mi43Nzg2ODU5IDU4Ljg4MDEyODksNDYuNzc3MzcwNyBDNTguODgwMTI4OSw0MC43NzUwNTY5IDUzLjk2NDUzMDksMzUuODkzMTIxNyA0Ny45MjIwNjQ2LDM1Ljg5MzEyMTcgQzQxLjg4MDYwMzYsMzUuODkzMTIxNyAzNi45NjUwMDU2LDQwLjc3NTA1NjkgMzYuOTY1MDA1Niw0Ni43NzczNzA3IEMzNi45NjUwMDU2LDUyLjc3ODY4NTkgNDEuODgwNjAzNiw1Ny42NjE2MTk3IDQ3LjkyMjA2NDYsNTcuNjYxNjE5NyBNNjcuMTExOTk2NSw2My44NjI2NDU5IEM2Ni40MjY0MjY0LDY0LjYxNjU1NDkgNjUuNDc4NDksNjUgNjQuNTI4NTQzMSw2NSBDNjMuNzAwMjI5Niw2NSA2Mi44Njk5MDU3LDY0LjcwODQyMiA2Mi4yMDc0NTYsNjQuMTE3Mjc3NCBMNTQuOTMwNTYxNSw1Ny41OTg3MTA3IEM1Mi45MDcwMjM5LDU4Ljg5NjgzMjEgNTAuNTA1NTE4LDU5LjY1ODcyOTYgNDcuOTIyMDY0Niw1OS42NTg3Mjk2IEM0MC43NzE4Mjk3LDU5LjY1ODcyOTYgMzQuOTU0NTM2MSw1My44ODAwOTIxIDM0Ljk1NDUzNjEsNDYuNzc3MzcwNyBDMzQuOTU0NTM2MSwzOS42NzQ2NDkzIDQwLjc3MTgyOTcsMzMuODk2MDExOCA0Ny45MjIwNjQ2LDMzLjg5NjAxMTggQzU1LjA3MzMwNDgsMzMuODk2MDExOCA2MC44OTA1OTg1LDM5LjY3NDY0OTMgNjAuODkwNTk4NSw0Ni43NzczNzA3IEM2MC44OTA1OTg1LDQ4LjgxNTQyMTMgNjAuMzk5MDM4Nyw1MC43MzY2NDExIDU5LjU0NjU5OTYsNTIuNDUxMTU5OSBMNjYuODU1NjYxNiw1OC45OTA2OTYzIEM2OC4yNzUwNTMxLDYwLjI2NTg1MSA2OC4zODk2NDk5LDYyLjQ0OTY5MDcgNjcuMTExOTk2NSw2My44NjI2NDU5IE0yMS4yODAzMjc0LDI5LjM5MjUyOSBDMjEuMjgwMzI3NCwyOS45MTE3Nzc2IDIxLjMxMjQ5NDksMzAuNDI5MDI5IDIxLjM3MzgxNDMsMzAuOTI5MzA1MSBDMjEuNDA4OTk3NSwzMS4yMTM4OTMyIDIxLjMyMDUzNjgsMzEuNDk4NDgxNCAyMS4xMjk1NDIyLDMxLjcxMzE3MDcgQzIwLjk3Nzc1MTgsMzEuODgzOTIzNiAyMC43NzM2ODkxLDMxLjk5Njc2MDMgMjAuNTUwNTI3LDMyLjAzNDcwNTQgQzE4LjA3ODY1NDcsMzIuNjY4Nzg3OCAxNC4wMTA0Njk1LDM0LjU4ODAxMDQgMTQuMDEwNDY5NSw0MC4zNDU2NzgyIEMxNC4wMTA0Njk1LDQ0LjY5MzM4NjUgMTYuNDI0MDM4Miw0Ny4wOTI5MTQxIDE4LjQ0OTU4NjMsNDguMzQxMTA3NyBDMTkuMTQxMTg3OCw0OC43NzQ0ODA2IDE5Ljk1OTQ0ODksNDkuMDA1MTQ2OCAyMC44MjI5NDU2LDQ5LjAxNDEzMzggTDMyLjk0NTA3MTcsNDkuMDI1MTE3OSBMMzIuOTQzMDYxMyw1MS4wMjIyMjc4IEwyMC44MTE4ODgsNTEuMDExMjQzNyBDMTkuNTY2NDAyMSw1MC45OTgyNjI1IDE4LjM4NDI0Niw1MC42NjA3NTA5IDE3LjM4NDAzNzQsNTAuMDM0NjU2OSBDMTUuMzc2NTgzNiw0OC43OTc0NDc0IDEyLDQ1Ljg4OTY1NTMgMTIsNDAuMzQ1Njc4MiBDMTIsMzMuNjYyMzUgMTYuNTk5OTU0MywzMS4xOTE5MjUgMTkuMzAwMDE0OSwzMC4zMTkxODggQzE5LjI3OTkxMDIsMzAuMDExNjMzMSAxOS4yNjk4NTc5LDI5LjcwMjA4MSAxOS4yNjk4NTc5LDI5LjM5MjUyOSBDMTkuMjY5ODU3OSwyMy45MzI0MzA1IDIyLjk5ODI3MzcsMTguMjY5NjI1NCAyNy45NDIwMTgzLDE2LjIyMTU4OTIgQzMzLjcyNDEyODcsMTMuODE1MDcxNyAzOS44NTAwMjk0LDE1LjAwODM0NDkgNDQuMzI2MzM5OSwxOS40MTA5NzM3IEM0NS43MTM1NjM4LDIwLjc3NDk5OTggNDYuODU0NTA1MywyMi40MzE2MDI0IDQ3LjczMDA2NDgsMjQuMzQ3ODI5NCBDNDguOTA2MTg5NSwyMy4zODAyMjk2IDUwLjM1NTczOCwyMi44NDYwMDI3IDUxLjg4MzY5NDksMjIuODQ2MDAyNyBDNTQuODg2MzMxMiwyMi44NDYwMDI3IDU4LjI2NTkzMDUsMjUuMTA5NzI2OCA1OC44NjgwNjYxLDMwLjA2MDU2MjIgQzYxLjY3OTcwNzgsMzAuNzA0NjMwMiA2Ny42MjA2NDUzLDMyLjk1NTM3MzEgNjcuNjIwNjQ1Myw0MC40MjI1NjcgQzY3LjYyMDY0NTMsNDMuNDA0MjUyMSA2Ni42Nzk3NDU1LDQ1Ljg2NjY4ODYgNjQuODIzMDc2OSw0Ny43NDE5NzQ4IEw2My4zODk2MTIxLDQ2LjM0MTAwMjIgQzY0Ljg2MzI4NjMsNDQuODUzMTU1MyA2NS42MTAxNzU3LDQyLjg2MjAzNjcgNjUuNjEwMTc1Nyw0MC40MjI1NjcgQzY1LjYxMDE3NTcsMzMuODkxMDE5IDYwLjEwNTUxMDEsMzIuMjY2MzcwMSA1Ny43MzcxNzcsMzEuODcxOTQwOSBDNTcuNDY3Nzc0MSwzMS44MjcwMDYgNTcuMjI5NTMzNCwzMS42NzUyMjU2IDU3LjA3NTczMjUsMzEuNDUxNTQ5MyBDNTYuOTI1OTUyNSwzMS4yMzU4NjE0IDU2Ljg2ODY1NDEsMzAuOTcxMjQ0NCA1Ni45MTM4ODk3LDMwLjcxNDYxNTcgQzU2LjU4NTE3NzksMjYuNjYwNDgyNiA1NC4xNjA1NTE2LDI0Ljg0MzExMjYgNTEuODgzNjk0OSwyNC44NDMxMTI2IEM1MC40NDcyMTQ0LDI0Ljg0MzExMjYgNDkuMTAwMTk5OCwyNS41MzgxMDY5IDQ4LjE4NzQ0NjYsMjYuNzUwMzUyNiBDNDcuOTY1Mjg5NywyNy4wNDM5Mjc3IDQ3LjYwNDQxMDUsMjcuMTkzNzExIDQ3LjIzNDQ4NDEsMjcuMTM5Nzg5IEM0Ni44Njk1ODM4LDI3LjA4NTg2NyA0Ni41NjI5ODcyLDI2LjgzNjIyODMgNDYuNDM3MzMyOSwyNi40OTE3MjY4IEM0NS42MTQwNDU2LDI0LjIyNjAwNTcgNDQuNDI3ODY4NiwyMi4zMjA3NjI4IDQyLjkxMTk3NDUsMjAuODMwOTE4OCBDMzkuMDMyNzczNSwxNy4wMTU0NDA0IDMzLjcyODE0OTYsMTUuOTgwOTM3NCAyOC43MTcwNTQzLDE4LjA2NDkyMTYgQzI0LjU0NjMzNTIsMTkuNzkyNDIxNyAyMS4yODAzMjc0LDI0Ljc2NzIyMjQgMjEuMjgwMzI3NCwyOS4zOTI1MjkiIGlkPSJBbWF6b24tQ2xvdWRXYXRjaF9JY29uXzY0X1NxdWlkIiBmaWxsPSIjRkZGRkZGIi8+CiAgICA8L2c+Cjwvc3ZnPg==",
+      "created": 1779105649329
+    }
+  }
+}

--- a/src/content/docs/integrations/amazon/cloudwatch.mdx
+++ b/src/content/docs/integrations/amazon/cloudwatch.mdx
@@ -7,6 +7,8 @@ observability service in AWS. Tenzir can read CloudWatch events with
 <Op>from_amazon_cloudwatch</Op> and write events with
 <Op>to_amazon_cloudwatch</Op>.
 
+![CloudWatch](cloudwatch.excalidraw)
+
 CloudWatch stores log data in log groups and log streams. Use Tenzir to live
 tail new logs, search historical logs with filter patterns, replay one log
 stream, or forward pipeline output into an existing log stream.


### PR DESCRIPTION
## 🔍 Problem

- The CloudWatch integration page describes the read and write paths, but lacks a diagram like the other integration pages.

## 🛠️ Solution

- Add the CloudWatch Excalidraw diagram after the introduction so readers see the flow before configuration details.

## 💬 Review

- Focus on whether the diagram placement matches the integration page pattern.