### PR TITLE
Document pub/sub shutdown guarantees

### DIFF
--- a/src/content/docs/guides/routing/split-and-merge-streams.mdx
+++ b/src/content/docs/guides/routing/split-and-merge-streams.mdx
@@ -136,6 +136,20 @@ subscribe "alerts", "notices", "critical"
 to_kafka "all-priority-events"
 ```
 
+## Shutdown guarantees
+
+On shutdown, Tenzir drains in-flight publish/subscribe data before it stops
+pipelines. This guarantee is strongest when you use fixed topic names and
+an acyclic pipeline graph.
+
+Avoid cyclic publish/subscribe topologies. If a pipeline publishes back into a
+stream that eventually feeds the same pipeline again, Tenzir can't guarantee a
+fully graceful drain and may drop data during shutdown.
+
+There is also a small probability of data loss during shutdown when using
+dynamic topics. In practice, this is likely to happen only for newly started
+nodes or newly observed topics during shutdown.
+
 ## Combining with fork
 
 Use <Op>fork</Op> with

--- a/src/content/docs/reference/operators/publish.mdx
+++ b/src/content/docs/reference/operators/publish.mdx
@@ -13,12 +13,17 @@ publish [topic:string]
 ## Description
 
 The `publish` operator publishes events at a node in a channel with the
-specified topic. All [`subscribers`](/reference/operators/subscribe) of the channel operator
-receive the events immediately.
+specified topic. All <Op>subscribe</Op> operators on that topic receive the
+events immediately.
 
 :::note
-The `publish` operator does not guarantee that events stay in their
-original order.
+The `publish` operator does not guarantee that events stay in their original
+order.
+:::
+
+During shutdown, `subscribe` will wait for `publish` to drain all data before
+shutting down itself. This prevents data loss, as long as pub/sub do not
+form cycles and `publish` does not use dynamic topic names.
 :::
 
 ### `topic: string (optional)`

--- a/src/content/docs/reference/operators/publish.mdx
+++ b/src/content/docs/reference/operators/publish.mdx
@@ -24,7 +24,6 @@ order.
 During shutdown, `subscribe` will wait for `publish` to drain all data before
 shutting down itself. This prevents data loss, as long as pub/sub do not
 form cycles and `publish` does not use dynamic topic names.
-:::
 
 ### `topic: string (optional)`
 

--- a/src/content/docs/reference/operators/subscribe.mdx
+++ b/src/content/docs/reference/operators/subscribe.mdx
@@ -22,6 +22,10 @@ avoid data loss. This mechanism is disabled for pipelines that are not visible
 on the overview page on [app.tenzir.com](https://app.tenzir.com), which drop
 data rather than slow down their publishers.
 
+During shutdown, `subscribe` will wait for `publish` to drain all data before
+shutting down itself. This prevents data loss, as long as pub/sub do not
+form cycles and `publish` does not use dynamic topic names.
+
 ### `topic: string... (optional)`
 
 Optional channel names to subscribe to. If unspecified, the operator


### PR DESCRIPTION
## 🔍 Problem

- The publish/subscribe docs did not explain what graceful shutdown guarantees cover.
- Readers had no warning about the remaining edge cases for cyclic topologies and dynamic topic names.

## 🛠️ Solution

- Document graceful shutdown behavior in the routing guide.
- Add the same caveats to the `publish` and `subscribe` operator reference pages.
- Clarify that fixed topics in acyclic graphs have the strongest guarantees.

## 💬 Review

- Please review the wording around dynamic topics and shutdown risk.
- The goal is to be clear about the limitation without overstating how often it happens.

<sub>
🛠️ Code PR: tenzir/tenzir#6215<br>
🎫 References TNZ-538
</sub>