### PR TITLE
Document idiomatic TQL shaping patterns

### DIFF
--- a/.agents/references/content.md
+++ b/.agents/references/content.md
@@ -21,12 +21,19 @@ Use plain markdown links only when you need custom link text or emphasis.
 Semantic components support anchor targets, for example
 `<Guide>node-setup/tune-performance#benchmark-the-node</Guide>`.
 
-## Consecutive code blocks
+## TQL example outputs
 
-Consecutive TQL code blocks render as a merged visual unit where the second
-block shows an "OUTPUT" label. Only use consecutive blocks when the first is a
-pipeline and the second shows its output. Otherwise, add a paragraph between
-blocks to separate them visually.
+When a TQL code block is an executable pipeline and the result helps readers
+verify the behavior, prefer following it with a second consecutive `tql` code
+block containing representative output. The renderer labels the second block as
+"OUTPUT".
+
+Skip the output block for incomplete snippets, destructive or external-side-
+effect pipelines, sink-only examples, long noisy outputs, or examples where the
+output doesn't clarify the point.
+
+Only use consecutive TQL code blocks for this pipeline/output pair. Otherwise,
+add prose between code blocks to keep them visually separate.
 
 ## First paragraph guidelines
 

--- a/src/content/docs/guides/transformation/reshape-complex-data.mdx
+++ b/src/content/docs/guides/transformation/reshape-complex-data.mdx
@@ -344,6 +344,10 @@ Combine data split across multiple records.
 
 ### Merge records with spread operator
 
+Prefer record spread over <Fn>merge</Fn> when you assemble data from fragments.
+Spread keeps the resulting record visible and scales naturally beyond two
+inputs.
+
 ```tql
 from {
   user: {id: 1, name: "Alice"},

--- a/src/content/docs/guides/transformation/shape-lists.mdx
+++ b/src/content/docs/guides/transformation/shape-lists.mdx
@@ -52,9 +52,11 @@ multi_append = colors.append("blue").append("purple")
 }
 ```
 
-## Combine lists
+## Combine lists with spread
 
-Join multiple lists with <Fn>concatenate</Fn> or spread syntax:
+Use the spread operator `...` to combine lists. Spread keeps the resulting list
+visible where you construct it, and lets you mix existing lists with literals or
+computed values:
 
 ```tql
 from {
@@ -62,8 +64,7 @@ from {
   list2: [4, 5, 6],
   list3: [7, 8, 9]
 }
-combined = concatenate(concatenate(list1, list2), list3)
-spread = [...list1, ...list2, ...list3]
+combined = [...list1, ...list2, ...list3]
 with_value = [...list1, 10, ...list2]
 ```
 
@@ -73,10 +74,33 @@ with_value = [...list1, 10, ...list2]
   list2: [4, 5, 6],
   list3: [7, 8, 9],
   combined: [1, 2, 3, 4, 5, 6, 7, 8, 9],
-  spread: [1, 2, 3, 4, 5, 6, 7, 8, 9],
   with_value: [1, 2, 3, 10, 4, 5, 6]
 }
 ```
+
+Use `else []` when a list fragment may be missing:
+
+```tql
+from {
+  custom_tags: ["vip"],
+  system_tags: ["imported", "reviewed"],
+}
+labels = [
+  ...(custom_tags? else []),
+  ...(system_tags? else []),
+]
+```
+
+```tql
+{
+  custom_tags: ["vip"],
+  system_tags: ["imported", "reviewed"],
+  labels: ["vip", "imported", "reviewed"]
+}
+```
+
+The <Fn>concatenate</Fn> function returns the same result for two lists, but
+prefer spread in transformation code when you construct the resulting list.
 
 ## Transform list elements
 

--- a/src/content/docs/guides/transformation/shape-records.mdx
+++ b/src/content/docs/guides/transformation/shape-records.mdx
@@ -3,7 +3,8 @@ title: Shape records
 ---
 
 Records (objects) contain key-value pairs. This guide shows you how to work with
-records — accessing fields, extracting keys, merging, and transforming values.
+records — accessing fields, extracting keys, combining fragments, and
+transforming values.
 
 ## Access record fields
 
@@ -65,29 +66,62 @@ num_fields = config.keys().length()
 }
 ```
 
-## Merge records
+## Combine records with spread
 
-Combine multiple records with <Fn>merge</Fn> or spread syntax:
+Use the spread operator `...` to combine records. Spread keeps the resulting
+record visible where you construct it, and lets you mix existing fragments with
+literals or computed fields. Later fields overwrite earlier fields, so put
+defaults first and overrides last:
 
 ```tql
 from {
   defaults: {host: "localhost", port: 80, ssl: false},
   custom: {port: 8080, ssl: true}
 }
-merged = merge(defaults, custom)
-spread = {...defaults, ...custom}
-with_extra = {...defaults, ...custom, debug: true}
+service = {
+  ...defaults,
+  ...custom,
+  debug: true,
+}
 ```
 
 ```tql
 {
   defaults: {host: "localhost", port: 80, ssl: false},
   custom: {port: 8080, ssl: true},
-  merged: {host: "localhost", port: 8080, ssl: true},
-  spread: {host: "localhost", port: 8080, ssl: true},
-  with_extra: {host: "localhost", port: 8080, ssl: true, debug: true}
+  service: {
+    host: "localhost",
+    port: 8080,
+    ssl: true,
+    debug: true
+  }
 }
 ```
+
+Use `else {}` when a record fragment may be missing:
+
+```tql
+from {base: {id: 1, name: "Alice"}}
+user = {
+  ...base,
+  ...(profile? else {}),
+  active: true,
+}
+```
+
+```tql
+{
+  base: {id: 1, name: "Alice"},
+  user: {
+    id: 1,
+    name: "Alice",
+    active: true
+  }
+}
+```
+
+The <Fn>merge</Fn> function returns the same result for two records, but prefer
+spread in transformation code when you construct the resulting record.
 
 ## Transform record values
 

--- a/src/content/docs/reference/functions/concatenate.mdx
+++ b/src/content/docs/reference/functions/concatenate.mdx
@@ -40,3 +40,4 @@ zs = concatenate(xs, ys)
 - <Fn>prepend</Fn>
 - <Fn>zip</Fn>
 - <Guide>transformation/shape-lists</Guide>
+- <Tutorial>learn-idiomatic-tql</Tutorial>

--- a/src/content/docs/reference/functions/merge.mdx
+++ b/src/content/docs/reference/functions/merge.mdx
@@ -78,5 +78,6 @@ select result = merge(x, y)
 ## See Also
 
 - <Fn>concatenate</Fn>
+- <Guide>transformation/reshape-complex-data</Guide>
 - <Guide>transformation/shape-records</Guide>
 - <Tutorial>learn-idiomatic-tql</Tutorial>

--- a/src/content/docs/reference/functions/merge.mdx
+++ b/src/content/docs/reference/functions/merge.mdx
@@ -79,3 +79,4 @@ select result = merge(x, y)
 
 - <Fn>concatenate</Fn>
 - <Guide>transformation/shape-records</Guide>
+- <Tutorial>learn-idiomatic-tql</Tutorial>

--- a/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
+++ b/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
@@ -432,6 +432,122 @@ if event_code == "4624" or event_code == "4625" or event_code == "4648" {
 }
 ```
 
+### Prefer spread when combining records and lists
+
+Use the spread operator `...` when you build a record or list from other records
+or lists. Spread keeps the resulting shape visible where you construct it, and
+lets you mix existing fragments with literals or computed fields.
+
+✅ Clear record construction:
+
+```tql
+from {
+  metadata: {original_event_uid: "evt-1"},
+  title: "Suspicious login",
+  service_source: "Microsoft Defender",
+  finding_type_fields: {type_id: 1, type_name: "Finding"},
+}
+finding_info = {
+  uid: metadata.original_event_uid,
+  title: title?,
+  product: {
+    name: service_source?,
+    vendor_name: "Microsoft",
+  },
+  ...finding_type_fields?,
+}
+```
+
+```tql
+{
+  metadata: {original_event_uid: "evt-1"},
+  title: "Suspicious login",
+  service_source: "Microsoft Defender",
+  finding_type_fields: {type_id: 1, type_name: "Finding"},
+  finding_info: {
+    uid: "evt-1",
+    title: "Suspicious login",
+    product: {
+      name: "Microsoft Defender",
+      vendor_name: "Microsoft"
+    },
+    type_id: 1,
+    type_name: "Finding"
+  }
+}
+```
+
+❌ Function call hides the target shape:
+
+```tql
+finding_info = merge({
+  uid: metadata.original_event_uid,
+  title: title?,
+  product: {
+    name: service_source?,
+    vendor_name: "Microsoft",
+  },
+}, finding_type_fields?)
+```
+
+For records, later fields overwrite earlier fields. Put defaults first and
+overrides last:
+
+```tql
+from {observed_endpoint: {hostname: "api.example.com", port: 443}}
+endpoint = {
+  hostname: "unknown",
+  port: 0,
+  ...observed_endpoint,
+  role: "server",
+}
+```
+
+```tql
+{
+  observed_endpoint: {hostname: "api.example.com", port: 443},
+  endpoint: {
+    hostname: "api.example.com",
+    port: 443,
+    role: "server"
+  }
+}
+```
+
+✅ Clear list construction:
+
+```tql
+from {
+  custom_tags: ["vip"],
+  system_tags: ["imported", "reviewed"],
+}
+labels = [
+  ...(custom_tags? else []),
+  ...(system_tags? else []),
+]
+```
+
+```tql
+{
+  custom_tags: ["vip"],
+  system_tags: ["imported", "reviewed"],
+  labels: ["vip", "imported", "reviewed"]
+}
+```
+
+❌ Nested list concatenation gets noisy as inputs grow:
+
+```tql
+labels = concatenate(
+  (custom_tags? else []),
+  (system_tags? else []),
+)
+```
+
+Keep <Fn>merge</Fn> and <Fn>concatenate</Fn> in mind when you read existing code
+or need an explicit two-argument function. For new transformations, prefer
+spread when you are constructing the resulting record or list.
+
 ## Field management
 
 ### Use `move` expressions to prevent field duplication
@@ -744,7 +860,12 @@ severity_level = "critical" if score > 90 else "high" if score > 70 else "medium
 result = "blocked" if is_malicious else "allowed" if is_trusted else "quarantine" if risk > 0.8 else "review" if risk > 0.5 else "log"
 ```
 
-These inline chains are a serious anti-pattern because:
+When you see a statement-level `if`/`else if` ladder over one field, reach for
+`match` first. It models finite dispatch directly, keeps each branch as its own
+pipeline, and forces you to write an explicit fallback. Use a record constant
+only when every branch is a pure key-to-value lookup.
+
+Nested inline chains are a serious anti-pattern because:
 
 - **Unreadable**: Eyes can't parse the logic flow easily
 - **Error-prone**: Easy to mix up conditions and values
@@ -775,8 +896,33 @@ This pattern is particularly powerful for:
 - Providing sensible defaults for missing data
 - Creating reusable transformation logic
 
-If each case needs to run statements instead of returning values, use `match`
-instead of forcing the logic into a record.
+✅ Use `match` for branch pipelines:
+
+```tql
+from {action: "BLOCKED"}
+match action {
+  "BLOCKED" | "DENIED" => {
+    disposition = {id: 2, name: "Blocked"}
+    outcome = "failure"
+  }
+  "ALLOWED" => {
+    disposition = {id: 1, name: "Allowed"}
+    outcome = "success"
+  }
+  _ => {
+    disposition = {id: 0, name: "Unknown"}
+    outcome = "unknown"
+  }
+}
+```
+
+```tql
+{
+  action: "BLOCKED",
+  disposition: {id: 2, name: "Blocked"},
+  outcome: "failure"
+}
+```
 
 ## Writing comments
 

--- a/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
+++ b/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
@@ -438,111 +438,51 @@ Use the spread operator `...` when you build a record or list from other records
 or lists. Spread keeps the resulting shape visible where you construct it, and
 lets you mix existing fragments with literals or computed fields.
 
-✅ Clear record construction:
+✅ Clear construction:
 
 ```tql
 from {
-  metadata: {original_event_uid: "evt-1"},
-  title: "Suspicious login",
-  service_source: "Microsoft Defender",
-  finding_type_fields: {type_id: 1, type_name: "Finding"},
+  defaults: {host: "localhost", port: 80},
+  overrides: {port: 443},
+  base_tags: ["prod"],
+  extra_tags: ["api"],
 }
-finding_info = {
-  uid: metadata.original_event_uid,
-  title: title?,
-  product: {
-    name: service_source?,
-    vendor_name: "Microsoft",
-  },
-  ...finding_type_fields?,
+
+service = {
+  ...defaults,
+  ...overrides,
+  tls: true,
 }
-```
-
-```tql
-{
-  metadata: {original_event_uid: "evt-1"},
-  title: "Suspicious login",
-  service_source: "Microsoft Defender",
-  finding_type_fields: {type_id: 1, type_name: "Finding"},
-  finding_info: {
-    uid: "evt-1",
-    title: "Suspicious login",
-    product: {
-      name: "Microsoft Defender",
-      vendor_name: "Microsoft"
-    },
-    type_id: 1,
-    type_name: "Finding"
-  }
-}
-```
-
-❌ Function call hides the target shape:
-
-```tql
-finding_info = merge({
-  uid: metadata.original_event_uid,
-  title: title?,
-  product: {
-    name: service_source?,
-    vendor_name: "Microsoft",
-  },
-}, finding_type_fields?)
-```
-
-For records, later fields overwrite earlier fields. Put defaults first and
-overrides last:
-
-```tql
-from {observed_endpoint: {hostname: "api.example.com", port: 443}}
-endpoint = {
-  hostname: "unknown",
-  port: 0,
-  ...observed_endpoint,
-  role: "server",
-}
-```
-
-```tql
-{
-  observed_endpoint: {hostname: "api.example.com", port: 443},
-  endpoint: {
-    hostname: "api.example.com",
-    port: 443,
-    role: "server"
-  }
-}
-```
-
-✅ Clear list construction:
-
-```tql
-from {
-  custom_tags: ["vip"],
-  system_tags: ["imported", "reviewed"],
-}
-labels = [
-  ...(custom_tags? else []),
-  ...(system_tags? else []),
+tags = [
+  ...base_tags,
+  "monitored",
+  ...extra_tags,
 ]
 ```
 
 ```tql
 {
-  custom_tags: ["vip"],
-  system_tags: ["imported", "reviewed"],
-  labels: ["vip", "imported", "reviewed"]
+  defaults: {host: "localhost", port: 80},
+  overrides: {port: 443},
+  base_tags: ["prod"],
+  extra_tags: ["api"],
+  service: {host: "localhost", port: 443, tls: true},
+  tags: ["prod", "monitored", "api"]
 }
 ```
 
-❌ Nested list concatenation gets noisy as inputs grow:
+For records, later fields overwrite earlier fields. Put defaults first and
+overrides last.
+
+❌ Nested function calls hide the target shape:
 
 ```tql
-labels = concatenate(
-  (custom_tags? else []),
-  (system_tags? else []),
-)
+service = merge(merge(defaults, overrides), {tls: true})
+tags = concatenate(concatenate(base_tags, ["monitored"]), extra_tags)
 ```
+
+When a fragment may be missing, use `...(record? else {})` for records and
+`...(list? else [])` for lists.
 
 Keep <Fn>merge</Fn> and <Fn>concatenate</Fn> in mind when you read existing code
 or need an explicit two-argument function. For new transformations, prefer


### PR DESCRIPTION
## 🔍 Problem

- The idiomatic TQL docs did not consistently show outputs for executable examples.
- The guide mentioned alternatives to if/else chains, but the `match` recommendation was easy to miss.

## 🛠️ Solution

- Prefer spread in list and record shaping examples, including missing-fragment fallbacks and output blocks.
- Call out `match` as the first choice for statement-level finite branch ladders.
- Add agent guidance to prefer representative output blocks after executable TQL examples.

## 💬 Review

- Focus on whether the output examples are representative and whether the `match` vs record-lookup guidance is clear.