### PR TITLE
Clarify from_http body secret resolution

### DIFF
--- a/src/content/docs/reference/operators/from_http.mdx
+++ b/src/content/docs/reference/operators/from_http.mdx
@@ -95,6 +95,9 @@ Defaults to `1s`.
 
 Body to send with the HTTP request.
 
+Tenzir resolves secrets in string bodies and in nested record values before it
+sends the request.
+
 If the value is a `record`, the body is encoded according to the `encode`
 option and Tenzir sets an appropriate `Content-Type` header.
 


### PR DESCRIPTION
## 🔍 Problem

- The `from_http` reference did not say whether request bodies can contain secrets.
- TNZ-645 fixes body secret resolution, so the operator reference should state that behavior explicitly.

## 🛠️ Solution

- Document that `from_http` resolves secrets in string bodies and nested record values before sending the request.

## 💬 Review

- Reference-only change in the `from_http` operator docs.

<sub>
🛠️ Code PR: tenzir/tenzir#6213<br>
🎫 References TNZ-645
</sub>
