### PR TITLE
Document Amazon SQS operator rename

### DIFF
--- a/src/content/docs/guides/collecting/read-from-message-brokers.mdx
+++ b/src/content/docs/guides/collecting/read-from-message-brokers.mdx
@@ -110,12 +110,12 @@ parameters. The operator emits each AMQP payload in the `message` field.
 ## Amazon SQS
 
 [Amazon SQS](/integrations/amazon/sqs) is a managed message queue. Use
-`from_sqs` to receive events from SQS queues.
+`from_amazon_sqs` to receive events from SQS queues.
 
 ### Receive from a queue
 
 ```tql
-from_sqs "sqs://my-queue"
+from_amazon_sqs "sqs://my-queue"
 this = message.parse_json()
 ```
 
@@ -125,7 +125,7 @@ Use long polling to reduce empty responses, and set `batch_size` to control the
 maximum number of messages per receive request:
 
 ```tql
-from_sqs "sqs://my-queue", poll_time=5s, batch_size=10
+from_amazon_sqs "sqs://my-queue", poll_time=5s, batch_size=10
 ```
 
 By default, Tenzir deletes each SQS message after emitting it. Set
@@ -133,7 +133,7 @@ By default, Tenzir deletes each SQS message after emitting it. Set
 again after the queue's visibility timeout:
 
 ```tql
-from_sqs "sqs://my-queue", keep_messages=true, visibility_timeout=30s
+from_amazon_sqs "sqs://my-queue", keep_messages=true, visibility_timeout=30s
 ```
 
 ## Google Cloud Pub/Sub

--- a/src/content/docs/guides/routing/send-to-destinations.mdx
+++ b/src/content/docs/guides/routing/send-to-destinations.mdx
@@ -75,7 +75,7 @@ Send to SQS:
 
 ```tql
 subscribe "notifications"
-to_sqs "sqs://notifications", message=this.print_json()
+to_amazon_sqs "sqs://notifications", message=this.print_json()
 ```
 
 Send to Pub/Sub:

--- a/src/content/docs/guides/tenzir-v6-migration.mdx
+++ b/src/content/docs/guides/tenzir-v6-migration.mdx
@@ -196,8 +196,8 @@ detection is not enough.
 | `save_kafka`               | `to_kafka`                 |
 | `load_amqp`                | `from_amqp`                |
 | `save_amqp`                | `to_amqp`                  |
-| `load_sqs`                 | `from_sqs`                 |
-| `save_sqs`                 | `to_sqs`                   |
+| `load_sqs`                 | `from_amazon_sqs`          |
+| `save_sqs`                 | `to_amazon_sqs`            |
 | `load_google_cloud_pubsub` | `from_google_cloud_pubsub` |
 | `save_google_cloud_pubsub` | `to_google_cloud_pubsub`   |
 
@@ -270,7 +270,7 @@ the v6 operator for each URI scheme.
 | `kafka`             | `from_kafka`                      |
 | `opensearch`        | `from_opensearch`                 |
 | `s3`                | `from_s3`                         |
-| `sqs`               | `from_sqs`                        |
+| `sqs`               | `from_amazon_sqs`                 |
 | `tcp`               | `from_tcp` or `accept_tcp`        |
 | `udp`               | `accept_udp`                      |
 
@@ -297,7 +297,7 @@ the v6 operator for each URI scheme.
 | `inproc`, `zmq`                     | `to_zmq`                         |
 | `kafka`                             | `to_kafka`                       |
 | `s3`                                | `to_s3`                          |
-| `sqs`                               | `to_sqs`                         |
+| `sqs`                               | `to_amazon_sqs`                  |
 | `tcp`                               | `to_tcp` or `serve_tcp`          |
 | `udp`                               | `to_udp`                         |
 | `smtp`, `smtps`, `mailto`, `email`  | No replacement — see below.      |
@@ -622,6 +622,10 @@ no default serialization format.
 
 #### SQS
 
+In compatibility mode, the legacy operators keep the names `load_sqs` and
+`save_sqs`. When you migrate SQS pipelines to the v6 new executor, use the
+vendor-qualified <Op>from_amazon_sqs</Op> and <Op>to_amazon_sqs</Op> operators.
+
 ##### Consume
 
 Before:
@@ -634,7 +638,7 @@ read_json
 After:
 
 ```tql
-from_sqs "queue"
+from_amazon_sqs "queue"
 this = message.parse_json()
 ```
 
@@ -652,10 +656,11 @@ After:
 
 ```tql
 export
-to_sqs "queue"
+to_amazon_sqs "queue"
 ```
 
-`to_sqs` sends one SQS message per event and serializes it as NDJSON by default.
+`to_amazon_sqs` sends one SQS message per event and serializes it as NDJSON by
+default.
 
 #### ZMQ
 

--- a/src/content/docs/integrations/amazon/sqs.mdx
+++ b/src/content/docs/integrations/amazon/sqs.mdx
@@ -6,8 +6,8 @@ title: SQS
 message queue on AWS. It supports microservices, distributed systems, and
 serverless applications.
 
-Tenzir can receive messages from SQS queues with <Op>from_sqs</Op> and send
-messages to SQS queues with <Op>to_sqs</Op>.
+Tenzir can receive messages from SQS queues with <Op>from_amazon_sqs</Op> and
+send messages to SQS queues with <Op>to_amazon_sqs</Op>.
 
 ![SQS](sqs.svg)
 
@@ -22,7 +22,7 @@ Combine it with `visibility_timeout` to control when SQS makes the messages
 visible again:
 
 ```tql
-from_sqs "sqs://my-queue", keep_messages=true, visibility_timeout=30s
+from_amazon_sqs "sqs://my-queue", keep_messages=true, visibility_timeout=30s
 ```
 
 With `keep_messages=true`, SQS makes the message visible again after the
@@ -41,9 +41,9 @@ per receive request. SQS supports values from `1` to `10`.
 Pass a queue name, an `sqs://` URL, or a full SQS queue URL:
 
 ```tql
-from_sqs "alerts"
-from_sqs "sqs://alerts"
-from_sqs "https://sqs.eu-west-1.amazonaws.com/123456789012/alerts",
+from_amazon_sqs "alerts"
+from_amazon_sqs "sqs://alerts"
+from_amazon_sqs "https://sqs.eu-west-1.amazonaws.com/123456789012/alerts",
   aws_region="eu-west-1"
 ```
 
@@ -60,7 +60,7 @@ authenticate with your AWS credentials.
 Alternatively, use the `aws_iam` parameter to provide explicit credentials:
 
 ```tql
-from_sqs "my-queue", aws_iam={
+from_amazon_sqs "my-queue", aws_iam={
   region: "us-east-1",
   access_key_id: secret("aws-key"),
   secret_access_key: secret("aws-secret")
@@ -70,7 +70,7 @@ from_sqs "my-queue", aws_iam={
 You can also use `aws_iam` to assume an IAM role:
 
 ```tql
-from_sqs "my-queue", aws_iam={
+from_amazon_sqs "my-queue", aws_iam={
   region: "eu-west-1",
   assume_role: "arn:aws:iam::123456789012:role/my-sqs-role",
   session_name: "tenzir-session"
@@ -79,13 +79,13 @@ from_sqs "my-queue", aws_iam={
 
 Tenzir needs these SQS permissions:
 
-| Operator      | Required permissions                                      |
-| ------------- | --------------------------------------------------------- |
-| <Op>from_sqs</Op> | `sqs:GetQueueUrl`, `sqs:ReceiveMessage`, `sqs:DeleteMessage` |
-| <Op>to_sqs</Op>   | `sqs:GetQueueUrl`, `sqs:SendMessage`                       |
+| Operator                 | Required permissions                                             |
+| ------------------------ | ---------------------------------------------------------------- |
+| <Op>from_amazon_sqs</Op> | `sqs:GetQueueUrl`, `sqs:ReceiveMessage`, `sqs:DeleteMessage`     |
+| <Op>to_amazon_sqs</Op>   | `sqs:GetQueueUrl`, `sqs:SendMessage`                             |
 
 You don't need `sqs:GetQueueUrl` when you pass a full queue URL. You also don't
-need `sqs:DeleteMessage` for `from_sqs` pipelines that always use
+need `sqs:DeleteMessage` for `from_amazon_sqs` pipelines that always use
 `keep_messages=true`.
 
 ## Examples
@@ -94,13 +94,13 @@ need `sqs:DeleteMessage` for `from_sqs` pipelines that always use
 
 ```tql
 from {foo: 42}
-to_sqs "sqs://my-queue", message=this.print_json()
+to_amazon_sqs "sqs://my-queue", message=this.print_json()
 ```
 
 ### Receive messages from an SQS queue
 
 ```tql
-from_sqs "sqs://my-queue", poll_time=5s, batch_size=10
+from_amazon_sqs "sqs://my-queue", poll_time=5s, batch_size=10
 this = message.parse_json()
 ```
 
@@ -111,7 +111,7 @@ this = message.parse_json()
 ### Receive messages without deleting them
 
 ```tql
-from_sqs "sqs://my-queue",
+from_amazon_sqs "sqs://my-queue",
   keep_messages=true,
   poll_time=5s,
   batch_size=10,
@@ -121,7 +121,7 @@ this = message.parse_json()
 
 ## See Also
 
-- <Op>from_sqs</Op>
-- <Op>to_sqs</Op>
+- <Op>from_amazon_sqs</Op>
+- <Op>to_amazon_sqs</Op>
 - <Guide>collecting/read-from-message-brokers</Guide>
 - <Guide>routing/send-to-destinations</Guide>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -411,10 +411,10 @@ operators:
     description: 'Retrieves PowerQuery results from SentinelOne Singularity Data Lake.'
     example: 'from_sentinelone_data_lake "https://…", …'
     path: 'reference/operators/from_sentinelone_data_lake'
-  - name: 'from_sqs'
+  - name: 'from_amazon_sqs'
     description: 'Receives messages from an Amazon SQS queue.'
-    example: 'from_sqs "sqs://tenzir", poll_time=5s'
-    path: 'reference/operators/from_sqs'
+    example: 'from_amazon_sqs "sqs://tenzir", poll_time=5s'
+    path: 'reference/operators/from_amazon_sqs'
   - name: 'from_stdin'
     description: 'Reads and parses events from standard input.'
     example: 'from_stdin { read_json }'
@@ -627,10 +627,10 @@ operators:
     description: 'Sends messages to an AMQP exchange.'
     example: 'to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"'
     path: 'reference/operators/to_amqp'
-  - name: 'to_sqs'
+  - name: 'to_amazon_sqs'
     description: 'Sends messages to an Amazon SQS queue.'
-    example: 'to_sqs "sqs://tenzir"'
-    path: 'reference/operators/to_sqs'
+    example: 'to_amazon_sqs "sqs://tenzir"'
+    path: 'reference/operators/to_amazon_sqs'
   - name: 'to_udp'
     description: 'Sends one UDP datagram per input event.'
     example: 'to_udp "127.0.0.1:514"'
@@ -1570,10 +1570,10 @@ from_sentinelone_data_lake "https://…", …
 
 </ReferenceCard>
 
-<ReferenceCard title="from_sqs" description="Receives messages from an Amazon SQS queue." href="/reference/operators/from_sqs">
+<ReferenceCard title="from_amazon_sqs" description="Receives messages from an Amazon SQS queue." href="/reference/operators/from_amazon_sqs">
 
 ```tql
-from_sqs "sqs://tenzir", poll_time=5s
+from_amazon_sqs "sqs://tenzir", poll_time=5s
 ```
 
 </ReferenceCard>
@@ -2074,10 +2074,10 @@ to_splunk "localhost:8088", …
 
 </ReferenceCard>
 
-<ReferenceCard title="to_sqs" description="Sends messages to an Amazon SQS queue." href="/reference/operators/to_sqs">
+<ReferenceCard title="to_amazon_sqs" description="Sends messages to an Amazon SQS queue." href="/reference/operators/to_amazon_sqs">
 
 ```tql
-to_sqs "sqs://tenzir"
+to_amazon_sqs "sqs://tenzir"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -351,6 +351,10 @@ operators:
     description: 'Reads events from Amazon CloudWatch.'
     example: 'from_amazon_cloudwatch "/aws/lambda/api", mode="search"'
     path: 'reference/operators/from_amazon_cloudwatch'
+  - name: 'from_amazon_sqs'
+    description: 'Receives messages from an Amazon SQS queue.'
+    example: 'from_amazon_sqs "sqs://tenzir", poll_time=5s'
+    path: 'reference/operators/from_amazon_sqs'
   - name: 'from_amqp'
     description: 'Receives messages from an AMQP queue.'
     example: 'from_amqp "amqp://admin:pass@0.0.0.1:5672/vhost", queue="events"'
@@ -411,10 +415,6 @@ operators:
     description: 'Retrieves PowerQuery results from SentinelOne Singularity Data Lake.'
     example: 'from_sentinelone_data_lake "https://…", …'
     path: 'reference/operators/from_sentinelone_data_lake'
-  - name: 'from_amazon_sqs'
-    description: 'Receives messages from an Amazon SQS queue.'
-    example: 'from_amazon_sqs "sqs://tenzir", poll_time=5s'
-    path: 'reference/operators/from_amazon_sqs'
   - name: 'from_stdin'
     description: 'Reads and parses events from standard input.'
     example: 'from_stdin { read_json }'
@@ -627,10 +627,6 @@ operators:
     description: 'Sends messages to an AMQP exchange.'
     example: 'to_amqp "amqp://admin:pass@0.0.0.1:5672/vhost"'
     path: 'reference/operators/to_amqp'
-  - name: 'to_amazon_sqs'
-    description: 'Sends messages to an Amazon SQS queue.'
-    example: 'to_amazon_sqs "sqs://tenzir"'
-    path: 'reference/operators/to_amazon_sqs'
   - name: 'to_udp'
     description: 'Sends one UDP datagram per input event.'
     example: 'to_udp "127.0.0.1:514"'
@@ -651,6 +647,10 @@ operators:
     description: 'Sends OCSF events to Amazon Security Lake.'
     example: 'to_amazon_security_lake "s3://…"'
     path: 'reference/operators/to_amazon_security_lake'
+  - name: 'to_amazon_sqs'
+    description: 'Sends messages to an Amazon SQS queue.'
+    example: 'to_amazon_sqs "sqs://tenzir"'
+    path: 'reference/operators/to_amazon_sqs'
   - name: 'to_azure_blob_storage'
     description: 'Writes events to one or multiple blobs in Azure Blob Storage.'
     example: 'to_azure_blob_storage "abfs://container/data/{uuid}.json" { write_ndjson }'
@@ -1450,6 +1450,14 @@ from_amazon_cloudwatch "/aws/lambda/api", mode="search"
 
 </ReferenceCard>
 
+<ReferenceCard title="from_amazon_sqs" description="Receives messages from an Amazon SQS queue." href="/reference/operators/from_amazon_sqs">
+
+```tql
+from_amazon_sqs "sqs://tenzir", poll_time=5s
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="from_amqp" description="Receives messages from an AMQP queue." href="/reference/operators/from_amqp">
 
 ```tql
@@ -1566,14 +1574,6 @@ from_s3 "s3://my-bucket/data/**.json"
 
 ```tql
 from_sentinelone_data_lake "https://…", …
-```
-
-</ReferenceCard>
-
-<ReferenceCard title="from_amazon_sqs" description="Receives messages from an Amazon SQS queue." href="/reference/operators/from_amazon_sqs">
-
-```tql
-from_amazon_sqs "sqs://tenzir", poll_time=5s
 ```
 
 </ReferenceCard>
@@ -1906,6 +1906,14 @@ to_amazon_security_lake "s3://…"
 
 </ReferenceCard>
 
+<ReferenceCard title="to_amazon_sqs" description="Sends messages to an Amazon SQS queue." href="/reference/operators/to_amazon_sqs">
+
+```tql
+to_amazon_sqs "sqs://tenzir"
+```
+
+</ReferenceCard>
+
 <ReferenceCard title="to_amqp" description="Sends messages to an AMQP exchange." href="/reference/operators/to_amqp">
 
 ```tql
@@ -2070,14 +2078,6 @@ to_snowflake account_identifier="…
 
 ```tql
 to_splunk "localhost:8088", …
-```
-
-</ReferenceCard>
-
-<ReferenceCard title="to_amazon_sqs" description="Sends messages to an Amazon SQS queue." href="/reference/operators/to_amazon_sqs">
-
-```tql
-to_amazon_sqs "sqs://tenzir"
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/operators/from_amazon_sqs.mdx
+++ b/src/content/docs/reference/operators/from_amazon_sqs.mdx
@@ -1,7 +1,7 @@
 ---
-title: from_sqs
+title: from_amazon_sqs
 category: Inputs/Events
-example: 'from_sqs "sqs://tenzir", poll_time=5s'
+example: 'from_amazon_sqs "sqs://tenzir", poll_time=5s'
 ---
 
 import AWSIAMOptions from '@partials/operators/AWSIAMOptions.mdx';
@@ -11,15 +11,16 @@ Receives messages from an [Amazon SQS][sqs] queue.
 [sqs]: https://docs.aws.amazon.com/sqs/
 
 ```tql
-from_sqs queue:str, [keep_messages=bool, batch_size=int, poll_time=duration,
-                     visibility_timeout=duration, aws_region=str, aws_iam=record]
+from_amazon_sqs queue:str, [keep_messages=bool, batch_size=int, poll_time=duration,
+                            visibility_timeout=duration, aws_region=str,
+                            aws_iam=record]
 ```
 
 ## Description
 
 [Amazon Simple Queue Service (Amazon SQS)][sqs] is a fully managed message
-queueing service for decoupling distributed systems. The `from_sqs` operator
-reads messages from an SQS queue and emits one event per message.
+queueing service for decoupling distributed systems. The `from_amazon_sqs`
+operator reads messages from an SQS queue and emits one event per message.
 
 The emitted events use the `tenzir.sqs` schema with these fields:
 
@@ -83,7 +84,7 @@ Defaults to `false`.
 Set this option to `true` to keep received messages in the queue:
 
 ```tql
-from_sqs "my-queue", keep_messages=true
+from_amazon_sqs "my-queue", keep_messages=true
 ```
 
 When `keep_messages=true`, SQS hides each received message until the queue's
@@ -102,7 +103,7 @@ Use this option with `keep_messages=true` to control when messages become
 available for redelivery:
 
 ```tql
-from_sqs "my-queue", keep_messages=true, visibility_timeout=30s
+from_amazon_sqs "my-queue", keep_messages=true, visibility_timeout=30s
 ```
 
 ### `aws_region = str (optional)`
@@ -119,20 +120,20 @@ it uses the default AWS SDK region resolution.
 ### Receive messages from a queue
 
 ```tql
-from_sqs "sqs://tenzir"
+from_amazon_sqs "sqs://tenzir"
 ```
 
 ### Parse JSON messages
 
 ```tql
-from_sqs "sqs://alerts", poll_time=5s, batch_size=10
+from_amazon_sqs "sqs://alerts", poll_time=5s, batch_size=10
 this = message.parse_json()
 ```
 
 ### Receive messages without deleting them
 
 ```tql
-from_sqs "sqs://alerts",
+from_amazon_sqs "sqs://alerts",
   keep_messages=true,
   poll_time=5s,
   batch_size=10,
@@ -143,20 +144,20 @@ this = message.parse_json()
 ### Use an explicit region
 
 ```tql
-from_sqs "my-queue", aws_region="us-east-1"
+from_amazon_sqs "my-queue", aws_region="us-east-1"
 ```
 
 ### Pass a queue URL directly
 
 ```tql
-from_sqs "https://sqs.eu-west-1.amazonaws.com/123456789012/my-queue",
+from_amazon_sqs "https://sqs.eu-west-1.amazonaws.com/123456789012/my-queue",
   aws_region="eu-west-1"
 ```
 
 ### Use explicit credentials
 
 ```tql
-from_sqs "my-queue", aws_iam={
+from_amazon_sqs "my-queue", aws_iam={
   region: "us-east-1",
   access_key_id: secret("aws-key"),
   secret_access_key: secret("aws-secret")
@@ -166,7 +167,7 @@ from_sqs "my-queue", aws_iam={
 ### Assume an IAM role
 
 ```tql
-from_sqs "my-queue", aws_iam={
+from_amazon_sqs "my-queue", aws_iam={
   region: "eu-west-1",
   assume_role: "arn:aws:iam::123456789012:role/my-sqs-role",
   session_name: "tenzir-session"
@@ -175,6 +176,6 @@ from_sqs "my-queue", aws_iam={
 
 ## See Also
 
-- <Op>to_sqs</Op>
+- <Op>to_amazon_sqs</Op>
 - <Guide>collecting/read-from-message-brokers</Guide>
 - <Integration>amazon/sqs</Integration>

--- a/src/content/docs/reference/operators/to_amazon_sqs.mdx
+++ b/src/content/docs/reference/operators/to_amazon_sqs.mdx
@@ -1,7 +1,7 @@
 ---
-title: to_sqs
+title: to_amazon_sqs
 category: Outputs/Events
-example: 'to_sqs "sqs://tenzir"'
+example: 'to_amazon_sqs "sqs://tenzir"'
 ---
 
 import AWSIAMOptions from '@partials/operators/AWSIAMOptions.mdx';
@@ -11,19 +11,19 @@ Sends messages to an [Amazon SQS][sqs] queue.
 [sqs]: https://docs.aws.amazon.com/sqs/
 
 ```tql
-to_sqs queue:str, [message=str|blob, aws_region=str, aws_iam=record]
+to_amazon_sqs queue:str, [message=str|blob, aws_region=str, aws_iam=record]
 ```
 
 ## Description
 
 [Amazon Simple Queue Service (Amazon SQS)][sqs] is a fully managed message
-queueing service for decoupling distributed systems. The `to_sqs` operator sends
-one SQS message per input event.
+queueing service for decoupling distributed systems. The `to_amazon_sqs`
+operator sends one SQS message per input event.
 
-By default, `to_sqs` serializes each input event as NDJSON. Use the `message`
-option to send a specific string or blob expression instead. If the expression
-evaluates to `null` or another type, the operator skips that event and emits a
-warning.
+By default, `to_amazon_sqs` serializes each input event as NDJSON. Use the
+`message` option to send a specific string or blob expression instead. If the
+expression evaluates to `null` or another type, the operator skips that event
+and emits a warning.
 
 The operator requires the following AWS permissions:
 
@@ -60,29 +60,29 @@ it uses the default AWS SDK region resolution.
 ### Send events to a queue
 
 ```tql
-subscribe "to-sqs"
-to_sqs "sqs://tenzir"
+subscribe "to-amazon-sqs"
+to_amazon_sqs "sqs://tenzir"
 ```
 
 ### Send a specific field as the message body
 
 ```tql
 from {payload: "security event detected"}
-to_sqs "alerts-queue", message=payload
+to_amazon_sqs "alerts-queue", message=payload
 ```
 
 ### Use an explicit region
 
 ```tql
 from {alert: "security event detected"}
-to_sqs "alerts-queue", aws_region="us-east-1"
+to_amazon_sqs "alerts-queue", aws_region="us-east-1"
 ```
 
 ### Pass a queue URL directly
 
 ```tql
 from {alert: "security event detected"}
-to_sqs "https://sqs.eu-west-1.amazonaws.com/123456789012/alerts-queue",
+to_amazon_sqs "https://sqs.eu-west-1.amazonaws.com/123456789012/alerts-queue",
   aws_region="eu-west-1"
 ```
 
@@ -90,7 +90,7 @@ to_sqs "https://sqs.eu-west-1.amazonaws.com/123456789012/alerts-queue",
 
 ```tql
 from {alert: "security event detected"}
-to_sqs "alerts-queue", aws_iam={
+to_amazon_sqs "alerts-queue", aws_iam={
   region: "us-east-1",
   access_key_id: secret("aws-key"),
   secret_access_key: secret("aws-secret")
@@ -101,7 +101,7 @@ to_sqs "alerts-queue", aws_iam={
 
 ```tql
 subscribe "events"
-to_sqs "my-queue", aws_iam={
+to_amazon_sqs "my-queue", aws_iam={
   region: "eu-west-1",
   assume_role: "arn:aws:iam::123456789012:role/my-sqs-role"
 }
@@ -109,6 +109,6 @@ to_sqs "my-queue", aws_iam={
 
 ## See Also
 
-- <Op>from_sqs</Op>
+- <Op>from_amazon_sqs</Op>
 - <Guide>routing/send-to-destinations</Guide>
 - <Integration>amazon/sqs</Integration>

--- a/src/utils/redirects.mjs
+++ b/src/utils/redirects.mjs
@@ -13,6 +13,9 @@ const STATIC_REDIRECTS = {
   "/explanations/language/expressions": "/reference/expressions",
   "/explanations/language/statements": "/reference/statements",
   "/explanations/language/programs": "/reference/programs",
+  // Operator aliases
+  "/reference/operators/from_sqs": "/reference/operators/from_amazon_sqs",
+  "/reference/operators/to_sqs": "/reference/operators/to_amazon_sqs",
 };
 
 /**


### PR DESCRIPTION
## 🔍 Problem

The v6 migration guide and SQS docs still referenced the old new-executor operator names `from_sqs` and `to_sqs`.

## 🛠️ Solution

- Document `from_amazon_sqs` and `to_amazon_sqs` as the v6 replacements for SQS pipelines.
- Update the SQS integration and operator reference pages to use the vendor-qualified names.

## 💬 Review

Focus on the migration-guide wording: compatibility mode keeps `load_sqs` and `save_sqs`, while migrated v6 neo pipelines should use the renamed operators.

<sub>
⚙️ Code PR: tenzir/tenzir#6238<br>
🎫 References TNZ-613
</sub>
