### PR TITLE
Update Google SecOps import docs

### DIFF
--- a/src/content/docs/guides/normalization/map-to-udm.mdx
+++ b/src/content/docs/guides/normalization/map-to-udm.mdx
@@ -7,11 +7,10 @@ This guide shows you how to map events to Google SecOps Unified Data Model
 metadata, model participants as UDM nouns, convert enum values, and preserve
 unmapped source fields.
 
-:::caution[Structured UDM ingestion is coming soon]
-Tenzir's <Op>to_google_secops</Op> operator currently sends unstructured logs to
-Google SecOps. Use this guide to design and test UDM mapping operators, but
-don't send structured UDM records directly with <Op>to_google_secops</Op> until
-structured UDM ingestion support is available.
+:::tip[Send structured UDM records]
+Tenzir's <Op>to_google_secops</Op> operator can send structured UDM records to
+Google SecOps. Use `mode="udm_event"` for UDM event rows, or
+`mode="udm_entity"` for UDM entity rows.
 :::
 
 The TQL examples in this guide build API-facing UDM records, so they use

--- a/src/content/docs/integrations/google/secops.mdx
+++ b/src/content/docs/integrations/google/secops.mdx
@@ -22,7 +22,7 @@ with names such as `metadata.eventType`, and write YARA-L or rule field paths
 with names such as `metadata.event_type`.
 
 Tenzir's <Op>to_google_secops</Op> operator can send raw logs, UDM events, and
-entities. Use `mode="udm"` after shaping events into SecOps UDM records.
+entities. Use `mode="udm_event"` after shaping events into SecOps UDM records.
 
 ## Authentication
 
@@ -37,7 +37,7 @@ to use Google Application Default Credentials.
 ```tql
 from {log: "31-Mar-2025 01:35:02.187 client 0.0.0.0#4238: query: tenzir.com IN A + (255.255.255.255)"}
 to_google_secops \
-  mode="log",
+  mode="raw_log",
   project="my-project",
   region="us",
   instance="my-secops-instance",
@@ -79,7 +79,7 @@ from {
   },
 }
 to_google_secops \
-  mode="udm",
+  mode="udm_event",
   project="my-project",
   region="us",
   instance="my-secops-instance",
@@ -106,7 +106,7 @@ from {
   },
 }
 to_google_secops \
-  mode="entity",
+  mode="udm_entity",
   project="my-project",
   region="us",
   instance="my-secops-instance",

--- a/src/content/docs/integrations/google/secops.mdx
+++ b/src/content/docs/integrations/google/secops.mdx
@@ -23,6 +23,8 @@ with names such as `metadata.event_type`.
 
 Tenzir's <Op>to_google_secops</Op> operator can send raw logs, UDM events, and
 entities. Use `mode="udm_event"` after shaping events into SecOps UDM records.
+The operator forwards UDM and entity rows as-is, so build them with the
+ingestion field names before sending them.
 
 ## Authentication
 
@@ -62,11 +64,18 @@ from {
     eventType: "NETWORK_CONNECTION",
     vendorName: "Tenzir",
     productName: "Tenzir Pipeline",
+    productVersion: "dev",
     productEventType: "connection",
+    productLogId: "tenzir-udm-001",
+    description: "Network connection observed by Tenzir",
   },
   principal: {
     hostname: "host.example",
     ip: ["192.0.2.10"],
+    user: {
+      userid: "alice",
+      emailAddresses: ["alice@example.com"],
+    },
   },
   target: {
     hostname: "service.example",
@@ -76,6 +85,18 @@ from {
   network: {
     applicationProtocol: "HTTPS",
     ipProtocol: "TCP",
+    sentBytes: 1250,
+    receivedBytes: 4096,
+  },
+  securityResult: [{
+    action: ["ALLOW"],
+    severity: "LOW",
+  }],
+  additional: {
+    fields: {
+      sourcePipeline: {stringValue: "to_google_secops-example"},
+      marker: {stringValue: "tenzir-udm-rich"},
+    },
   },
 }
 to_google_secops \
@@ -101,7 +122,17 @@ from {
       userid: "alice@example.com",
       productObjectId: "alice-0001",
       userDisplayName: "Alice Example",
-      emailAddresses: ["alice@example.com"],
+      emailAddresses: ["alice@example.com", "alice@corp.example"],
+      employeeId: "E0001",
+      title: "Security Analyst",
+      companyName: "Example Corp",
+      department: "Security Operations",
+    },
+  },
+  additional: {
+    fields: {
+      sourcePipeline: {stringValue: "to_google_secops-example"},
+      marker: {stringValue: "tenzir-entity-rich"},
     },
   },
 }

--- a/src/content/docs/integrations/google/secops.mdx
+++ b/src/content/docs/integrations/google/secops.mdx
@@ -57,11 +57,25 @@ to_google_secops \
 ```tql
 from {
   metadata: {
-    event_type: "NETWORK_DNS",
-    product_name: "Tenzir",
+    eventTimestamp: 2026-01-01T00:00:00,
+    collectedTimestamp: 2026-01-01T00:00:01,
+    eventType: "NETWORK_CONNECTION",
+    vendorName: "Tenzir",
+    productName: "Tenzir Pipeline",
+    productEventType: "connection",
   },
   principal: {
     hostname: "host.example",
+    ip: ["192.0.2.10"],
+  },
+  target: {
+    hostname: "service.example",
+    ip: ["198.51.100.20"],
+    port: 443,
+  },
+  network: {
+    applicationProtocol: "HTTPS",
+    ipProtocol: "TCP",
   },
 }
 to_google_secops \
@@ -77,11 +91,18 @@ to_google_secops \
 ```tql
 from {
   metadata: {
-    entity_type: "ASSET",
-    product_name: "Tenzir",
+    collectedTimestamp: 2026-01-01T00:00:01,
+    vendorName: "Tenzir",
+    productName: "Tenzir Pipeline",
+    entityType: "USER",
   },
   entity: {
-    hostname: "host.example",
+    user: {
+      userid: "alice@example.com",
+      productObjectId: "alice-0001",
+      userDisplayName: "Alice Example",
+      emailAddresses: ["alice@example.com"],
+    },
   },
 }
 to_google_secops \
@@ -90,5 +111,5 @@ to_google_secops \
   region="us",
   instance="my-secops-instance",
   service_credentials=secret("my_secops_service_account"),
-  log_type="ASSET_CONTEXT"
+  log_type="AZURE_AD_CONTEXT"
 ```

--- a/src/content/docs/integrations/google/secops.mdx
+++ b/src/content/docs/integrations/google/secops.mdx
@@ -4,10 +4,8 @@ title: SecOps
 
 [Google Security Operations
 (SecOps)](https://cloud.google.com/security/products/security-operations) is
-Google's security operations platform. Tenzir can send events to Google SecOps
-using the [unstructured logs ingestion API][api].
-
-[api]: https://cloud.google.com/chronicle/docs/reference/ingestion-api#unstructuredlogentries
+Google's security operations platform. Tenzir can send raw logs, UDM events, and
+entity records to Google SecOps using Chronicle import APIs.
 
 ![Google Security Operations](secops.svg)
 
@@ -23,20 +21,74 @@ For agent-assisted work, follow
 with names such as `metadata.eventType`, and write YARA-L or rule field paths
 with names such as `metadata.event_type`.
 
-Tenzir's <Op>to_google_secops</Op> operator currently sends unstructured logs.
-Structured UDM ingestion support is coming soon.
+Tenzir's <Op>to_google_secops</Op> operator can send raw logs, UDM events, and
+entities. Use `mode="udm"` after shaping events into SecOps UDM records.
+
+## Authentication
+
+<Op>to_google_secops</Op> targets a SecOps instance with `project`, `region`, and
+`instance`. Provide service-account JSON with `service_credentials`, or omit it
+to use Google Application Default Credentials.
 
 ## Examples
 
-### Send an event to Google SecOps
+### Send Raw Logs
 
 ```tql
 from {log: "31-Mar-2025 01:35:02.187 client 0.0.0.0#4238: query: tenzir.com IN A + (255.255.255.255)"}
 to_google_secops \
-  customer_id="00000000-0000-0000-00000000000000000",
-  private_key=secret("my_secops_key"),
-  client_email="somebody@example.com",
+  mode="log",
+  project="my-project",
+  region="us",
+  instance="my-secops-instance",
+  service_credentials=secret("my_secops_service_account"),
   log_text=log,
   log_type="BIND_DNS",
-  region="europe"
+  log_entry_time=2026-01-01T00:00:00,
+  collection_time=2026-01-01T00:00:01,
+  labels={tenant: {value: "acme", rbac_enabled: true}},
+  forwarder="forwarder-1",
+  hint="bind-dns",
+  source_filename="named.log"
+```
+
+### Send UDM Events
+
+```tql
+from {
+  metadata: {
+    event_type: "NETWORK_DNS",
+    product_name: "Tenzir",
+  },
+  principal: {
+    hostname: "host.example",
+  },
+}
+to_google_secops \
+  mode="udm",
+  project="my-project",
+  region="us",
+  instance="my-secops-instance",
+  service_credentials=secret("my_secops_service_account")
+```
+
+### Send Entities
+
+```tql
+from {
+  metadata: {
+    entity_type: "ASSET",
+    product_name: "Tenzir",
+  },
+  entity: {
+    hostname: "host.example",
+  },
+}
+to_google_secops \
+  mode="entity",
+  project="my-project",
+  region="us",
+  instance="my-secops-instance",
+  service_credentials=secret("my_secops_service_account"),
+  log_type="ASSET_CONTEXT"
 ```

--- a/src/content/docs/reference/functions/file_contents.mdx
+++ b/src/content/docs/reference/functions/file_contents.mdx
@@ -26,10 +26,10 @@ Defaults to `false`.
 
 ## Examples
 
+### Read a text file
+
 ```tql
-let $secops_credentials = file_contents("/path/to/service-account.json")
-…
-to_google_secops service_credentials=$secops_credentials, …
+from {hostname: file_contents("/etc/hostname")}
 ```
 
 ## See Also

--- a/src/content/docs/reference/functions/file_contents.mdx
+++ b/src/content/docs/reference/functions/file_contents.mdx
@@ -27,9 +27,9 @@ Defaults to `false`.
 ## Examples
 
 ```tql
-let $secops_config = file_contents("/path/to/file.json").parse_json()
+let $secops_credentials = file_contents("/path/to/service-account.json")
 …
-to_google_secops client_email=$secops_config.client_email, …
+to_google_secops service_credentials=$secops_credentials, …
 ```
 
 ## See Also

--- a/src/content/docs/reference/operators.mdx
+++ b/src/content/docs/reference/operators.mdx
@@ -724,7 +724,7 @@ operators:
     example: 'to_google_cloud_storage "gs://my-bucket/data/{uuid}.json" { write_ndjson }'
     path: 'reference/operators/to_google_cloud_storage'
   - name: 'to_google_secops'
-    description: 'Sends unstructured events to a Google SecOps Chronicle instance.'
+    description: 'Sends raw logs, UDM events, or entities to a Google SecOps Chronicle instance.'
     example: 'to_google_secops …'
     path: 'reference/operators/to_google_secops'
   - name: 'serve_zmq'
@@ -2096,7 +2096,7 @@ to_google_cloud_storage "gs://my-bucket/data/{uuid}.json" { write_ndjson }
 
 </ReferenceCard>
 
-<ReferenceCard title="to_google_secops" description="Sends unstructured events to a Google SecOps Chronicle instance." href="/reference/operators/to_google_secops">
+<ReferenceCard title="to_google_secops" description="Sends raw logs, UDM events, or entities to a Google SecOps Chronicle instance." href="/reference/operators/to_google_secops">
 
 ```tql
 to_google_secops …

--- a/src/content/docs/reference/operators/parallel.mdx
+++ b/src/content/docs/reference/operators/parallel.mdx
@@ -95,8 +95,10 @@ Send events to Google SecOps with 4 concurrent connections:
 ```tql
 subscribe "events"
 parallel 4 {
-  to_google_secops customer_id="…", private_key=secret("secops_key"),
-                   client_email="…", log_type="…", log_text=raw
+  to_google_secops project="…", region="us", instance="…",
+                   service_credentials=secret("secops_service_account"),
+                   log_type="…", log_text=raw,
+                   log_entry_time=ts, collection_time=now()
 }
 ```
 

--- a/src/content/docs/reference/operators/to_google_secops.mdx
+++ b/src/content/docs/reference/operators/to_google_secops.mdx
@@ -8,7 +8,7 @@ Sends raw logs, UDM events, or entities to a Google SecOps Chronicle instance.
 
 ```tql
 to_google_secops [mode=string,] project=string, region=string, instance=string,
-                 [service_credentials=string, log_type=string,
+                 [service_credentials=secret, log_type=string,
                  log_text=blob|string, log_entry_time=time,
                  collection_time=time, labels=record, forwarder=string,
                  hint=string, source_filename=string, namespace=string,
@@ -49,7 +49,7 @@ The SecOps location. This also selects the regional API host.
 
 The SecOps instance ID.
 
-### `service_credentials = string (optional)`
+### `service_credentials = secret (optional)`
 
 Full service-account JSON to use for Google Cloud OAuth2 authentication. Use a
 secret value for credentials in production.

--- a/src/content/docs/reference/operators/to_google_secops.mdx
+++ b/src/content/docs/reference/operators/to_google_secops.mdx
@@ -63,7 +63,17 @@ The raw log type or entity log type. Required when `mode="log"` or
 
 For raw logs, this selects the SecOps log type in the `logs.import` resource
 path. For entities, this sets the `logType` field in the `entities.import`
-request.
+request. Use a context source log type accepted by your SecOps instance, such as
+`AZURE_AD_CONTEXT` for Azure AD user context. This is not the same as the UDM
+entity type, such as `USER` or `ASSET`.
+
+### UDM and Entity Field Names
+
+UDM events and entities are sent as ingestion API JSON. Shape these rows with
+Google's lowerCamelCase ingestion field names, such as `metadata.eventType` and
+`metadata.entityType`. Query field names in SecOps search and YARA-L often use
+snake_case, such as `metadata.event_type`; those are not the field names to send
+to the import APIs.
 
 ### `log_text = blob|string`
 
@@ -172,11 +182,25 @@ to_google_secops \
 ```tql
 from {
   metadata: {
-    event_type: "NETWORK_DNS",
-    product_name: "Tenzir",
+    eventTimestamp: 2026-01-01T00:00:00,
+    collectedTimestamp: 2026-01-01T00:00:01,
+    eventType: "NETWORK_CONNECTION",
+    vendorName: "Tenzir",
+    productName: "Tenzir Pipeline",
+    productEventType: "connection",
   },
   principal: {
     hostname: "host.example",
+    ip: ["192.0.2.10"],
+  },
+  target: {
+    hostname: "service.example",
+    ip: ["198.51.100.20"],
+    port: 443,
+  },
+  network: {
+    applicationProtocol: "HTTPS",
+    ipProtocol: "TCP",
   },
 }
 to_google_secops \
@@ -192,11 +216,18 @@ to_google_secops \
 ```tql
 from {
   metadata: {
-    entity_type: "ASSET",
-    product_name: "Tenzir",
+    collectedTimestamp: 2026-01-01T00:00:01,
+    vendorName: "Tenzir",
+    productName: "Tenzir Pipeline",
+    entityType: "USER",
   },
   entity: {
-    hostname: "host.example",
+    user: {
+      userid: "alice@example.com",
+      productObjectId: "alice-0001",
+      userDisplayName: "Alice Example",
+      emailAddresses: ["alice@example.com"],
+    },
   },
 }
 to_google_secops \
@@ -205,7 +236,7 @@ to_google_secops \
   region="us",
   instance="my-secops-instance",
   service_credentials=secret("my_secops_service_account"),
-  log_type="ASSET_CONTEXT"
+  log_type="AZURE_AD_CONTEXT"
 ```
 
 ## See Also

--- a/src/content/docs/reference/operators/to_google_secops.mdx
+++ b/src/content/docs/reference/operators/to_google_secops.mdx
@@ -73,7 +73,8 @@ UDM events and entities are sent as ingestion API JSON. Shape these rows with
 Google's lowerCamelCase ingestion field names, such as `metadata.eventType` and
 `metadata.entityType`. Query field names in SecOps search and YARA-L often use
 snake_case, such as `metadata.event_type`; those are not the field names to send
-to the import APIs.
+to the import APIs. The operator forwards each UDM or entity row as-is and does
+not translate field names.
 
 ### `log_text = blob|string`
 
@@ -141,7 +142,7 @@ Defaults to `2M`. Values must be between `100k` and `4M`.
 
 The maximum number of events to include in one import request.
 
-Defaults to `1k`.
+Defaults to `1k`. Must be at least `1`.
 
 ### `batch_timeout = duration (optional)`
 
@@ -153,7 +154,7 @@ Defaults to `5s`.
 
 The maximum number of concurrent import requests.
 
-Defaults to `50`.
+Defaults to `50`. Must be at least `1`.
 
 ## Examples
 
@@ -187,11 +188,18 @@ from {
     eventType: "NETWORK_CONNECTION",
     vendorName: "Tenzir",
     productName: "Tenzir Pipeline",
+    productVersion: "dev",
     productEventType: "connection",
+    productLogId: "tenzir-udm-001",
+    description: "Network connection observed by Tenzir",
   },
   principal: {
     hostname: "host.example",
     ip: ["192.0.2.10"],
+    user: {
+      userid: "alice",
+      emailAddresses: ["alice@example.com"],
+    },
   },
   target: {
     hostname: "service.example",
@@ -201,6 +209,18 @@ from {
   network: {
     applicationProtocol: "HTTPS",
     ipProtocol: "TCP",
+    sentBytes: 1250,
+    receivedBytes: 4096,
+  },
+  securityResult: [{
+    action: ["ALLOW"],
+    severity: "LOW",
+  }],
+  additional: {
+    fields: {
+      sourcePipeline: {stringValue: "to_google_secops-example"},
+      marker: {stringValue: "tenzir-udm-rich"},
+    },
   },
 }
 to_google_secops \
@@ -226,7 +246,17 @@ from {
       userid: "alice@example.com",
       productObjectId: "alice-0001",
       userDisplayName: "Alice Example",
-      emailAddresses: ["alice@example.com"],
+      emailAddresses: ["alice@example.com", "alice@corp.example"],
+      employeeId: "E0001",
+      title: "Security Analyst",
+      companyName: "Example Corp",
+      department: "Security Operations",
+    },
+  },
+  additional: {
+    fields: {
+      sourcePipeline: {stringValue: "to_google_secops-example"},
+      marker: {stringValue: "tenzir-entity-rich"},
     },
   },
 }

--- a/src/content/docs/reference/operators/to_google_secops.mdx
+++ b/src/content/docs/reference/operators/to_google_secops.mdx
@@ -21,21 +21,21 @@ to_google_secops [mode=string,] project=string, region=string, instance=string,
 The `to_google_secops` operator ingests telemetry via the Google SecOps Chronicle
 import APIs:
 
-- `mode="log"` sends raw logs to the [`logs.import` API][logs-import].
-- `mode="udm"` sends each input row as a UDM event to the [`events.import`
+- `mode="raw_log"` sends raw logs to the [`logs.import` API][logs-import].
+- `mode="udm_event"` sends each input row as a UDM event to the [`events.import`
   API][events-import].
-- `mode="entity"` sends each input row as an entity to the [`entities.import`
+- `mode="udm_entity"` sends each input row as an entity to the [`entities.import`
   API][entities-import].
 
 [logs-import]: https://cloud.google.com/chronicle/docs/reference/rest/v1/projects.locations.instances.logTypes.logs/import
 [events-import]: https://cloud.google.com/chronicle/docs/reference/rest/v1/projects.locations.instances.events/import
-[entities-import]: https://cloud.google.com/chronicle/docs/reference/rest/v1beta/projects.locations.instances.entities/import
+[entities-import]: https://cloud.google.com/chronicle/docs/reference/rest/v1/projects.locations.instances.entities/import
 
 ### `mode = string`
 
-Selects the ingestion mode. Must be `log`, `udm`, or `entity`.
+Selects the ingestion mode. Must be `raw_log`, `udm_event`, or `udm_entity`.
 
-Defaults to `log`.
+Defaults to `raw_log`.
 
 ### `project = string`
 
@@ -58,8 +58,8 @@ When omitted, the operator uses Google Application Default Credentials.
 
 ### `log_type = string`
 
-The raw log type or entity log type. Required when `mode="log"` or
-`mode="entity"`.
+The raw log type or entity log type. Required when `mode="raw_log"` or
+`mode="udm_entity"`.
 
 For raw logs, this selects the SecOps log type in the `logs.import` resource
 path. For entities, this sets the `logType` field in the `entities.import`
@@ -80,16 +80,16 @@ to the import APIs.
 The raw log text. String values must contain valid UTF-8. Blob and string values
 are base64-encoded before they are sent to SecOps.
 
-Required when `mode="log"`.
+Required when `mode="raw_log"`.
 
 ### `log_entry_time = time`
 
-The timestamp of the raw log entry. Required when `mode="log"`.
+The timestamp of the raw log entry. Required when `mode="raw_log"`.
 
 ### `collection_time = time`
 
 The time at which the raw log entry was collected. Google requires this to be
-after `log_entry_time`. Required when `mode="log"`.
+after `log_entry_time`. Required when `mode="raw_log"`.
 
 ### `labels = record (optional)`
 
@@ -105,31 +105,31 @@ labels={
 }
 ```
 
-Only valid when `mode="log"`.
+Only valid when `mode="raw_log"`.
 
 ### `forwarder = string (optional)`
 
 The SecOps forwarder name to attach to raw logs.
 
-Only valid when `mode="log"`.
+Only valid when `mode="raw_log"`.
 
 ### `hint = string (optional)`
 
 The parser hint to pass to the `logs.import` API.
 
-Only valid when `mode="log"`.
+Only valid when `mode="raw_log"`.
 
 ### `source_filename = string (optional)`
 
 The source filename to attach to raw logs.
 
-Only valid when `mode="log"`.
+Only valid when `mode="raw_log"`.
 
 ### `namespace = string (optional)`
 
 The environment namespace for raw logs.
 
-Only valid when `mode="log"`.
+Only valid when `mode="raw_log"`.
 
 ### `max_request_size = int (optional)`
 
@@ -162,7 +162,7 @@ Defaults to `50`.
 ```tql
 from {log: "31-Mar-2025 01:35:02.187 client 0.0.0.0#4238: query: tenzir.com IN A + (255.255.255.255)"}
 to_google_secops \
-  mode="log",
+  mode="raw_log",
   project="my-project",
   region="us",
   instance="my-secops-instance",
@@ -204,7 +204,7 @@ from {
   },
 }
 to_google_secops \
-  mode="udm",
+  mode="udm_event",
   project="my-project",
   region="us",
   instance="my-secops-instance",
@@ -231,7 +231,7 @@ from {
   },
 }
 to_google_secops \
-  mode="entity",
+  mode="udm_entity",
   project="my-project",
   region="us",
   instance="my-secops-instance",

--- a/src/content/docs/reference/operators/to_google_secops.mdx
+++ b/src/content/docs/reference/operators/to_google_secops.mdx
@@ -4,69 +4,134 @@ category: Outputs/Events
 example: 'to_google_secops …'
 ---
 
-Sends unstructured events to a Google SecOps Chronicle instance.
+Sends raw logs, UDM events, or entities to a Google SecOps Chronicle instance.
 
 ```tql
-to_google_secops customer_id=string, private_key=string, client_email=string,
-                 log_type=string, log_text=string, [region=string,
-                 timestamp=time, labels=record, namespace=string,
-                 max_request_size=int, batch_timeout=duration]
+to_google_secops [mode=string,] project=string, region=string, instance=string,
+                 [service_credentials=string, log_type=string,
+                 log_text=blob|string, log_entry_time=time,
+                 collection_time=time, labels=record, forwarder=string,
+                 hint=string, source_filename=string, namespace=string,
+                 max_request_size=int, max_batch_events=int,
+                 batch_timeout=duration, parallel=int]
 ```
 
 ## Description
 
-The `to_google_secops` operator makes it possible to ingest events via the
-[Google SecOps Chronicle unstructured logs ingestion
-API](https://cloud.google.com/chronicle/docs/reference/ingestion-api#unstructuredlogentries).
+The `to_google_secops` operator ingests telemetry via the Google SecOps Chronicle
+import APIs:
 
-### `customer_id = string`
+- `mode="log"` sends raw logs to the [`logs.import` API][logs-import].
+- `mode="udm"` sends each input row as a UDM event to the [`events.import`
+  API][events-import].
+- `mode="entity"` sends each input row as an entity to the [`entities.import`
+  API][entities-import].
 
-The customer UUID to use.
+[logs-import]: https://cloud.google.com/chronicle/docs/reference/rest/v1/projects.locations.instances.logTypes.logs/import
+[events-import]: https://cloud.google.com/chronicle/docs/reference/rest/v1/projects.locations.instances.events/import
+[entities-import]: https://cloud.google.com/chronicle/docs/reference/rest/v1beta/projects.locations.instances.entities/import
 
-### `private_key = string`
+### `mode = string`
 
-The private key to use for authentication. This corresponds to the `private_key`
-in the SecOps collector config.
+Selects the ingestion mode. Must be `log`, `udm`, or `entity`.
 
-### `client_email = string`
+Defaults to `log`.
 
-The user email to use for authentication. This corresponds to the `client_email`
-in the SecOps collector config.
+### `project = string`
+
+The Google Cloud project that owns the SecOps instance.
+
+### `region = string`
+
+The SecOps location. This also selects the regional API host.
+
+### `instance = string`
+
+The SecOps instance ID.
+
+### `service_credentials = string (optional)`
+
+Full service-account JSON to use for Google Cloud OAuth2 authentication. Use a
+secret value for credentials in production.
+
+When omitted, the operator uses Google Application Default Credentials.
 
 ### `log_type = string`
 
-The log type of the events.
+The raw log type or entity log type. Required when `mode="log"` or
+`mode="entity"`.
 
-### `log_text = string`
+For raw logs, this selects the SecOps log type in the `logs.import` resource
+path. For entities, this sets the `logType` field in the `entities.import`
+request.
 
-The log text to send.
+### `log_text = blob|string`
 
-### `region = string (optional)`
+The raw log text. String values must contain valid UTF-8. Blob and string values
+are base64-encoded before they are sent to SecOps.
 
-[Regional
-prefix](https://cloud.google.com/chronicle/docs/reference/ingestion-api#regional_endpoints)
-for the Ingestion endpoint (`malachiteingestion-pa.googleapis.com`).
+Required when `mode="log"`.
 
-### `timestamp = time (optional)`
+### `log_entry_time = time`
 
-Optional timestamp field to attach to logs.
+The timestamp of the raw log entry. Required when `mode="log"`.
+
+### `collection_time = time`
+
+The time at which the raw log entry was collected. Google requires this to be
+after `log_entry_time`. Required when `mode="log"`.
 
 ### `labels = record (optional)`
 
-A record of labels to attach to the logs. For example, `{node: "Configured
-Tenzir Node"}`.
+A record of custom metadata labels to attach to raw logs.
+
+String values default to `rbacEnabled=false`. To allow a label to be used for
+Google SecOps Data RBAC, use the structured form:
+
+```tql
+labels={
+  env: "prod",
+  tenant: {value: "acme", rbac_enabled: true},
+}
+```
+
+Only valid when `mode="log"`.
+
+### `forwarder = string (optional)`
+
+The SecOps forwarder name to attach to raw logs.
+
+Only valid when `mode="log"`.
+
+### `hint = string (optional)`
+
+The parser hint to pass to the `logs.import` API.
+
+Only valid when `mode="log"`.
+
+### `source_filename = string (optional)`
+
+The source filename to attach to raw logs.
+
+Only valid when `mode="log"`.
 
 ### `namespace = string (optional)`
 
-The namespace to use when ingesting.
+The environment namespace for raw logs.
 
-Defaults to `tenzir`.
+Only valid when `mode="log"`.
 
 ### `max_request_size = int (optional)`
 
-The maximum number of bytes in the request payload.
+The maximum number of bytes in the uncompressed request payload.
 
-Defaults to `1M`.
+Defaults to `2M`. Values must be between `100k` and `4M`.
+
+### `max_batch_events = int (optional)`
+
+The maximum number of events to include in one import request.
+
+Defaults to `1k`.
 
 ### `batch_timeout = duration (optional)`
 
@@ -74,17 +139,73 @@ The maximum duration to wait for new events before sending the request.
 
 Defaults to `5s`.
 
+### `parallel = int (optional)`
+
+The maximum number of concurrent import requests.
+
+Defaults to `50`.
+
 ## Examples
+
+### Send Raw Logs
 
 ```tql
 from {log: "31-Mar-2025 01:35:02.187 client 0.0.0.0#4238: query: tenzir.com IN A + (255.255.255.255)"}
 to_google_secops \
-  customer_id="00000000-0000-0000-00000000000000000",
-  private_key=secret("my_secops_key"),
-  client_email="somebody@example.com",
+  mode="log",
+  project="my-project",
+  region="us",
+  instance="my-secops-instance",
+  service_credentials=secret("my_secops_service_account"),
   log_text=log,
   log_type="BIND_DNS",
-  region="europe"
+  log_entry_time=2026-01-01T00:00:00,
+  collection_time=2026-01-01T00:00:01,
+  labels={tenant: {value: "acme", rbac_enabled: true}},
+  forwarder="forwarder-1",
+  hint="bind-dns",
+  source_filename="named.log"
+```
+
+### Send UDM Events
+
+```tql
+from {
+  metadata: {
+    event_type: "NETWORK_DNS",
+    product_name: "Tenzir",
+  },
+  principal: {
+    hostname: "host.example",
+  },
+}
+to_google_secops \
+  mode="udm",
+  project="my-project",
+  region="us",
+  instance="my-secops-instance",
+  service_credentials=secret("my_secops_service_account")
+```
+
+### Send Entities
+
+```tql
+from {
+  metadata: {
+    entity_type: "ASSET",
+    product_name: "Tenzir",
+  },
+  entity: {
+    hostname: "host.example",
+  },
+}
+to_google_secops \
+  mode="entity",
+  project="my-project",
+  region="us",
+  instance="my-secops-instance",
+  service_credentials=secret("my_secops_service_account"),
+  log_type="ASSET_CONTEXT"
 ```
 
 ## See Also


### PR DESCRIPTION
## Summary

Updates the Google SecOps integration and `to_google_secops` operator reference to match the Chronicle import API migration in the code PR and the current live-test findings.

- Documents the `logs.import`, `events.import`, and `entities.import` modes.
- Clarifies that UDM and entity rows must use Google ingestion API field names, such as `metadata.eventType` and `metadata.entityType`, not snake_case SecOps query/YARA-L field names.
- Updates UDM and entity examples to use richer, live-accepted payload shapes.
- Uses `AZURE_AD_CONTEXT` for the entity example instead of the rejected `ASSET_CONTEXT` value.

Companion code PR: https://github.com/tenzir/tenzir/pull/6250

## Validation

- `git -C .docs diff --check -- src/content/docs/reference/operators/to_google_secops.mdx src/content/docs/integrations/google/secops.mdx`
- `just build`
- `just test --match operators/to_google_secops` (`23 passed`)
- Live Google SecOps import tests against the provided instance for raw logs, UDM events, and user entities
- `searchRawLogs` found 3 raw-log matches for the live marker
- `udmSearch` found 1 UDM event for the live marker after indexing delay

## Live-Test Findings

- `ASSET_CONTEXT` is rejected by the live `entities.import` API as `invalid log type` on this instance.
- Entity metadata with `creationTimestamp` is rejected with `ImportEntities failed` on this instance.
- The operator reports non-2xx ingestion responses as warning diagnostics and exits successfully, so callers need diagnostics to notice those failures today.
- `searchEntities` returned 0 entities for accepted user-entity indicators in this instance; entity import acceptance was verified by the import response, but search visibility was not confirmed via that API.