### PR TITLE
Document rebuild memory limits

### DIFF
--- a/src/content/docs/guides/node-setup/tune-performance/index.mdx
+++ b/src/content/docs/guides/node-setup/tune-performance/index.mdx
@@ -210,10 +210,15 @@ configured partition size limit `tenzir.max-partition-size`.
 
 The `--all` flag causes Tenzir to rebuild all partitions.
 
-The `--parallel` options is a performance tuning knob. The parallelism level
+The `--parallel` option is a performance tuning knob. The parallelism level
 controls how many sets of partitions to rebuild in parallel. This value defaults
 to 1 to limit the CPU and memory requirements of the rebuilding process, which
 grow linearly with the selected parallelism level.
+
+Rebuilds limit how much partition data they load into memory at once. When
+available memory is low, Tenzir processes fewer partitions in a batch and leaves
+the remaining partitions for a later rebuild step instead of loading the full
+selected input set up front.
 
 The `--max-partitions` option allows for setting an upper bound to the number of
 partitions to rebuild.


### PR DESCRIPTION
## 🔍 Problem

The rebuild tuning guide describes parallelism but not the new memory-aware input loading behavior.

## 🛠️ Solution

- Explain that rebuilds limit how much partition data they load into memory at once.
- Mention that low-memory rebuilds defer remaining partitions to later rebuild steps.
- Fix a small `--parallel` wording typo.

## 💬 Review

Focus on whether the wording is accurate for both automatic rebuilds and manual `tenzir-ctl rebuild start` runs.

<sub>
⚙️ Code PR: tenzir/tenzir#6216
</sub>