### PR TITLE
Document inline dependency controls

### DIFF
--- a/src/content/docs/guides/testing/create-fixtures.mdx
+++ b/src/content/docs/guides/testing/create-fixtures.mdx
@@ -50,6 +50,29 @@ The harness calls the generator once per fixture activation. Everything before
 also receive a per-test scratch directory via `TENZIR_TMP_DIR` for temporary
 files.
 
+## Declare Python dependencies
+
+Fixture modules can declare Python package dependencies with PEP 723 script
+metadata. Put the metadata block at the top of the fixture file:
+
+```python
+# /// script
+# dependencies = ["boto3"]
+# ///
+
+from tenzir_test import fixture
+```
+
+When fixture modules declare dependencies, `tenzir-test` installs missing
+packages into the active Python environment with `uv` before it imports the
+fixtures. If a bare dependency name, such as `boto3`, is already installed, the
+harness reuses it instead of running `uv pip install`.
+
+Set `TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL=1` when another tool, such
+as Nix, provisions all fixture dependencies and `tenzir-test` should not install
+packages at runtime. The harness still reads dependency metadata, but fixture
+imports can fail if the dependency is not actually available.
+
 ## Use the fixture in a test
 
 Request a fixture by name in the test's frontmatter. The harness starts it

--- a/src/content/docs/guides/testing/create-fixtures.mdx
+++ b/src/content/docs/guides/testing/create-fixtures.mdx
@@ -50,29 +50,6 @@ The harness calls the generator once per fixture activation. Everything before
 also receive a per-test scratch directory via `TENZIR_TMP_DIR` for temporary
 files.
 
-## Declare Python dependencies
-
-Fixture modules can declare Python package dependencies with PEP 723 script
-metadata. Put the metadata block at the top of the fixture file:
-
-```python
-# /// script
-# dependencies = ["boto3"]
-# ///
-
-from tenzir_test import fixture
-```
-
-When fixture modules declare dependencies, `tenzir-test` installs missing
-packages into the active Python environment with `uv` before it imports the
-fixtures. If a bare dependency name, such as `boto3`, is already installed, the
-harness reuses it instead of running `uv pip install`.
-
-Set `TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL=1` when another tool, such
-as Nix, provisions all fixture dependencies and `tenzir-test` should not install
-packages at runtime. The harness still reads dependency metadata, but fixture
-imports can fail if the dependency is not actually available.
-
 ## Use the fixture in a test
 
 Request a fixture by name in the test's frontmatter. The harness starts it
@@ -193,12 +170,17 @@ def localstack():
     ...
 ```
 
-When a fixture file declares dependencies, `tenzir-test` installs them with
-`uv` before importing project fixtures:
+When a fixture file declares dependencies, `tenzir-test` installs missing
+packages into the active Python environment with `uv` before importing project
+fixtures:
 
 ```sh
 uv pip install --python <current-python> boto3
 ```
+
+If a bare dependency name, such as `boto3`, is already installed, the harness
+reuses it instead of running `uv pip install`. Versioned requirements, such as
+`boto3>=1.34`, still use `uv` so the requested version is enforced.
 
 This works for `fixtures.py` and for any Python module under `fixtures/`,
 including nested modules imported by `fixtures/__init__.py`. The feature also
@@ -209,6 +191,12 @@ Make sure `uv` is on `PATH` when fixture files declare dependencies. If a
 fixture imports an undeclared package, `tenzir-test` still reports the missing
 dependency and suggests running the harness from a project environment or with
 `uvx --with`.
+
+Pass `--disable-inline-dependency-install`, or set
+`TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL=1`, when another tool, such as
+Nix, provisions all fixture dependencies and `tenzir-test` should not install
+packages at runtime. The harness still reads dependency metadata, but fixture
+imports can fail if the dependency is not actually available.
 
 ## Use container runtime helpers
 

--- a/src/content/docs/reference/test-framework/index.mdx
+++ b/src/content/docs/reference/test-framework/index.mdx
@@ -204,6 +204,9 @@ Useful options:
 - `--no-hooks`: Disable project hook loading and invocation. Use this when you
   need to recover from a broken hook or compare behavior without hook side
   effects.
+- `--disable-inline-dependency-install`: Disable runtime installation for
+  inline Python dependencies declared by tests or fixtures. Use this when
+  another tool provisions the Python environment.
 
 Set `TENZIR_TEST_DEBUG=1` in CI when you want the same diagnostics without
 passing `--debug` on the command line.
@@ -1231,7 +1234,7 @@ walks through the full implementation.
   (equivalent to `--no-hooks`).
 - `TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL` – Disable runtime
   installation for inline Python dependencies declared by tests or fixtures.
-  Use this when another tool provisions the Python environment.
+  Equivalent to `--disable-inline-dependency-install`.
 
 ### Binary resolution
 

--- a/src/content/docs/reference/test-framework/index.mdx
+++ b/src/content/docs/reference/test-framework/index.mdx
@@ -1229,6 +1229,9 @@ walks through the full implementation.
   `--debug`).
 - `TENZIR_TEST_DISABLE_HOOKS` – Disable project hook loading and invocation
   (equivalent to `--no-hooks`).
+- `TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL` – Disable runtime
+  installation for inline Python dependencies declared by tests or fixtures.
+  Use this when another tool provisions the Python environment.
 
 ### Binary resolution
 


### PR DESCRIPTION
## 🔍 Problem

- `tenzir-test` can install inline Python dependencies for tests and project fixtures.
- The docs did not explain how pre-provisioned environments interact with those dependencies.
- The new opt-out environment variable was not listed in the test framework reference.

## 🛠️ Solution

- Document PEP 723 fixture dependency metadata in the fixture guide.
- Explain that already-installed bare dependencies are reused.
- Document `TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL` for environments that manage Python dependencies themselves.

## 💬 Review

- The guide text is intentionally scoped to fixture modules; the reference entry covers the environment variable for both tests and fixtures.

<sub>
⚙️ Code PR: tenzir/test#49
</sub>