### PR TITLE
Document to_http batching patterns

### DIFF
--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -404,14 +404,13 @@ each parallel=4 {
 ```
 
 :::tip[Getting responses back]
-If you need to process the HTTP response for each event, use <Op>from_http</Op>
-inside <Op>each</Op> instead:
+When sending a single event and either using JSON or form encoding, <Op>from_http</Op>
+can be used. This makes code more concise, but also allows response processing.
 
 ```tql
-from {ip: "10.0.0.5"},
-     {ip: "10.0.0.7"}
+subscribe "alerts"
 each {
-  from_http f"https://api.example.com/lookup?ip={$this.ip}" {
+  from_http f"https://example.com/webhook", body=$this {
     read_json
   }
 }

--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -367,7 +367,7 @@ from {message: "event-1"},
      {message: "event-2"},
      {message: "event-3"}
 to_http "https://example.com/ingest" {
-  write_parquet
+  write_ndjson
 }
 ```
 
@@ -402,6 +402,21 @@ each parallel=4 {
   }
 }
 ```
+
+:::tip[Getting responses back]
+If you need to process the HTTP response for each event, use <Op>from_http</Op>
+inside <Op>each</Op> instead:
+
+```tql
+from {ip: "10.0.0.5"},
+     {ip: "10.0.0.7"}
+each {
+  from_http f"https://api.example.com/lookup?ip={$this.ip}" {
+    read_json
+  }
+}
+```
+:::
 
 Per-event delivery is ideal for webhooks that expect one payload per call or
 when each event must be sent immediately.

--- a/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
+++ b/src/content/docs/guides/collecting/fetch-via-http-and-apis.mdx
@@ -351,6 +351,78 @@ from_http "https://api.example.com/scan?q=example.com",
 
 Use `paginate_delay` to manage request rates appropriately.
 
+## Controlling Batching with `to_http`
+
+When sending events to an HTTP endpoint, you can control how many events go
+into each request.
+
+### Send all events in a single request
+
+By default, `to_http` collects all input events into one request. The printer
+sub-pipeline serializes the events and Tenzir streams the body to the
+connection:
+
+```tql
+from {message: "event-1"},
+     {message: "event-2"},
+     {message: "event-3"}
+to_http "https://example.com/ingest" {
+  write_parquet
+}
+```
+
+This is useful for one-shot pipelines that produce a finite set of events.
+
+### Send one request per event
+
+Wrap `to_http` in <Op>each</Op> to send a separate HTTP request for every
+event:
+
+```tql
+from {message: "event-1"},
+     {message: "event-2"},
+     {message: "event-3"}
+each {
+  from $this
+  to_http "https://example.com/webhook" {
+    write_json
+  }
+}
+```
+
+This sends three independent `POST` requests, each carrying one event as JSON.
+Use `parallel` to control how many requests run concurrently:
+
+```tql
+subscribe "alerts"
+each parallel=4 {
+  from $this
+  to_http "https://example.com/webhook" {
+    write_json
+  }
+}
+```
+
+Per-event delivery is ideal for webhooks that expect one payload per call or
+when each event must be sent immediately.
+
+### Send periodic batches
+
+Wrap `to_http` in <Op>every</Op> to accumulate events over a time window and
+then flush them as one request:
+
+```tql
+subscribe "stream-of-events"
+every 5m {
+  to_http "https://example.com/ingest" {
+    write_parquet
+  }
+}
+```
+
+Every 5 minutes, `every` stops the input, causing `to_http` to finish the
+request wait for response and then restart.
+
 ## Practical Examples
 
 These examples demonstrate typical use cases for API integration in real-world

--- a/src/content/docs/reference/operators/accept_http.mdx
+++ b/src/content/docs/reference/operators/accept_http.mdx
@@ -151,7 +151,6 @@ accept_http "0.0.0.0:8443" {
 ## See Also
 
 - <Op>from_http</Op>
-- <Op>http</Op>
 - <Op>to_http</Op>
 - <Op>serve_http</Op>
 - <Guide>collecting/fetch-via-http-and-apis</Guide>

--- a/src/content/docs/reference/operators/each.mdx
+++ b/src/content/docs/reference/operators/each.mdx
@@ -97,5 +97,7 @@ each {
 - <Op>fork</Op>
 - <Op>group</Op>
 - <Op>parallel</Op>
+- <Op>to_http</Op>
 - <Guide>tenzir-v6-migration</Guide>
+- <Guide>collecting/fetch-via-http-and-apis</Guide>
 - <Guide>routing/fan-out-with-subpipelines</Guide>

--- a/src/content/docs/reference/operators/every.mdx
+++ b/src/content/docs/reference/operators/every.mdx
@@ -109,7 +109,9 @@ every 1h {
 
 - <Op>cron</Op>
 - <Op>each</Op>
+- <Op>to_http</Op>
 - <Op>summarize</Op>
+- <Guide>collecting/fetch-via-http-and-apis</Guide>
 - <Guide>transformation/work-with-time</Guide>
 - <Guide>enrichment/work-with-lookup-tables</Guide>
 - <Tutorial>write-a-package</Tutorial>

--- a/src/content/docs/reference/operators/every.mdx
+++ b/src/content/docs/reference/operators/every.mdx
@@ -57,7 +57,6 @@ enumerate
 ```tql
 subscribe "event-stream"
 every 30s {
-  batch
   to_http "https://example.org/api/ingest" {
     write_json
   }
@@ -65,8 +64,8 @@ every 30s {
 ```
 
 Events flow into the sub-pipeline continuously. Every 30 seconds, `every` stops
-the input, causing <Op>batch</Op> to flush and <Op>to_http</Op> to send the
-accumulated batch. Then a new sub-pipeline starts.
+the input, causing <Op>to_http</Op> to finish the request and wait for the
+response. Then a new sub-pipeline starts.
 
 ### Aggregate metrics periodically with `summarize`
 

--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -137,8 +137,7 @@ next request must use a different method. If `body` is a record, the `encode`
 option also applies to paginated request bodies.
 
 This request-record pagination behavior applies to <Op>from_http</Op> only. It
-does not change <Op>http</Op>, <Op>to_http</Op>, <Op>accept_http</Op>, or
-<Op>serve_http</Op>.
+does not change <Op>to_http</Op>, <Op>accept_http</Op>, or <Op>serve_http</Op>.
 
 **Link mode**: The string `"link"` to automatically follow pagination links in
 the HTTP `Link` response header as defined in [RFC
@@ -388,7 +387,6 @@ Tenzir emits a diagnostic before each retry with the reason and wait time.
 ## See Also
 
 - <Op>accept_http</Op>
-- <Op>http</Op>
 - <Op>to_http</Op>
 - <Op>serve_http</Op>
 - <Guide>tenzir-v6-migration</Guide>

--- a/src/content/docs/reference/operators/to_http.mdx
+++ b/src/content/docs/reference/operators/to_http.mdx
@@ -98,16 +98,56 @@ import TLSOptions from '@partials/operators/TLSOptions.mdx';
 
 ## Examples
 
-### Send events to a webhook
+### Send all events in a single request
 
-Send all events as a single JSON POST request:
+By default, `to_http` collects all input events into a single HTTP request:
 
 ```tql
-from {message: "hello", severity: "info"}
-to_http "https://example.com/webhook" {
-  write_ndjson
+from {message: "hello", severity: "info"},
+     {message: "world", severity: "warn"}
+to_http "https://example.com/ingest" {
+  write_parquet
 }
 ```
+
+This sends one `POST` request whose body contains both events as NDJSON.
+
+### Send one request per event
+
+Wrap `to_http` in <Op>each</Op> to send a separate HTTP request for every
+incoming event:
+
+```tql
+from {message: "hello", severity: "info"},
+     {message: "world", severity: "warn"}
+each {
+  from $this
+  to_http "https://example.com/webhook" {
+    write_json
+  }
+}
+```
+
+Each event becomes an independent `POST` request with a JSON body. Use the
+`parallel` option of <Op>each</Op> to control concurrency.
+
+### Send events in periodic batches
+
+Use <Op>every</Op> to group events into time-based batches, with each batch
+sent as a separate HTTP request:
+
+```tql
+subscribe "stream-of-events"
+every 1m {
+  to_http "https://example.com/ingest" {
+    write_parquet
+  }
+}
+```
+
+Every minute, `every` stops the input, causing `to_http` to finish the request,
+wait for response and then restart. Adjust the interval to control batch size —
+use `every 5s` for near-real-time delivery or `every 10m` for larger batches.
 
 ### Control the request body format
 
@@ -116,7 +156,7 @@ Use the printer sub-pipeline to control how the operator serializes events:
 ```tql
 from {foo: "bar"}
 to_http "https://example.com/api" {
-  write_json
+  write_csv
 }
 ```
 
@@ -124,9 +164,7 @@ to_http "https://example.com/api" {
 
 ```tql
 from {foo: "bar"}
-to_http "https://example.com/api",
-  method="put",
-  headers={"X-Custom": "value"} {
+to_http "192.168.1.10", method="put", headers={"X-Custom": "value"} {
   write_ndjson
 }
 ```
@@ -135,33 +173,17 @@ to_http "https://example.com/api",
 
 ```tql
 from {data: "sensitive"}
-to_http "https://secure.example.com/api",
-  tls={skip_peer_verification: true} {
+to_http "https://secure.example.com/api", tls={skip_peer_verification: true} {
   write_ndjson
-}
-```
-
-### Send events in periodic batches
-
-Use `every` to group events into time-based batches, with each batch sent as
-a separate HTTP request:
-
-```tql
-subscribe "stream-of-events"
-every 1m {
-  batch
-  to_http "https://example.com/ingest" {
-    write_ndjson
-  }
 }
 ```
 
 ## See Also
 
 - <Op>from_http</Op>
-- <Op>http</Op>
 - <Op>accept_http</Op>
 - <Op>serve_http</Op>
+- <Op>each</Op>
 - <Op>every</Op>
 - <Guide>tenzir-v6-migration</Guide>
 - <Guide>collecting/fetch-via-http-and-apis</Guide>

--- a/src/content/docs/reference/operators/to_http.mdx
+++ b/src/content/docs/reference/operators/to_http.mdx
@@ -105,12 +105,14 @@ By default, `to_http` collects all input events into a single HTTP request:
 ```tql
 from {message: "hello", severity: "info"},
      {message: "world", severity: "warn"}
-to_http "https://example.com/ingest" {
-  write_parquet
+to_http "https://example.com/webhook" {
+  write_ndjson
 }
 ```
 
 This sends one `POST` request whose body contains both events as NDJSON.
+Use any printer, such as `write_json`, `write_csv`, or `write_parquet`,
+to control the wire format.
 
 ### Send one request per event
 


### PR DESCRIPTION
## 🔍 Problem

The `to_http` docs only show the default single-request behavior. Users don't know how to send one request per event or periodic batches.

## 🛠️ Solution

- Add three batching patterns to `to_http` reference: all-at-once (default), per-event (`each`), periodic (`every`).
- Add a "Controlling Batching with `to_http`" section to the HTTP guide with the same patterns plus a concurrency example.
- Use `write_parquet` for bulk periodic examples to imply larger batches.
- Add reciprocal cross-references from `each` and `every` operator pages.
- Remove stale `<Op>http</Op>` references from `accept_http` and `from_http`.

## 💬 Review

Focus on whether the three batching patterns are clear and complete. All examples were tested against httpbin.org.