### PR TITLE
Update package skill name

### DIFF
--- a/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
+++ b/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
@@ -30,10 +30,10 @@ Tenzir publishes the following skills:
 
 ### 🛡️ Tenzir Users
 
-| Skill                   | Description                                                                            |
-| ----------------------- | -------------------------------------------------------------------------------------- |
-| `tenzir-docs`           | Tenzir documentation for TQL, operators, functions, integrations, and deployment        |
-| `tenzir-create-package` | Create library-quality Tenzir packages with operators, tests, examples, and pipelines   |
+| Skill                    | Description                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------- |
+| `tenzir-docs`            | Tenzir documentation for TQL, operators, functions, integrations, and deployment             |
+| `tenzir-manage-packages` | Package lifecycle routing for manifests, operators, pipelines, tests, and schema mappings   |
 
 ### 🏗️ Tenzir Contributors
 


### PR DESCRIPTION
## 🔍 Problem

- The AI Workbench guide still lists the package lifecycle skill as `tenzir-create-package`.
- The companion skills PR renames that skill to `tenzir-manage-packages` and broadens it to package lifecycle routing.

## 🛠️ Solution

- Update the available-skills table to use `tenzir-manage-packages`.
- Describe the skill as package lifecycle routing for manifests, operators, pipelines, tests, and schema mappings.

## 💬 Review

- Check that the table wording matches the companion skills PR and remains concise.

<sub>
⚙️ Code PR: tenzir/skills#13
</sub>