### PR TITLE
Document read_chunks and write_chunks operators

### DIFF
--- a/src/content/docs/reference/operators/read_all.mdx
+++ b/src/content/docs/reference/operators/read_all.mdx
@@ -50,6 +50,7 @@ from_file "data.bin" {
 
 ## See Also
 
+- <Op>read_chunks</Op>
 - <Op>read_delimited</Op>
 - <Op>read_delimited_regex</Op>
 - <Op>read_lines</Op>

--- a/src/content/docs/reference/operators/read_chunks.mdx
+++ b/src/content/docs/reference/operators/read_chunks.mdx
@@ -1,0 +1,53 @@
+---
+title: read_chunks
+category: Parsing
+example: 'read_chunks'
+---
+
+Parses binary data into events with a single `data` field, in a streaming
+fasion.
+
+```tql
+read_chunks
+```
+
+## Description
+
+The `read_chunks` operator turns each incoming byte chunk into a single event
+with a field called `data` of type `blob`. Unlike <Op>read_all</Op>, which
+buffers the entire input and produces one event, `read_chunks` emits events
+as data arrives.
+
+This is useful for piping binary data out `from_` operators, that can only emit
+events.
+
+## Examples
+
+### Read a file as blob events
+
+```tql
+from_file "data.bin" {
+  read_chunks
+}
+```
+
+```tql
+{data: b"<chunk contents>"}
+```
+
+### Round-trip with write_chunks
+
+```tql
+from_file "input.bin" {
+  read_chunks
+}
+to_file "output.bin" {
+  write_chunks
+}
+```
+
+## See Also
+
+- <Op>read_all</Op>
+- <Op>read_delimited</Op>
+- <Op>write_chunks</Op>

--- a/src/content/docs/reference/operators/write_all.mdx
+++ b/src/content/docs/reference/operators/write_all.mdx
@@ -64,4 +64,5 @@ to_file "/tmp/payload.bin" {
 - <Op>read_all</Op>
 - <Op>to_file</Op>
 - <Op>to_stdout</Op>
+- <Op>write_chunks</Op>
 - <Op>write_lines</Op>

--- a/src/content/docs/reference/operators/write_chunks.mdx
+++ b/src/content/docs/reference/operators/write_chunks.mdx
@@ -1,0 +1,63 @@
+---
+title: write_chunks
+category: Printing
+example: 'write_chunks'
+---
+
+Converts each input event into a separate byte chunk.
+
+```tql
+write_chunks [field]
+```
+
+## Description
+
+The `write_chunks` operator reads a field from each input event and emits it as
+a separate byte chunk. The field must be of type `blob`.
+
+Unlike <Op>write_all</Op>, which buffers all input and produces a single
+concatenated chunk at the end, `write_chunks` emits one chunk per event as data
+arrives.
+
+This is the inverse of <Op>read_chunks</Op>.
+
+### `field = field (optional)`
+
+The field to extract from each event. Defaults to `data`.
+
+## Examples
+
+### Write blob events to a file
+
+```tql
+from {data: b"hello"}, {data: b" "}, {data: b"world"}
+to_file "output.bin" {
+  write_chunks
+}
+```
+
+### Specify a custom field
+
+```tql
+from {payload: b"hello"}, {payload: b"world"}
+to_file "output.bin" {
+  write_chunks payload
+}
+```
+
+### Round-trip with read_chunks
+
+```tql
+from_file "input.bin" {
+  read_chunks
+}
+to_file "output.bin" {
+  write_chunks
+}
+```
+
+## See Also
+
+- <Op>read_chunks</Op>
+- <Op>write_all</Op>
+- <Op>write_lines</Op>


### PR DESCRIPTION
## 🔍 Problem

New `read_chunks` and `write_chunks` operators need reference documentation.

## 🛠️ Solution

- Add reference docs for `read_chunks` and `write_chunks`.
- Add see-also cross-links from `read_all` and `write_all`.

## 💬 Review

Straightforward reference pages following the existing operator doc pattern.

<sub>
⚙️ Code PR: tenzir/tenzir#6243
</sub>