### PR TITLE
Document Google UDM skill and mapping

### DIFF
--- a/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
+++ b/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
@@ -1,11 +1,11 @@
 ---
 title: Use agent skills
-description: Access Tenzir documentation as an Agent Skill for any compatible AI agent
+description: Install Tenzir agent skills for documentation, schemas, and workflow automation
 ---
 
 This guide shows you how to install and manage Tenzir's agent skills. You'll
-learn how to add skills globally or per project, install individual skills, and
-keep them up to date.
+learn which skills are available, how to add skills globally or per project,
+install individual skills, and keep them up to date.
 
 Tenzir publishes agent skills in the
 [`tenzir/skills`](https://github.com/tenzir/skills) repository.
@@ -16,6 +16,36 @@ knowledge that AI agents can use. Skills provide structured documentation with
 progressive disclosure, letting agents load a condensed overview first and drill
 into details only when needed.
 :::
+
+## Available skills
+
+Tenzir publishes the following skills:
+
+### 🧬 Schemas
+
+| Skill               | Description                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `tenzir-google-udm` | Google SecOps UDM schema and normalization guidance for fields, event types, and entity types  |
+| `tenzir-ocsf`       | OCSF schema reference for event classes, objects, attributes, profiles, and extensions         |
+
+### 🛡️ Tenzir Users
+
+| Skill                   | Description                                                                            |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `tenzir-docs`           | Tenzir documentation for TQL, operators, functions, integrations, and deployment        |
+| `tenzir-create-package` | Create library-quality Tenzir packages with operators, tests, examples, and pipelines   |
+
+### 🏗️ Tenzir Contributors
+
+| Skill                         | Description                                                              |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| `tenzir-commit-changes`       | Stage, split, and commit changes with clean messages                     |
+| `tenzir-create-pull-requests` | Open pull requests, add changelog entries, and link documentation PRs    |
+| `tenzir-review-changes`       | Review code with severity ratings and structured findings                |
+| `tenzir-design-system`        | Use frontend design tokens, components, and brand assets                 |
+| `tenzir-ship`                 | Write changelog entries, release notes, and GitHub releases              |
+| `tenzir-update-docs`          | Coordinate docs.tenzir.com updates alongside code changes                |
+| `tenzir-technical-writing`    | Write documentation in Tenzir's technical writing style                  |
 
 ## Install skills
 
@@ -36,12 +66,10 @@ to select targets.
 
 ### Install individual skills
 
-Append `@<skill-name>` to install a specific skill:
+Append `@<skill-name>` to install a specific skill from the available skills:
 
 ```bash
-npx skills add tenzir/skills@tenzir-docs
-npx skills add tenzir/skills@tenzir-ocsf
-npx skills add tenzir/skills@tenzir-create-package
+npx skills add tenzir/skills@<skill-name>
 ```
 
 ### Choose the installation scope

--- a/src/content/docs/guides/normalization/index.mdx
+++ b/src/content/docs/guides/normalization/index.mdx
@@ -79,13 +79,22 @@ OCSF mapping:
 - Handle unmapped fields
 - Validate with `ocsf::cast`
 
+### Map to UDM
+
+<Guide>normalization/map-to-udm</Guide> — Learn how to map events to Google
+SecOps UDM records:
+
+- Choose the correct UDM event type
+- Populate metadata and participant nouns
+- Convert source values to UDM enums
+- Preserve unmapped fields in `additional`
+
 ### Map to other schemas
 
 <Guide>normalization/map-to-other-schemas</Guide> — Brief guidance on
 alternative schemas:
 
 - Elastic Common Schema (ECS)
-- Google UDM
 - Microsoft ASIM
 
 ## When to normalize

--- a/src/content/docs/guides/normalization/map-to-ocsf.mdx
+++ b/src/content/docs/guides/normalization/map-to-ocsf.mdx
@@ -236,5 +236,6 @@ longer emits warnings.
 ## See also
 
 - <Guide>normalization/clean-up-values</Guide>
+- <Guide>normalization/map-to-udm</Guide>
 - <Guide>normalization/map-to-other-schemas</Guide>
 - <Tutorial>map-data-to-ocsf</Tutorial>

--- a/src/content/docs/guides/normalization/map-to-other-schemas.mdx
+++ b/src/content/docs/guides/normalization/map-to-other-schemas.mdx
@@ -166,23 +166,6 @@ fork {
 }
 ```
 
-## Best practices
-
-1. **Start with OCSF**: It's designed for security data and translates well to
-   other schemas.
-
-2. **Document mapping decisions**: Record why you chose specific field mappings,
-   especially for ambiguous cases.
-
-3. **Test with real data**: Each schema has quirks that only surface with
-   production data.
-
-4. **Maintain translator operators**: Package schema translations as reusable
-   operators.
-
-5. **Monitor for schema updates**: All schemas evolve; plan for periodic
-   updates to your mappings.
-
 ## See Also
 
 - <Op>to_opensearch</Op>

--- a/src/content/docs/guides/normalization/map-to-other-schemas.mdx
+++ b/src/content/docs/guides/normalization/map-to-other-schemas.mdx
@@ -4,8 +4,8 @@ title: Map to other schemas
 
 This guide provides brief guidance on mapping data to schemas other than OCSF.
 While OCSF is the recommended choice for security data, you may need to support
-Elastic Common Schema (ECS) or Microsoft ASIM for integration with specific
-platforms.
+Elastic Common Schema (ECS), Google UDM, or Microsoft ASIM for integration with
+specific platforms.
 
 ## Choosing a schema
 
@@ -13,6 +13,7 @@ platforms.
 | -------- | --------------------------- | ---------------------------------------------- |
 | **OCSF** | Security data normalization | Vendor-neutral, comprehensive security focus   |
 | **ECS**  | Elasticsearch/Elastic Stack | Tight Elastic integration, good field coverage |
+| **UDM**  | Google SecOps               | Required for SecOps, API-oriented UDM shape    |
 | **ASIM** | Microsoft Sentinel          | Required for Sentinel, KQL-optimized           |
 
 :::tip[Recommended approach]
@@ -163,6 +164,11 @@ fork {
   // Translate and send to Elasticsearch
   ocsf_to_ecs
   to_opensearch "https://elasticsearch.example.com:9200", action="index", index="ecs"
+}
+fork {
+  // Translate and send to Google SecOps
+  ocsf_to_udm
+  to_google_secops "..."
 }
 ```
 

--- a/src/content/docs/guides/normalization/map-to-other-schemas.mdx
+++ b/src/content/docs/guides/normalization/map-to-other-schemas.mdx
@@ -4,8 +4,8 @@ title: Map to other schemas
 
 This guide provides brief guidance on mapping data to schemas other than OCSF.
 While OCSF is the recommended choice for security data, you may need to support
-Elastic Common Schema (ECS), Google UDM, or Microsoft ASIM for integration with
-specific platforms.
+Elastic Common Schema (ECS) or Microsoft ASIM for integration with specific
+platforms.
 
 ## Choosing a schema
 
@@ -13,7 +13,6 @@ specific platforms.
 | -------- | --------------------------- | ---------------------------------------------- |
 | **OCSF** | Security data normalization | Vendor-neutral, comprehensive security focus   |
 | **ECS**  | Elasticsearch/Elastic Stack | Tight Elastic integration, good field coverage |
-| **UDM**  | Google SecOps (Chronicle)   | Required for Chronicle, maps well from OCSF    |
 | **ASIM** | Microsoft Sentinel          | Required for Sentinel, KQL-optimized           |
 
 :::tip[Recommended approach]
@@ -58,15 +57,6 @@ Common ECS field sets for security data:
 - `user.*` - User information
 - `host.*` - Host/device details
 - `threat.*` - Threat intelligence
-
-## Google Unified Data Model (UDM)
-
-[UDM](https://docs.cloud.google.com/chronicle/docs/event-processing/udm-overview)
-is Google Chronicle's (SecOps) event schema. Refer to the
-[UDM field list](https://cloud.google.com/chronicle/docs/reference/udm-field-list)
-for a complete reference.
-
-For a detailed TQL mapping pattern, see <Guide>normalization/map-to-udm</Guide>.
 
 ## Microsoft ASIM
 
@@ -124,9 +114,6 @@ When values need conversion:
 ```tql
 // OCSF uses integers, ECS might use strings
 ecs.event.severity = ocsf.severity_id.string()
-
-// Protocol name case differences
-udm.network.ip_protocol = ocsf.connection_info.protocol_name.to_upper()
 ```
 
 ### Structural transformation
@@ -177,11 +164,6 @@ fork {
   ocsf_to_ecs
   to_opensearch "https://elasticsearch.example.com:9200", action="index", index="ecs"
 }
-fork {
-  // Translate and send to Chronicle
-  ocsf_to_udm
-  to_google_secops "..."
-}
 ```
 
 ## Best practices
@@ -205,5 +187,4 @@ fork {
 
 - <Op>to_opensearch</Op>
 - <Guide>normalization/map-to-ocsf</Guide>
-- <Guide>normalization/map-to-udm</Guide>
 - <Guide>transformation/transform-values</Guide>

--- a/src/content/docs/guides/normalization/map-to-other-schemas.mdx
+++ b/src/content/docs/guides/normalization/map-to-other-schemas.mdx
@@ -66,32 +66,7 @@ is Google Chronicle's (SecOps) event schema. Refer to the
 [UDM field list](https://cloud.google.com/chronicle/docs/reference/udm-field-list)
 for a complete reference.
 
-### Key differences from OCSF
-
-- Uses protobuf-style nested structures
-- Strict typing with enums for many fields
-- Event type determines required field sets
-
-### Mapping pattern
-
-```tql
-// From OCSF to UDM
-udm.metadata.event_timestamp = ocsf.time
-udm.metadata.event_type = "NETWORK_CONNECTION"
-udm.principal.ip = [ocsf.src_endpoint.ip]
-udm.principal.port = ocsf.src_endpoint.port
-udm.target.ip = [ocsf.dst_endpoint.ip]
-udm.target.port = ocsf.dst_endpoint.port
-udm.network.ip_protocol = ocsf.connection_info.protocol_name.to_upper()
-```
-
-### UDM entity types
-
-- `principal` - Initiating entity (source)
-- `target` - Target entity (destination)
-- `src` - Alternative source (for multi-party events)
-- `observer` - Monitoring/logging entity
-- `intermediary` - Proxy or middlebox
+For a detailed TQL mapping pattern, see <Guide>normalization/map-to-udm</Guide>.
 
 ## Microsoft ASIM
 
@@ -230,4 +205,5 @@ fork {
 
 - <Op>to_opensearch</Op>
 - <Guide>normalization/map-to-ocsf</Guide>
+- <Guide>normalization/map-to-udm</Guide>
 - <Guide>transformation/transform-values</Guide>

--- a/src/content/docs/guides/normalization/map-to-other-schemas.mdx
+++ b/src/content/docs/guides/normalization/map-to-other-schemas.mdx
@@ -187,4 +187,5 @@ fork {
 
 - <Op>to_opensearch</Op>
 - <Guide>normalization/map-to-ocsf</Guide>
+- <Guide>normalization/map-to-udm</Guide>
 - <Guide>transformation/transform-values</Guide>

--- a/src/content/docs/guides/normalization/map-to-udm.mdx
+++ b/src/content/docs/guides/normalization/map-to-udm.mdx
@@ -14,9 +14,14 @@ don't send structured UDM records directly with <Op>to_google_secops</Op> until
 structured UDM ingestion support is available.
 :::
 
+The examples use lowerCamelCase UDM JSON field names, such as
+`metadata.eventType`, to match the API-facing record shape. Google SecOps rule
+and normalizer field paths may use snake_case names, such as
+`metadata.event_type`, in those contexts.
+
 ## Choose the UDM event type
 
-Start by choosing `metadata.event_type`. This value describes the activity that
+Start by choosing `metadata.eventType`. This value describes the activity that
 the event records, not the product that emitted the log. For example, a firewall
 connection log maps to `NETWORK_CONNECTION`, while DNS payloads map to
 `NETWORK_DNS`.
@@ -65,11 +70,11 @@ let $actions = {
 }
 
 udm.metadata = {
-  event_timestamp: move fw.ts,
-  event_type: "NETWORK_CONNECTION",
-  vendor_name: "Example Networks",
-  product_name: "Example Firewall",
-  product_event_type: fw.action,
+  eventTimestamp: move fw.ts,
+  eventType: "NETWORK_CONNECTION",
+  vendorName: "Example Networks",
+  productName: "Example Firewall",
+  productEventType: fw.action,
 }
 
 udm.principal = {
@@ -83,14 +88,14 @@ udm.target = {
 }
 
 udm.network = {
-  ip_protocol: $ip_protocols[fw.proto.to_lower()]? else "UNKNOWN_IP_PROTOCOL",
-  sent_bytes: move fw.bytes_out,
-  received_bytes: move fw.bytes_in,
+  ipProtocol: $ip_protocols[fw.proto.to_lower()]? else "UNKNOWN_IP_PROTOCOL",
+  sentBytes: move fw.bytes_out,
+  receivedBytes: move fw.bytes_in,
 }
 
-udm.security_result = [{
+udm.securityResult = [{
   action: [$actions[fw.action.to_lower()]? else "UNKNOWN_ACTION"],
-  action_details: fw.action,
+  actionDetails: fw.action,
 }]
 
 drop fw.action
@@ -102,11 +107,11 @@ this = {...udm, additional: fw}
 ```tql
 {
   metadata: {
-    event_timestamp: 2024-01-15T10:30:45Z,
-    event_type: "NETWORK_CONNECTION",
-    vendor_name: "Example Networks",
-    product_name: "Example Firewall",
-    product_event_type: "allowed",
+    eventTimestamp: 2024-01-15T10:30:45Z,
+    eventType: "NETWORK_CONNECTION",
+    vendorName: "Example Networks",
+    productName: "Example Firewall",
+    productEventType: "allowed",
   },
   principal: {
     ip: [
@@ -121,16 +126,16 @@ this = {...udm, additional: fw}
     port: 443,
   },
   network: {
-    ip_protocol: "TCP",
-    sent_bytes: 1280,
-    received_bytes: 8192,
+    ipProtocol: "TCP",
+    sentBytes: 1280,
+    receivedBytes: 8192,
   },
-  security_result: [
+  securityResult: [
     {
       action: [
         "ALLOW",
       ],
-      action_details: "allowed",
+      actionDetails: "allowed",
     },
   ],
   additional: {},
@@ -143,7 +148,7 @@ Use the same structure for larger mappings:
 
 - **Keep a source namespace**: Move the parsed event under a short namespace
   such as `fw`, `dns`, `edr`, or `event` before you create UDM fields.
-- **Set `metadata.event_type` early**: Let the UDM event type drive which
+- **Set `metadata.eventType` early**: Let the UDM event type drive which
   participant nouns and protocol fields you populate.
 - **Model participants as nouns**: Use `principal` for the initiating entity,
   `target` for the destination, `observer` for the sensor, and `intermediary`
@@ -152,13 +157,6 @@ Use the same structure for larger mappings:
   as `TCP`, `UDP`, `ALLOW`, or `BLOCK`.
 - **Preserve unmapped fields**: Keep source fields that don't have a deliberate
   UDM target under `additional` so reviewers can audit the mapping.
-
-## Test the operator
-
-Package UDM mappings like other normalization operators and test them with
-fixtures. Until Tenzir has a structured UDM validation and ingestion path, use
-fixture output to verify that each event type populates the expected UDM
-sections and enum values.
 
 ## See Also
 

--- a/src/content/docs/guides/normalization/map-to-udm.mdx
+++ b/src/content/docs/guides/normalization/map-to-udm.mdx
@@ -1,0 +1,170 @@
+---
+title: Map to UDM
+---
+
+This guide shows you how to map events to Google SecOps Unified Data Model
+(UDM) records in TQL. You'll learn how to choose a UDM event type, populate
+metadata, model participants as UDM nouns, convert enum values, and preserve
+unmapped source fields.
+
+:::caution[Structured UDM ingestion is coming soon]
+Tenzir's <Op>to_google_secops</Op> operator currently sends unstructured logs to
+Google SecOps. Use this guide to design and test UDM mapping operators, but
+don't send structured UDM records directly with <Op>to_google_secops</Op> until
+structured UDM ingestion support is available.
+:::
+
+## Choose the UDM event type
+
+Start by choosing `metadata.event_type`. This value describes the activity that
+the event records, not the product that emitted the log. For example, a firewall
+connection log maps to `NETWORK_CONNECTION`, while DNS payloads map to
+`NETWORK_DNS`.
+
+For a `NETWORK_CONNECTION` event, UDM expects these core sections:
+
+- `metadata`: The event timestamp and product context.
+- `principal`: The machine that initiated the network connection.
+- `target`: The destination machine if it differs from the principal.
+- `network`: The protocol, ports, byte counts, and other connection details.
+
+## Write a small mapping
+
+The following example maps a parsed firewall connection event to UDM. It keeps
+the source data under `fw`, moves one-use fields into UDM, converts source
+strings to UDM enum values, and preserves unmapped residue in `additional`.
+
+```tql
+from {
+  ts: 2024-01-15T10:30:45Z,
+  action: "allowed",
+  src_ip: "10.0.0.5",
+  src_port: 51544,
+  dst_ip: "203.0.113.10",
+  dst_port: 443,
+  proto: "tcp",
+  bytes_out: 1280,
+  bytes_in: 8192,
+}
+
+this = {fw: this}
+
+let $ip_protocols = {
+  tcp: "TCP",
+  udp: "UDP",
+  icmp: "ICMP",
+}
+
+let $actions = {
+  allow: "ALLOW",
+  allowed: "ALLOW",
+  deny: "BLOCK",
+  denied: "BLOCK",
+  block: "BLOCK",
+  blocked: "BLOCK",
+}
+
+udm.metadata = {
+  event_timestamp: move fw.ts,
+  event_type: "NETWORK_CONNECTION",
+  vendor_name: "Example Networks",
+  product_name: "Example Firewall",
+  product_event_type: fw.action,
+}
+
+udm.principal = {
+  ip: [move fw.src_ip],
+  port: move fw.src_port,
+}
+
+udm.target = {
+  ip: [move fw.dst_ip],
+  port: move fw.dst_port,
+}
+
+udm.network = {
+  ip_protocol: $ip_protocols[fw.proto.to_lower()]? else "UNKNOWN_IP_PROTOCOL",
+  sent_bytes: move fw.bytes_out,
+  received_bytes: move fw.bytes_in,
+}
+
+udm.security_result = [{
+  action: [$actions[fw.action.to_lower()]? else "UNKNOWN_ACTION"],
+  action_details: fw.action,
+}]
+
+drop fw.action
+drop fw.proto
+
+this = {...udm, additional: fw}
+```
+
+```tql
+{
+  metadata: {
+    event_timestamp: 2024-01-15T10:30:45Z,
+    event_type: "NETWORK_CONNECTION",
+    vendor_name: "Example Networks",
+    product_name: "Example Firewall",
+    product_event_type: "allowed",
+  },
+  principal: {
+    ip: [
+      "10.0.0.5",
+    ],
+    port: 51544,
+  },
+  target: {
+    ip: [
+      "203.0.113.10",
+    ],
+    port: 443,
+  },
+  network: {
+    ip_protocol: "TCP",
+    sent_bytes: 1280,
+    received_bytes: 8192,
+  },
+  security_result: [
+    {
+      action: [
+        "ALLOW",
+      ],
+      action_details: "allowed",
+    },
+  ],
+  additional: {},
+}
+```
+
+## Apply the mapping pattern
+
+Use the same structure for larger mappings:
+
+- **Keep a source namespace**: Move the parsed event under a short namespace
+  such as `fw`, `dns`, `edr`, or `event` before you create UDM fields.
+- **Set `metadata.event_type` early**: Let the UDM event type drive which
+  participant nouns and protocol fields you populate.
+- **Model participants as nouns**: Use `principal` for the initiating entity,
+  `target` for the destination, `observer` for the sensor, and `intermediary`
+  for proxies or middleboxes.
+- **Convert enum values explicitly**: Map source strings to UDM enum names such
+  as `TCP`, `UDP`, `ALLOW`, or `BLOCK`.
+- **Preserve unmapped fields**: Keep source fields that don't have a deliberate
+  UDM target under `additional` so reviewers can audit the mapping.
+
+## Test the operator
+
+Package UDM mappings like other normalization operators and test them with
+fixtures. Until Tenzir has a structured UDM validation and ingestion path, use
+fixture output to verify that each event type populates the expected UDM
+sections and enum values.
+
+## See Also
+
+- <Op>to_google_secops</Op>
+- <Guide>normalization/clean-up-values</Guide>
+- <Guide>normalization/map-to-ocsf</Guide>
+- <Guide>normalization/map-to-other-schemas</Guide>
+- <Guide>packages/create-a-package</Guide>
+- <Guide>testing/write-tests</Guide>

--- a/src/content/docs/integrations/google/secops.mdx
+++ b/src/content/docs/integrations/google/secops.mdx
@@ -11,6 +11,15 @@ using the [unstructured logs ingestion API][api].
 
 ![Google Security Operations](secops.svg)
 
+## UDM mapping
+
+Google SecOps stores normalized security data in the Unified Data Model (UDM).
+Use <Guide>normalization/map-to-udm</Guide> to shape parsed events into
+API-facing UDM records.
+
+Tenzir's <Op>to_google_secops</Op> operator currently sends unstructured logs.
+Structured UDM ingestion support is coming soon.
+
 ## Examples
 
 ### Send an event to Google SecOps

--- a/src/content/docs/reference/operators/to_google_secops.mdx
+++ b/src/content/docs/reference/operators/to_google_secops.mdx
@@ -90,4 +90,5 @@ to_google_secops \
 ## See Also
 
 - <Op>to_google_cloud_logging</Op>
+- <Guide>normalization/map-to-udm</Guide>
 - <Integration>google/secops</Integration>

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -126,6 +126,7 @@ export const guides = [
           { label: "Overview", link: "guides/normalization" },
           "guides/normalization/clean-up-values",
           "guides/normalization/map-to-ocsf",
+          "guides/normalization/map-to-udm",
           "guides/normalization/map-to-other-schemas",
         ],
       },


### PR DESCRIPTION
## 🔍 Problem

- The agent skills guide does not show the available Tenzir skills in one canonical, categorized place.
- The new Google UDM skill needs a user-facing docs entry point for mapping mechanics.
- Structured UDM ingestion through Tenzir is not ready yet, so the docs need to avoid implying that `to_google_secops` accepts UDM records today.

## 🛠️ Solution

- Document available Tenzir skills once using the marketplace categories.
- Add a `Map to UDM` normalization guide with a small executable TQL example and its actual output.
- Place the UDM guide directly after `Map to OCSF` in the normalization sidebar and link to it from related normalization pages.
- Link the Google SecOps integration page and `to_google_secops` operator reference to the UDM mapping guide.
- Add a caution callout that structured UDM ingestion support is coming soon.

## 💬 Review

- Check that the UDM example demonstrates mapping mechanics without promising structured SecOps ingestion.
- The example output was generated with `tenzir "<pipeline>"` from the guide's pipeline.

<sub>
⚙️ Code PR: tenzir/skills#10<br>
🎫 References TNZ-442
</sub>
