### PR TITLE
Document UDM skill naming contexts

### DIFF
--- a/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
+++ b/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
@@ -72,6 +72,39 @@ Append `@<skill-name>` to install a specific skill from the available skills:
 npx skills add tenzir/skills@<skill-name>
 ```
 
+### Use the Google UDM skill
+
+Install the Google SecOps UDM schema skill when you want an agent to help with
+UDM mapping or detection engineering:
+
+```bash
+npx skills add tenzir/skills@tenzir-google-udm
+```
+
+The `tenzir-google-udm` skill supports two naming contexts. Generated UDM field
+headings can show two forms, for example `event_type / eventType`:
+
+- Use the left-side field path form for YARA-L, Detect Engine, CBN, and other
+  dotted paths, such as `$event.metadata.event_type`.
+- Use the right-side ingestion object form when the agent creates API-facing UDM
+  event or entity objects, including TQL mapping output such as
+  `metadata.eventType`.
+
+Tell the agent which context you want:
+
+```text
+Use the tenzir-google-udm skill to map this firewall event to a UDM event
+object. Use ingestion object field names in the TQL output.
+```
+
+```text
+Use the tenzir-google-udm skill to write YARA-L detection logic for a UDM
+network connection event. Use field path names.
+```
+
+The spellings come from Google protobuf descriptors. Treat the pair as an
+explicit mapping instead of applying case conversion.
+
 ### Choose the installation scope
 
 Skills support two installation scopes:

--- a/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
+++ b/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
@@ -74,21 +74,21 @@ npx skills add tenzir/skills@<skill-name>
 
 ### Use the Google UDM skill
 
-Install the Google SecOps UDM schema skill when you want an agent to help with
-UDM mapping or detection engineering:
+Install the Google SecOps UDM schema skill when you want an agent to help
+generate UDM API ingestion payloads or write detection logic:
 
 ```bash
 npx skills add tenzir/skills@tenzir-google-udm
 ```
 
-The `tenzir-google-udm` skill supports two naming contexts. Generated UDM field
-headings can show two forms, for example `event_type / eventType`:
+The `tenzir-google-udm` skill supports two primary workflows. Generated UDM
+field headings can show two forms, for example `event_type / eventType`:
 
-- Use the left-side field path form for YARA-L, Detect Engine, CBN, and other
-  dotted paths, such as `$event.metadata.event_type`.
-- Use the right-side ingestion object form when the agent creates API-facing UDM
-  event or entity objects, including TQL mapping output such as
-  `metadata.eventType`.
+- Use the right-side ingestion object form when the agent maps logs into UDM
+  event or entity objects for Google SecOps UDM API ingestion, including TQL
+  mapping output such as `metadata.eventType`.
+- Use the left-side field path form when the agent writes YARA-L, Detect
+  Engine, CBN, or other dotted paths, such as `$event.metadata.event_type`.
 
 Tell the agent which context you want:
 
@@ -101,9 +101,6 @@ object. Use ingestion object field names in the TQL output.
 Use the tenzir-google-udm skill to write YARA-L detection logic for a UDM
 network connection event. Use field path names.
 ```
-
-The spellings come from Google protobuf descriptors. Treat the pair as an
-explicit mapping instead of applying case conversion.
 
 ### Choose the installation scope
 

--- a/src/content/docs/guides/normalization/map-to-udm.mdx
+++ b/src/content/docs/guides/normalization/map-to-udm.mdx
@@ -14,9 +14,9 @@ don't send structured UDM records directly with <Op>to_google_secops</Op> until
 structured UDM ingestion support is available.
 :::
 
-The TQL examples in this guide build API-facing UDM records, so they use field
-names such as `metadata.eventType`. Google SecOps rule and normalizer field
-paths use names such as `$event.metadata.event_type` in those contexts.
+The TQL examples in this guide build API-facing UDM records, so they use
+lowerCamelCase ingestion object field names such as `metadata.eventType` and
+`network.ipProtocol`.
 
 ## Use the UDM skill
 
@@ -25,24 +25,11 @@ schema decisions. See
 <Guide>ai-workbench/use-agent-skills#use-the-google-udm-skill</Guide> for
 installation and usage examples.
 
-The skill supports two primary UDM workflows:
-
-- **Mapping to UDM API payloads**: Ask the agent to use ingestion object field
-  names, such as `metadata.eventType` and `network.ipProtocol`, when it maps
-  logs into UDM event or entity objects for Google SecOps UDM API ingestion.
-- **Detection engineering**: Ask the agent to use field path names, such as
-  `$event.metadata.event_type` and `$event.network.ip_protocol`, when it writes
-  YARA-L or Google SecOps rule logic.
-
-Generated UDM field headings can show two forms:
-
-```text
-field_path_form / ingestionObjectForm
-```
-
-Use the left-side form in dotted field-path contexts. Use the right-side form
-in API-facing UDM records. If a heading has one name, both contexts use the same
-spelling.
+Ask the agent to use ingestion object field names when it maps logs into UDM
+event or entity objects for Google SecOps UDM API ingestion. When generated UDM
+field headings show two forms, choose the right-side lowerCamelCase ingestion
+object form. For example, use `metadata.eventType` and `network.ipProtocol` in
+the TQL output. If a heading has one name, use that spelling.
 
 ## Choose the UDM event type
 

--- a/src/content/docs/guides/normalization/map-to-udm.mdx
+++ b/src/content/docs/guides/normalization/map-to-udm.mdx
@@ -14,10 +14,36 @@ don't send structured UDM records directly with <Op>to_google_secops</Op> until
 structured UDM ingestion support is available.
 :::
 
-The examples use lowerCamelCase UDM JSON field names, such as
-`metadata.eventType`, to match the API-facing record shape. Google SecOps rule
-and normalizer field paths may use snake_case names, such as
-`metadata.event_type`, in those contexts.
+The TQL examples in this guide build API-facing UDM records, so they use field
+names such as `metadata.eventType`. Google SecOps rule and normalizer field
+paths use names such as `$event.metadata.event_type` in those contexts.
+
+## Use the UDM skill
+
+Install the `tenzir-google-udm` skill when you want an agent to help with UDM
+schema decisions. See
+<Guide>ai-workbench/use-agent-skills#use-the-google-udm-skill</Guide> for
+installation and usage examples.
+
+The skill supports both UDM workflows:
+
+- **Mapping to UDM records**: Ask the agent to use ingestion object field
+  names, such as `metadata.eventType` and `network.ipProtocol`, when it writes
+  TQL that builds a UDM event or entity object.
+- **Detection engineering**: Ask the agent to use field path names, such as
+  `$event.metadata.event_type` and `$event.network.ip_protocol`, when it writes
+  YARA-L or Google SecOps rule logic.
+
+Generated UDM field headings can show two forms:
+
+```text
+field_path_form / ingestionObjectForm
+```
+
+Use the left-side form in dotted field-path contexts. Use the right-side form
+in API-facing UDM records. If a heading has one name, both contexts use the same
+spelling. The mapping comes from Google protobuf descriptors, so don't derive
+one spelling from the other by case conversion.
 
 ## Choose the UDM event type
 

--- a/src/content/docs/guides/normalization/map-to-udm.mdx
+++ b/src/content/docs/guides/normalization/map-to-udm.mdx
@@ -25,11 +25,11 @@ schema decisions. See
 <Guide>ai-workbench/use-agent-skills#use-the-google-udm-skill</Guide> for
 installation and usage examples.
 
-The skill supports both UDM workflows:
+The skill supports two primary UDM workflows:
 
-- **Mapping to UDM records**: Ask the agent to use ingestion object field
-  names, such as `metadata.eventType` and `network.ipProtocol`, when it writes
-  TQL that builds a UDM event or entity object.
+- **Mapping to UDM API payloads**: Ask the agent to use ingestion object field
+  names, such as `metadata.eventType` and `network.ipProtocol`, when it maps
+  logs into UDM event or entity objects for Google SecOps UDM API ingestion.
 - **Detection engineering**: Ask the agent to use field path names, such as
   `$event.metadata.event_type` and `$event.network.ip_protocol`, when it writes
   YARA-L or Google SecOps rule logic.
@@ -42,8 +42,7 @@ field_path_form / ingestionObjectForm
 
 Use the left-side form in dotted field-path contexts. Use the right-side form
 in API-facing UDM records. If a heading has one name, both contexts use the same
-spelling. The mapping comes from Google protobuf descriptors, so don't derive
-one spelling from the other by case conversion.
+spelling.
 
 ## Choose the UDM event type
 

--- a/src/content/docs/integrations/google/secops.mdx
+++ b/src/content/docs/integrations/google/secops.mdx
@@ -19,9 +19,9 @@ API-facing UDM records.
 
 For agent-assisted work, follow
 <Guide>ai-workbench/use-agent-skills#use-the-google-udm-skill</Guide> to use
-the `tenzir-google-udm` skill. The skill distinguishes field path names for
-YARA-L, such as `metadata.event_type`, from ingestion object names for UDM
-records, such as `metadata.eventType`.
+the `tenzir-google-udm` skill. The skill helps map logs into UDM API ingestion
+payloads with names such as `metadata.eventType`, and write YARA-L or rule
+field paths with names such as `metadata.event_type`.
 
 Tenzir's <Op>to_google_secops</Op> operator currently sends unstructured logs.
 Structured UDM ingestion support is coming soon.

--- a/src/content/docs/integrations/google/secops.mdx
+++ b/src/content/docs/integrations/google/secops.mdx
@@ -17,6 +17,12 @@ Google SecOps stores normalized security data in the Unified Data Model (UDM).
 Use <Guide>normalization/map-to-udm</Guide> to shape parsed events into
 API-facing UDM records.
 
+For agent-assisted work, follow
+<Guide>ai-workbench/use-agent-skills#use-the-google-udm-skill</Guide> to use
+the `tenzir-google-udm` skill. The skill distinguishes field path names for
+YARA-L, such as `metadata.event_type`, from ingestion object names for UDM
+records, such as `metadata.eventType`.
+
 Tenzir's <Op>to_google_secops</Op> operator currently sends unstructured logs.
 Structured UDM ingestion support is coming soon.
 


### PR DESCRIPTION
## 🔍 Problem

- The UDM mapping docs did not explain how the Google UDM skill should be used across UDM API payload generation and detection-engineering workflows.
- The docs still framed UDM mapping names as JSON field names, which blurred the distinction between field paths and ingestion objects.
- The agent skill guidance underweighted the mapping use case for UDM event and entity objects sent to the Google SecOps UDM API.

## 🛠️ Solution

- Document the `tenzir-google-udm` skill as usable for both UDM API ingestion payloads and YARA-L field-path work.
- Explain the dual heading convention: `field_path_form / ingestionObjectForm`.
- Remove the case-conversion wording from the public docs.
- Point the Google SecOps integration page to the same UDM skill workflow.

## 💬 Review

- Check whether the naming-context guidance is clear for readers using agents to generate either UDM API payloads or YARA-L logic.
- Check whether the UDM mapping guide now avoids ambiguous JSON terminology.

<sub>
⚙️ Code PR: tenzir/skills#12
</sub>
