### PR TITLE
Document UDO parameter type syntax

### DIFF
--- a/src/content/docs/guides/packages/add-operators.mdx
+++ b/src/content/docs/guides/packages/add-operators.mdx
@@ -58,17 +58,23 @@ Each parameter supports the following fields:
 
 ### Supported types
 
-The `type` field constrains what values the parameter accepts:
+The `type` field constrains what values the parameter accepts. It uses TQL type
+definition syntax:
 
-| Type     | Description                                                           |
-| -------- | --------------------------------------------------------------------- |
-| `field`  | A field selector (for example, `name`). Cannot have non-null defaults |
-| `string` | A string literal or expression                                        |
-| `int`    | An integer value                                                      |
-| `double` | A floating-point value                                                |
-| `bool`   | A boolean value                                                       |
-| `ip`     | An IP address                                                         |
-| `secret` | A secret string (accepts string literals)                             |
+| Type       | Description                                                           |
+| ---------- | --------------------------------------------------------------------- |
+| `field`    | A field selector (for example, `name`). Cannot have non-null defaults |
+| `string`   | A string literal or expression                                        |
+| `int`      | A signed integer value                                                |
+| `uint`     | An unsigned integer value                                             |
+| `float`    | A floating-point value                                                |
+| `bool`     | A boolean value                                                       |
+| `duration` | A duration value                                                      |
+| `time`     | A timestamp value                                                     |
+| `ip`       | An IP address                                                         |
+| `subnet`   | A subnet value                                                        |
+| `blob`     | A blob value                                                          |
+| `secret`   | A secret string (accepts string literals)                             |
 
 If you omit the `type` field, the parameter accepts any value.
 

--- a/src/content/docs/guides/tenzir-v6-migration.mdx
+++ b/src/content/docs/guides/tenzir-v6-migration.mdx
@@ -85,6 +85,13 @@ Use this checklist to plan the migration:
 - If you use compatibility mode, track pipelines that still need `// neo`.
 - Deploy and monitor migrated pipelines.
 
+## Migrate package UDO parameter types
+
+Package UDO parameter types now use TQL type-definition syntax. Use TQL type
+names such as `int`, `uint`, and `float` instead of legacy names such as
+`int64`, `uint64`, and `double`. List types use TQL syntax and must be quoted in
+YAML, for example `type: "[int]"`.
+
 ## New v6 execution patterns
 
 The most important migration change is the move away from old byte-stream source


### PR DESCRIPTION
## Summary

- Document the v6 migration from legacy package UDO parameter type names to TQL type-definition syntax.
- Keep the current package operator guide focused on the supported current type names.
- List the supported builtin value types for UDO parameter metadata.

<sub>
⚙️ Code PR: tenzir/tenzir#6242
</sub>