### PR TITLE
Document to_http buffer_all argument

### DIFF
--- a/src/content/docs/reference/operators/to_http.mdx
+++ b/src/content/docs/reference/operators/to_http.mdx
@@ -12,8 +12,8 @@ import HttpClientOptions from '@partials/operators/HttpClientOptions.mdx';
 Sends events as a single HTTP request to a webhook or API endpoint.
 
 ```tql
-to_http url:string, [method=string, headers=record, timeout=duration,
-        tls=record, connection_timeout=duration,
+to_http url:string, [method=string, headers=record, buffer_all=bool,
+        timeout=duration, tls=record, connection_timeout=duration,
         max_retry_count=int, retry_delay=duration] { … }
 ```
 
@@ -34,8 +34,9 @@ arrived during that window.
 The operator retries transient connection errors and HTTP `429` and `5xx`
 responses up to `max_retry_count` times, but only before any body data has
 been sent. Once the body stream has started, retries are not possible because
-the data cannot be replayed. For retried HTTP responses, a `Retry-After`
-header overrides the configured delay.
+the data cannot be replayed. Set `buffer_all` to buffer the entire body in
+memory, which enables retries regardless of how much data has been sent. For
+retried HTTP responses, a `Retry-After` header overrides the configured delay.
 
 Non-2xx HTTP status codes cause pipeline errors.
 
@@ -60,6 +61,21 @@ One of the following HTTP methods to use:
 - `trace`
 
 Defaults to `post`.
+
+### `buffer_all = bool (optional)`
+
+Buffer the entire request body in memory before sending it.
+
+When set to `true`, the operator accumulates all output from the printer
+sub-pipeline and sends the request with a `Content-Length` header instead of
+`Transfer-Encoding: chunked`. This is required for servers that don't support
+chunked transfer encoding.
+
+Buffering also enables retries for every failure, because the full body is
+always available for replay. Without `buffer_all`, retries are only possible
+before the body stream starts.
+
+Defaults to `false`.
 
 <HttpClientOptions />
 
@@ -176,6 +192,18 @@ to_http "192.168.1.10", method="put", headers={"X-Custom": "value"} {
 ```tql
 from {data: "sensitive"}
 to_http "https://secure.example.com/api", tls={skip_peer_verification: true} {
+  write_ndjson
+}
+```
+
+### Buffer the full body
+
+Some HTTP servers don't support chunked transfer encoding and require a
+`Content-Length` header. Use `buffer_all` to send the complete body at once:
+
+```tql
+subscribe "events"
+to_http "https://s3.example.com/bucket/key", buffer_all=true {
   write_ndjson
 }
 ```

--- a/src/content/docs/reference/operators/to_http.mdx
+++ b/src/content/docs/reference/operators/to_http.mdx
@@ -203,10 +203,16 @@ Some HTTP servers don't support chunked transfer encoding and require a
 
 ```tql
 subscribe "events"
-to_http "https://s3.example.com/bucket/key", buffer_all=true {
+head 1000
+to_http "https://s3.example.com/bucket/key", method="put", buffer_all=true {
   write_ndjson
 }
 ```
+
+The `head 1000` limits the input so that `buffer_all` has a finite body to
+buffer. Without a bound, `subscribe` streams indefinitely and the buffer grows
+without limit. Use <Op>every</Op> instead of `head` when you want periodic
+flushing.
 
 ## See Also
 


### PR DESCRIPTION
## 🔍 Problem

The `to_http` operator gained a new `buffer_all` flag that lets users buffer the entire request body before sending. The docs need to reflect this.

## 🛠️ Solution

- Add `buffer_all=bool` to the operator synopsis.
- Add a parameter section describing its behavior (`Content-Length` vs chunked, retry implications).
- Mention `buffer_all` in the retry paragraph of the description.
- Add an example for S3-compatible servers.

<sub>
🛠️ Code PR: tenzir/tenzir#6214<br>
🎫 References TNZ-649
</sub>