### PR TITLE
Document Microsoft ASIM skill

### DIFF
--- a/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
+++ b/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
@@ -26,6 +26,7 @@ Tenzir publishes the following skills:
 | Skill               | Description                                                                                   |
 | ------------------- | --------------------------------------------------------------------------------------------- |
 | `tenzir-google-udm` | Google SecOps UDM schema and normalization guidance for fields, event types, and entity types  |
+| `tenzir-microsoft-asim` | Microsoft Sentinel ASIM schema and mapping guidance for schemas, fields, aliases, and roles |
 | `tenzir-ocsf`       | OCSF schema reference for event classes, objects, attributes, profiles, and extensions         |
 
 ### 🛡️ Tenzir Users
@@ -100,6 +101,33 @@ object. Use ingestion object field names in the TQL output.
 ```text
 Use the tenzir-google-udm skill to write YARA-L detection logic for a UDM
 network connection event. Use field path names.
+```
+
+### Use the Microsoft ASIM skill
+
+Install the Microsoft Sentinel ASIM schema skill when you want an agent to help
+choose ASIM schemas, map events or entities, inspect normalized fields, or
+resolve aliases:
+
+```bash
+npx skills add tenzir/skills@tenzir-microsoft-asim
+```
+
+The `tenzir-microsoft-asim` skill is generated from Microsoft Defender Docs and
+is optimized for schema-first mapping. Ask the agent to choose the ASIM schema
+before it maps fields, then use canonical ASIM field names such as
+`EventSchema`, `EventSchemaVersion`, `SrcIpAddr`, and `DstIpAddr`.
+
+Tell the agent which context you want:
+
+```text
+Use the tenzir-microsoft-asim skill to map this firewall event to a Microsoft
+Sentinel ASIM NetworkSession record.
+```
+
+```text
+Use the tenzir-microsoft-asim skill to explain the required and recommended
+fields for ASIM DNS events.
 ```
 
 ### Choose the installation scope

--- a/src/content/docs/guides/normalization/index.mdx
+++ b/src/content/docs/guides/normalization/index.mdx
@@ -89,13 +89,22 @@ SecOps UDM records:
 - Convert source values to UDM enums
 - Preserve unmapped fields in `additional`
 
+### Map to ASIM
+
+<Guide>normalization/map-to-asim</Guide> — Learn how to map events to
+Microsoft Sentinel ASIM records:
+
+- Choose the correct ASIM event or entity schema
+- Populate schema, product, and event metadata
+- Map role-prefixed source, destination, actor, target, and device fields
+- Preserve unmapped fields in `AdditionalFields`
+
 ### Map to other schemas
 
 <Guide>normalization/map-to-other-schemas</Guide> — Brief guidance on
-alternative schemas:
+alternative schemas that don't have a dedicated guide:
 
 - Elastic Common Schema (ECS)
-- Microsoft ASIM
 
 ## When to normalize
 

--- a/src/content/docs/guides/normalization/map-to-asim.mdx
+++ b/src/content/docs/guides/normalization/map-to-asim.mdx
@@ -1,0 +1,173 @@
+---
+title: Map to ASIM
+---
+
+This guide shows you how to map events to Microsoft Sentinel Advanced Security
+Information Model (ASIM) records in TQL. You'll learn how to choose an ASIM
+schema, populate schema and product metadata, map role-prefixed fields,
+normalize event results, and preserve unmapped source fields.
+
+## Use the ASIM skill
+
+Install the `tenzir-microsoft-asim` skill when you want an agent to help with
+ASIM schema decisions. See
+<Guide>ai-workbench/use-agent-skills#use-the-microsoft-asim-skill</Guide> for
+installation and usage examples.
+
+Ask the agent to choose the event or entity schema before it maps fields. ASIM
+fields use Microsoft Sentinel column names such as `EventSchema`,
+`EventSchemaVersion`, `SrcIpAddr`, and `DstIpAddr`. Prefer canonical fields
+over aliases when you build reusable mappings, analytics rules, or workbooks.
+
+## Choose the ASIM schema
+
+Start by choosing `EventSchema` and `EventSchemaVersion` for event records, or
+`EntitySchema` and `EntitySchemaVersion` for entity records. These fields
+identify the schema contract that the record follows.
+
+For a firewall connection event, choose the `NetworkSession` schema. It
+describes IP network activity from sources such as firewalls, NetFlow records,
+routers, operating systems, and intrusion prevention systems.
+
+For a `NetworkSession` event, start with these core fields:
+
+- `EventSchema`: The schema name. Use `NetworkSession`.
+- `EventSchemaVersion`: The schema version. Use `0.2.7` for `NetworkSession`.
+- `EventType`: The activity scenario, such as `NetworkSession`, `Flow`, or
+  `EndpointNetworkSession`.
+- `EventVendor` and `EventProduct`: The source product context.
+- `EventStartTime` and `EventEndTime`: The activity time range.
+- `EventResult`: The normalized result, such as `Success` or `Failure`.
+- `Src*` and `Dst*`: The source and destination participants.
+
+## Write a small mapping
+
+The following example maps a parsed firewall connection event to an ASIM
+`NetworkSession` record. It keeps the source data under `fw`, sets the ASIM
+schema constants, normalizes the device action and result, maps source and
+destination fields, and preserves unmapped residue in `AdditionalFields`.
+
+```tql
+from {
+  ts: 2024-01-15T10:30:45Z,
+  action: "allowed",
+  src_ip: "10.0.0.5",
+  src_port: 51544,
+  dst_ip: "203.0.113.10",
+  dst_port: 443,
+  proto: "tcp",
+  bytes_out: 1280,
+  bytes_in: 8192,
+  device: "edge-fw-01",
+}
+
+this = {fw: this}
+
+let $actions = {
+  allow: "Allow",
+  allowed: "Allow",
+  deny: "Deny",
+  denied: "Deny",
+  drop: "Drop",
+  dropped: "Drop",
+}
+
+let $results = {
+  allow: "Success",
+  allowed: "Success",
+  deny: "Failure",
+  denied: "Failure",
+  drop: "Failure",
+  dropped: "Failure",
+}
+
+asim.EventSchema = "NetworkSession"
+asim.EventSchemaVersion = "0.2.7"
+asim.EventType = "NetworkSession"
+asim.EventCount = 1
+asim.EventStartTime = fw.ts
+asim.EventEndTime = fw.ts
+asim.EventVendor = "Example Networks"
+asim.EventProduct = "Example Firewall"
+asim.DvcHostname = fw.device
+asim.DvcAction = $actions[fw.action.to_lower()]? else "Allow"
+asim.EventResult = $results[fw.action.to_lower()]? else "Success"
+asim.SrcIpAddr = fw.src_ip
+asim.SrcPortNumber = fw.src_port
+asim.DstIpAddr = fw.dst_ip
+asim.DstPortNumber = fw.dst_port
+asim.NetworkProtocol = fw.proto.to_upper()
+asim.SrcBytes = fw.bytes_out
+asim.DstBytes = fw.bytes_in
+asim.NetworkBytes = fw.bytes_out + fw.bytes_in
+
+drop fw.ts
+drop fw.action
+drop fw.src_ip
+drop fw.src_port
+drop fw.dst_ip
+drop fw.dst_port
+drop fw.proto
+drop fw.bytes_out
+drop fw.bytes_in
+drop fw.device
+
+this = {...asim, AdditionalFields: fw}
+```
+
+```tql
+{
+  EventSchema: "NetworkSession",
+  EventSchemaVersion: "0.2.7",
+  EventType: "NetworkSession",
+  EventCount: 1,
+  EventStartTime: 2024-01-15T10:30:45Z,
+  EventEndTime: 2024-01-15T10:30:45Z,
+  EventVendor: "Example Networks",
+  EventProduct: "Example Firewall",
+  DvcHostname: "edge-fw-01",
+  DvcAction: "Allow",
+  EventResult: "Success",
+  SrcIpAddr: "10.0.0.5",
+  SrcPortNumber: 51544,
+  DstIpAddr: "203.0.113.10",
+  DstPortNumber: 443,
+  NetworkProtocol: "TCP",
+  SrcBytes: 1280,
+  DstBytes: 8192,
+  NetworkBytes: 9472,
+  AdditionalFields: {},
+}
+```
+
+## Apply the mapping pattern
+
+Use the same structure for larger mappings:
+
+- **Keep a source namespace**: Move the parsed event under a short namespace
+  such as `fw`, `dns`, `edr`, or `event` before you create ASIM fields.
+- **Set the schema fields early**: Let `EventSchema` and
+  `EventSchemaVersion` drive which field records, constants, and conditional
+  requirements you apply.
+- **Map participants with role prefixes**: Use prefixes such as `Src`, `Dst`,
+  `Actor`, `Target`, `Acting`, and `Dvc` to distinguish entities in the event.
+- **Populate by field class**: Start with `Mandatory` fields, add useful
+  `Recommended` fields, and populate `Conditional` fields when their
+  documented condition applies.
+- **Normalize enum values explicitly**: Map source strings to ASIM values such
+  as `Allow`, `Deny`, `Success`, `Failure`, `TCP`, or `UDP`.
+- **Prefer canonical fields**: Resolve aliases to canonical ASIM fields before
+  you build reusable mappings or detections.
+- **Preserve unmapped fields**: Keep source fields that don't have a deliberate
+  ASIM target in `AdditionalFields` so reviewers can audit the mapping.
+
+## See Also
+
+- <Op>to_azure_log_analytics</Op>
+- <Guide>ai-workbench/use-agent-skills#use-the-microsoft-asim-skill</Guide>
+- <Guide>normalization/map-to-ocsf</Guide>
+- <Guide>normalization/map-to-udm</Guide>
+- <Guide>normalization/map-to-other-schemas</Guide>
+- <Guide>packages/create-a-package</Guide>
+- <Guide>testing/write-tests</Guide>
+- <Integration>microsoft/sentinel-log-analytics</Integration>

--- a/src/content/docs/guides/normalization/map-to-asim.mdx
+++ b/src/content/docs/guides/normalization/map-to-asim.mdx
@@ -66,6 +66,8 @@ this = {fw: this}
 let $actions = {
   allow: "Allow",
   allowed: "Allow",
+  block: "Deny",
+  blocked: "Deny",
   deny: "Deny",
   denied: "Deny",
   drop: "Drop",
@@ -75,42 +77,37 @@ let $actions = {
 let $results = {
   allow: "Success",
   allowed: "Success",
+  block: "Failure",
+  blocked: "Failure",
   deny: "Failure",
   denied: "Failure",
   drop: "Failure",
   dropped: "Failure",
 }
 
+fw.proto = fw.proto.to_upper()
+
 asim.EventSchema = "NetworkSession"
 asim.EventSchemaVersion = "0.2.7"
 asim.EventType = "NetworkSession"
 asim.EventCount = 1
 asim.EventStartTime = fw.ts
-asim.EventEndTime = fw.ts
+asim.EventEndTime = move fw.ts
 asim.EventVendor = "Example Networks"
 asim.EventProduct = "Example Firewall"
-asim.DvcHostname = fw.device
-asim.DvcAction = $actions[fw.action.to_lower()]? else "Allow"
-asim.EventResult = $results[fw.action.to_lower()]? else "Success"
-asim.SrcIpAddr = fw.src_ip
-asim.SrcPortNumber = fw.src_port
-asim.DstIpAddr = fw.dst_ip
-asim.DstPortNumber = fw.dst_port
-asim.NetworkProtocol = fw.proto.to_upper()
-asim.SrcBytes = fw.bytes_out
-asim.DstBytes = fw.bytes_in
-asim.NetworkBytes = fw.bytes_out + fw.bytes_in
-
-drop fw.ts
-drop fw.action
-drop fw.src_ip
-drop fw.src_port
-drop fw.dst_ip
-drop fw.dst_port
-drop fw.proto
-drop fw.bytes_out
-drop fw.bytes_in
-drop fw.device
+asim.Dvc = fw.device
+asim.DvcHostname = move fw.device
+asim.DvcAction = $actions[fw.action.to_lower()]? else fw.action
+asim.EventResult = $results[fw.action.to_lower()]? else "NA"
+asim.DvcOriginalAction = move fw.action
+asim.SrcIpAddr = move fw.src_ip
+asim.SrcPortNumber = move fw.src_port
+asim.DstIpAddr = move fw.dst_ip
+asim.DstPortNumber = move fw.dst_port
+asim.NetworkProtocol = move fw.proto
+asim.SrcBytes = move fw.bytes_out
+asim.DstBytes = move fw.bytes_in
+asim.NetworkBytes = asim.SrcBytes + asim.DstBytes
 
 this = {...asim, AdditionalFields: fw}
 ```
@@ -125,9 +122,11 @@ this = {...asim, AdditionalFields: fw}
   EventEndTime: 2024-01-15T10:30:45Z,
   EventVendor: "Example Networks",
   EventProduct: "Example Firewall",
+  Dvc: "edge-fw-01",
   DvcHostname: "edge-fw-01",
   DvcAction: "Allow",
   EventResult: "Success",
+  DvcOriginalAction: "allowed",
   SrcIpAddr: "10.0.0.5",
   SrcPortNumber: 51544,
   DstIpAddr: "203.0.113.10",

--- a/src/content/docs/guides/normalization/map-to-other-schemas.mdx
+++ b/src/content/docs/guides/normalization/map-to-other-schemas.mdx
@@ -4,8 +4,12 @@ title: Map to other schemas
 
 This guide provides brief guidance on mapping data to schemas other than OCSF.
 While OCSF is the recommended choice for security data, you may need to support
-Elastic Common Schema (ECS), Google UDM, or Microsoft ASIM for integration with
-specific platforms.
+Elastic Common Schema (ECS), Google UDM, Microsoft ASIM, or another
+platform-specific schema.
+
+Use <Guide>normalization/map-to-udm</Guide> and
+<Guide>normalization/map-to-asim</Guide> for the dedicated Google UDM and
+Microsoft ASIM workflows.
 
 ## Choosing a schema
 
@@ -63,28 +67,14 @@ Common ECS field sets for security data:
 
 [ASIM](https://learn.microsoft.com/en-us/azure/sentinel/normalization) (Advanced
 Security Information Model) is Microsoft Sentinel's normalization schema.
+Use <Guide>normalization/map-to-asim</Guide> for the detailed ASIM mapping
+workflow.
 
 ### Key differences from OCSF
 
 - Designed for KQL queries
 - Uses specific parser naming conventions
 - Column-oriented naming style
-
-### Mapping pattern
-
-```tql
-// From OCSF to ASIM Network Session
-asim.EventType = "NetworkSession"
-asim.EventProduct = ocsf.metadata.product.name
-asim.EventVendor = ocsf.metadata.product.vendor_name
-asim.TimeGenerated = ocsf.time
-asim.SrcIpAddr = ocsf.src_endpoint.ip
-asim.SrcPortNumber = ocsf.src_endpoint.port
-asim.DstIpAddr = ocsf.dst_endpoint.ip
-asim.DstPortNumber = ocsf.dst_endpoint.port
-asim.NetworkProtocol = ocsf.connection_info.protocol_name
-asim.NetworkBytes = ocsf.traffic.total_bytes
-```
 
 ### ASIM schemas
 
@@ -177,4 +167,5 @@ fork {
 - <Op>to_opensearch</Op>
 - <Guide>normalization/map-to-ocsf</Guide>
 - <Guide>normalization/map-to-udm</Guide>
+- <Guide>normalization/map-to-asim</Guide>
 - <Guide>transformation/transform-values</Guide>

--- a/src/content/docs/integrations/microsoft/sentinel-log-analytics.mdx
+++ b/src/content/docs/integrations/microsoft/sentinel-log-analytics.mdx
@@ -18,6 +18,19 @@ All logs in Azure land in a [Log Analytics Workspace][workspace]. Microsoft
 Sentinel and Azure Monitor read from this workspace; they don't store data
 themselves.
 
+## ASIM mapping
+
+Microsoft Sentinel uses the Advanced Security Information Model (ASIM) to query
+normalized security data across products. Use
+<Guide>normalization/map-to-asim</Guide> to shape parsed events into ASIM
+records before you send them to Log Analytics tables.
+
+For agent-assisted work, follow
+<Guide>ai-workbench/use-agent-skills#use-the-microsoft-asim-skill</Guide> to
+use the `tenzir-microsoft-asim` skill. The skill helps choose ASIM schemas,
+inspect fields, resolve aliases, and map source telemetry with canonical field
+names such as `EventSchema`, `SrcIpAddr`, and `DstIpAddr`.
+
 To get data into a workspace, Azure uses two components:
 
 1. A [Data Collection Endpoint (DCE)][dce] receives your data via HTTPS. This is
@@ -133,4 +146,5 @@ making them ideal for historical forensics and ad-hoc KQL queries.
 
 - <Op>from_microsoft_graph</Op>
 - <Op>to_azure_log_analytics</Op>
+- <Guide>normalization/map-to-asim</Guide>
 - <Integration>microsoft/graph</Integration>

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -127,6 +127,7 @@ export const guides = [
           "guides/normalization/clean-up-values",
           "guides/normalization/map-to-ocsf",
           "guides/normalization/map-to-udm",
+          "guides/normalization/map-to-asim",
           "guides/normalization/map-to-other-schemas",
         ],
       },


### PR DESCRIPTION
## 🔍 Problem

- The skills PR adds `tenzir-microsoft-asim`, but docs only describe the Google UDM schema skill workflow.
- Readers need the same first-class placement for Microsoft Sentinel ASIM: installation, normalization guidance, and Sentinel integration context.

## 🛠️ Solution

- Add a dedicated `Map to ASIM` normalization guide that mirrors the Google UDM guide structure.
- Document the ASIM skill in the agent-skills guide, add the normalization sidebar entry, and link ASIM guidance from the Sentinel & Log Analytics integration page.
- Keep `map-to-other-schemas` as a brief overview and route detailed ASIM work to the dedicated guide.

## 💬 Review

- Focus on the ASIM `NetworkSession` mapping example, field naming, and placement relative to the Google UDM documentation.
- Validation: `uvx tenzir --strict` for the TQL example; `bun run lint:files` for changed files; `bun run build`; pre-push hooks.

<sub>
⚙️ Code PR: tenzir/skills#11<br>
🎫 References TNZ-686
</sub>