### PR TITLE
Document TQL editor setup

### DIFF
--- a/src/content/docs/guides/development/setup-syntax-highlighting.mdx
+++ b/src/content/docs/guides/development/setup-syntax-highlighting.mdx
@@ -30,36 +30,12 @@ latest TQL parser and highlight queries.
 
 ## Helix
 
-Add a TQL language entry to `~/.config/helix/languages.toml`:
-
-```toml
-[[language]]
-name = "tql"
-scope = "source.tql"
-file-types = ["tql"]
-comment-tokens = "//"
-block-comment-tokens = { start = "/*", end = "*/" }
-indent = { tab-width = 2, unit = "  " }
-
-[[grammar]]
-name = "tql"
-source = { git = "https://github.com/tenzir/tree-sitter-tql", rev = "main" }
-```
-
-Fetch and build the parser:
+Helix includes TQL syntax highlighting and indentation support. Use a Helix
+version that ships the TQL grammar, then fetch and build the bundled parser:
 
 ```sh
 hx --grammar fetch
 hx --grammar build
-```
-
-Helix loads query files from its runtime directory. Clone the grammar repository
-and copy the TQL queries into your local Helix runtime:
-
-```sh
-git clone https://github.com/tenzir/tree-sitter-tql
-mkdir -p ~/.config/helix/runtime/queries/tql
-cp tree-sitter-tql/queries/tql/*.scm ~/.config/helix/runtime/queries/tql/
 ```
 
 Open a `.tql` file and run `hx --health tql` to confirm that Helix detects the

--- a/src/content/docs/guides/development/setup-syntax-highlighting.mdx
+++ b/src/content/docs/guides/development/setup-syntax-highlighting.mdx
@@ -17,6 +17,10 @@ highlights, indentation, folds, injections, and local variables.
 Install the [TQL extension for VS Code](https://github.com/tenzir/vscode-tql)
 for syntax highlighting and language support.
 
+VS Code-compatible editors such as Cursor and Windsurf can use the same
+extension when it is available in their extension marketplace. If the extension
+doesn't appear there, install a packaged `.vsix` file manually.
+
 ## Zed
 
 [Zed](https://zed.dev) is a high-performance editor with AI integration. Install

--- a/src/content/docs/guides/development/setup-syntax-highlighting.mdx
+++ b/src/content/docs/guides/development/setup-syntax-highlighting.mdx
@@ -58,13 +58,13 @@ return {
     'tenzir/tree-sitter-tql',
   },
   opts = function(_, opts)
-    opts.ensure_installed = {
-      'tql',
-    }
+    opts.ensure_installed = opts.ensure_installed or {}
+    if not vim.tbl_contains(opts.ensure_installed, 'tql') then
+      table.insert(opts.ensure_installed, 'tql')
+    end
 
-    opts.highlight = {
-      enable = true,
-    }
+    opts.highlight = opts.highlight or {}
+    opts.highlight.enable = true
 
     return opts
   end,

--- a/src/content/docs/guides/development/setup-syntax-highlighting.mdx
+++ b/src/content/docs/guides/development/setup-syntax-highlighting.mdx
@@ -52,7 +52,7 @@ configuration:
 
 ```lua
 return {
-  'nvim-treesitter/nvim-treesitter',
+  'neovim-treesitter/nvim-treesitter',
   dependencies = {
     'neovim-treesitter/treesitter-parser-registry',
   },

--- a/src/content/docs/guides/development/setup-syntax-highlighting.mdx
+++ b/src/content/docs/guides/development/setup-syntax-highlighting.mdx
@@ -51,35 +51,40 @@ With [lazy.nvim](https://github.com/folke/lazy.nvim), add this plugin
 configuration:
 
 ```lua
+local function register_tql_parser()
+  require('nvim-treesitter.parsers').tql = {
+    install_info = {
+      url = 'https://github.com/tenzir/tree-sitter-tql',
+      branch = 'main',
+    },
+  }
+end
+
 return {
   'nvim-treesitter/nvim-treesitter',
+  branch = 'main',
   build = ':TSUpdate',
   dependencies = {
     'tenzir/tree-sitter-tql',
   },
-  opts = function(_, opts)
-    opts.ensure_installed = opts.ensure_installed or {}
-    if not vim.tbl_contains(opts.ensure_installed, 'tql') then
-      table.insert(opts.ensure_installed, 'tql')
-    end
+  config = function()
+    local treesitter = require('nvim-treesitter')
 
-    opts.highlight = opts.highlight or {}
-    opts.highlight.enable = true
+    vim.api.nvim_create_autocmd('User', {
+      pattern = 'TSUpdate',
+      callback = register_tql_parser,
+    })
+    register_tql_parser()
 
-    return opts
-  end,
-  config = function(_, opts)
-    local parser_config = require('nvim-treesitter.parsers').get_parser_configs()
-    parser_config.tql = {
-      install_info = {
-        url = 'https://github.com/tenzir/tree-sitter-tql',
-        files = { 'src/parser.c' },
-        branch = 'main',
-      },
-      filetype = 'tql',
-    }
+    treesitter.setup()
+    treesitter.install({ 'tql' })
 
-    require('nvim-treesitter.configs').setup(opts)
+    vim.api.nvim_create_autocmd('FileType', {
+      pattern = 'tql',
+      callback = function()
+        vim.treesitter.start()
+      end,
+    })
     vim.filetype.add({ extension = { tql = 'tql' } })
   end,
 }

--- a/src/content/docs/guides/development/setup-syntax-highlighting.mdx
+++ b/src/content/docs/guides/development/setup-syntax-highlighting.mdx
@@ -3,16 +3,107 @@ title: Setup syntax highlighting
 description: Install TQL language extensions for syntax highlighting in your editor
 ---
 
-This guide shows you how to set up TQL syntax highlighting in your editor.
-You'll get proper colorization, language detection, and basic language support
+This guide shows you how to set up TQL syntax highlighting and language
+detection in your editor. You'll get colorization and basic language support
 for `.tql` files.
+
+TQL editor integrations use the
+[Tree-sitter TQL grammar](https://github.com/tenzir/tree-sitter-tql) for
+incremental parsing. The grammar repository also ships Tree-sitter queries for
+highlights, indentation, folds, injections, and local variables.
 
 ## VS Code
 
-Install the [TQL extension](https://github.com/tenzir/vscode-tql) for syntax
-highlighting and language support.
+Install the [TQL extension for VS Code](https://github.com/tenzir/vscode-tql)
+for syntax highlighting and language support.
 
 ## Zed
 
 [Zed](https://zed.dev) is a high-performance editor with AI integration. Install
-the [TQL extension](https://github.com/tenzir/zed-tql) for syntax highlighting.
+the [TQL extension for Zed](https://github.com/tenzir/zed-tql) from the Zed
+extensions view or from the extension repository. The extension bundles the
+latest TQL parser and highlight queries.
+
+## Helix
+
+Add a TQL language entry to `~/.config/helix/languages.toml`:
+
+```toml
+[[language]]
+name = "tql"
+scope = "source.tql"
+file-types = ["tql"]
+comment-tokens = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "tql"
+source = { git = "https://github.com/tenzir/tree-sitter-tql", rev = "main" }
+```
+
+Fetch and build the parser:
+
+```sh
+hx --grammar fetch
+hx --grammar build
+```
+
+Helix loads query files from its runtime directory. Clone the grammar repository
+and copy the TQL queries into your local Helix runtime:
+
+```sh
+git clone https://github.com/tenzir/tree-sitter-tql
+mkdir -p ~/.config/helix/runtime/queries/tql
+cp tree-sitter-tql/queries/tql/*.scm ~/.config/helix/runtime/queries/tql/
+```
+
+Open a `.tql` file and run `hx --health tql` to confirm that Helix detects the
+language and parser.
+
+## Neovim
+
+Use
+[nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) to
+install the Tree-sitter TQL parser and register the `tql` filetype.
+
+With [lazy.nvim](https://github.com/folke/lazy.nvim), add this plugin
+configuration:
+
+```lua
+return {
+  'nvim-treesitter/nvim-treesitter',
+  build = ':TSUpdate',
+  dependencies = {
+    'tenzir/tree-sitter-tql',
+  },
+  opts = function(_, opts)
+    opts.ensure_installed = {
+      'tql',
+    }
+
+    opts.highlight = {
+      enable = true,
+    }
+
+    return opts
+  end,
+  config = function(_, opts)
+    local parser_config = require('nvim-treesitter.parsers').get_parser_configs()
+    parser_config.tql = {
+      install_info = {
+        url = 'https://github.com/tenzir/tree-sitter-tql',
+        files = { 'src/parser.c' },
+        branch = 'main',
+      },
+      filetype = 'tql',
+    }
+
+    require('nvim-treesitter.configs').setup(opts)
+    vim.filetype.add({ extension = { tql = 'tql' } })
+  end,
+}
+```
+
+After you update your Neovim plugins, open a `.tql` file and run
+`:InspectTree` to confirm that Neovim uses the TQL parser.

--- a/src/content/docs/guides/development/setup-syntax-highlighting.mdx
+++ b/src/content/docs/guides/development/setup-syntax-highlighting.mdx
@@ -44,45 +44,43 @@ language and parser.
 ## Neovim
 
 Use
-[nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) to
+[nvim-treesitter](https://github.com/neovim-treesitter/nvim-treesitter) to
 install the Tree-sitter TQL parser and register the `tql` filetype.
 
 With [lazy.nvim](https://github.com/folke/lazy.nvim), add this plugin
 configuration:
 
 ```lua
-local function register_tql_parser()
-  require('nvim-treesitter.parsers').tql = {
-    install_info = {
-      url = 'https://github.com/tenzir/tree-sitter-tql',
-      branch = 'main',
-    },
-  }
-end
-
 return {
   'nvim-treesitter/nvim-treesitter',
-  branch = 'main',
-  build = ':TSUpdate',
   dependencies = {
-    'tenzir/tree-sitter-tql',
+    'neovim-treesitter/treesitter-parser-registry',
   },
+  lazy = false,
+  build = ':TSUpdate',
   config = function()
     local treesitter = require('nvim-treesitter')
 
-    vim.api.nvim_create_autocmd('User', {
-      pattern = 'TSUpdate',
-      callback = register_tql_parser,
-    })
-    register_tql_parser()
-
-    treesitter.setup()
+    treesitter.setup {
+      local_parsers = {
+        tql = {
+          source = {
+            type = 'self_contained',
+            url = 'https://github.com/tenzir/tree-sitter-tql',
+            semver = false,
+            queries_path = 'queries/tql',
+          },
+          filetypes = { 'tql' },
+        },
+      },
+    }
     treesitter.install({ 'tql' })
 
     vim.api.nvim_create_autocmd('FileType', {
       pattern = 'tql',
       callback = function()
         vim.treesitter.start()
+        vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
       end,
     })
     vim.filetype.add({ extension = { tql = 'tql' } })


### PR DESCRIPTION
## 🔍 Problem

- The syntax-highlighting guide only points to VS Code and Zed.
- Users who want to configure Tree-sitter-capable editors need to piece together setup details from the grammar repository.

## 🛠️ Solution

- Expand the guide with the role of the TQL grammar and bundled queries.
- Add setup instructions for Helix and Neovim.
- Keep VS Code and Zed as extension-based setup paths.

## 💬 Review

- Check that the Helix and Neovim snippets match current editor expectations.
- Confirm that Tree-sitter stays framed as implementation detail behind editor support.