### PR TITLE
Document null spread behavior

### DIFF
--- a/src/content/docs/guides/transformation/reshape-complex-data.mdx
+++ b/src/content/docs/guides/transformation/reshape-complex-data.mdx
@@ -386,6 +386,10 @@ merged = {
 }
 ```
 
+Optional fragments compose the same way: use `...profile?` when a fragment may
+be missing. If the spread expression evaluates to `null`, it contributes no
+fields.
+
 ## Handle dynamic schemas
 
 Work with data that has varying structures.

--- a/src/content/docs/guides/transformation/reshape-complex-data.mdx
+++ b/src/content/docs/guides/transformation/reshape-complex-data.mdx
@@ -386,8 +386,8 @@ merged = {
 }
 ```
 
-Optional fragments compose the same way: use `...profile?` when a fragment may
-be missing. If the spread expression evaluates to `null`, it contributes no
+Optional fragments compose the same way: use `...user.profile?` when a fragment
+may be missing. If the spread expression evaluates to `null`, it contributes no
 fields.
 
 ## Handle dynamic schemas

--- a/src/content/docs/guides/transformation/shape-lists.mdx
+++ b/src/content/docs/guides/transformation/shape-lists.mdx
@@ -78,29 +78,59 @@ with_value = [...list1, 10, ...list2]
 }
 ```
 
-Use `else []` when a list fragment may be missing:
+Use optional access when a list fragment may be missing. If the spread
+expression evaluates to `null`, it contributes no elements, so an explicit
+`else []` fallback is not necessary:
 
 ```tql
 from {
-  custom_tags: ["vip"],
   system_tags: ["imported", "reviewed"],
 }
 labels = [
-  ...(custom_tags? else []),
-  ...(system_tags? else []),
+  "production",
+  ...custom_tags?,
+  ...system_tags?,
 ]
 ```
 
 ```tql
 {
-  custom_tags: ["vip"],
-  system_tags: ["imported", "reviewed"],
-  labels: ["vip", "imported", "reviewed"]
+  system_tags: [
+    "imported",
+    "reviewed",
+  ],
+  labels: [
+    "production",
+    "imported",
+    "reviewed",
+  ],
 }
 ```
 
-The <Fn>concatenate</Fn> function returns the same result for two lists, but
-prefer spread in transformation code when you construct the resulting list.
+This also works when a nullable list is transformed before spreading. If
+<Fn>map</Fn> receives `null`, it returns `null`, and the spread contributes no
+elements:
+
+```tql
+from {xs: null}
+ys = [
+  ...xs.map(x => x + 1),
+  0,
+]
+```
+
+```tql
+{
+  xs: null,
+  ys: [
+    0,
+  ],
+}
+```
+
+The <Fn>concatenate</Fn> function returns the same result for two lists,
+including `null` fragments, but prefer spread in transformation code when you
+construct the resulting list.
 
 ## Transform list elements
 

--- a/src/content/docs/guides/transformation/shape-lists.mdx
+++ b/src/content/docs/guides/transformation/shape-lists.mdx
@@ -84,25 +84,19 @@ expression evaluates to `null`, it contributes no elements, so an explicit
 
 ```tql
 from {
-  system_tags: ["imported", "reviewed"],
+  event: {},
 }
 labels = [
   "production",
-  ...custom_tags?,
-  ...system_tags?,
+  ...event.tags?,
 ]
 ```
 
 ```tql
 {
-  system_tags: [
-    "imported",
-    "reviewed",
-  ],
+  event: {},
   labels: [
     "production",
-    "imported",
-    "reviewed",
   ],
 }
 ```

--- a/src/content/docs/guides/transformation/shape-records.mdx
+++ b/src/content/docs/guides/transformation/shape-records.mdx
@@ -103,17 +103,17 @@ expression evaluates to `null`, it contributes no fields, so an explicit
 `else {}` fallback is not necessary:
 
 ```tql
-from {base: {id: 1, name: "Alice"}}
+from {account: {id: 1, name: "Alice"}}
 user = {
-  ...base,
-  ...profile?,
+  ...account,
+  ...account.profile?,
   active: true,
 }
 ```
 
 ```tql
 {
-  base: {
+  account: {
     id: 1,
     name: "Alice",
   },

--- a/src/content/docs/guides/transformation/shape-records.mdx
+++ b/src/content/docs/guides/transformation/shape-records.mdx
@@ -98,30 +98,36 @@ service = {
 }
 ```
 
-Use `else {}` when a record fragment may be missing:
+Use optional access when a record fragment may be missing. If the spread
+expression evaluates to `null`, it contributes no fields, so an explicit
+`else {}` fallback is not necessary:
 
 ```tql
 from {base: {id: 1, name: "Alice"}}
 user = {
   ...base,
-  ...(profile? else {}),
+  ...profile?,
   active: true,
 }
 ```
 
 ```tql
 {
-  base: {id: 1, name: "Alice"},
+  base: {
+    id: 1,
+    name: "Alice",
+  },
   user: {
     id: 1,
     name: "Alice",
-    active: true
-  }
+    active: true,
+  },
 }
 ```
 
-The <Fn>merge</Fn> function returns the same result for two records, but prefer
-spread in transformation code when you construct the resulting record.
+The <Fn>merge</Fn> function returns the same result for two records, including
+`null` fragments, but prefer spread in transformation code when you construct the
+resulting record.
 
 ## Transform record values
 

--- a/src/content/docs/reference/expressions.mdx
+++ b/src/content/docs/reference/expressions.mdx
@@ -424,8 +424,8 @@ Spreading `null` contributes no elements and emits no warning. Spreading any
 other non-list value emits a warning and contributes no elements.
 
 ```tql
-from {base: [1, 2]}
-extended = [...base, ...extra?, 3]
+from {base: [1, 2], extra: null}
+extended = [...base, ...extra, 3]
 ```
 
 ```tql
@@ -434,6 +434,7 @@ extended = [...base, ...extra?, 3]
     1,
     2,
   ],
+  extra: null,
   extended: [
     1,
     2,
@@ -441,6 +442,9 @@ extended = [...base, ...extra?, 3]
   ],
 }
 ```
+
+Use optional access, for example `...extra?`, when the list field might be
+missing.
 
 ### Records
 

--- a/src/content/docs/reference/expressions.mdx
+++ b/src/content/docs/reference/expressions.mdx
@@ -402,8 +402,44 @@ from {
 The spread operator `...` expands lists into other lists:
 
 ```tql
-let $base = [1, 2]
-let $extended = [...$base, 3]  // Results in [1, 2, 3]
+from {base: [1, 2]}
+extended = [...base, 3]
+```
+
+```tql
+{
+  base: [
+    1,
+    2,
+  ],
+  extended: [
+    1,
+    2,
+    3,
+  ],
+}
+```
+
+Spreading `null` contributes no elements and emits no warning. Spreading any
+other non-list value emits a warning and contributes no elements.
+
+```tql
+from {base: [1, 2]}
+extended = [...base, ...extra?, 3]
+```
+
+```tql
+{
+  base: [
+    1,
+    2,
+  ],
+  extended: [
+    1,
+    2,
+    3,
+  ],
+}
 ```
 
 ### Records
@@ -443,6 +479,9 @@ this = {type: type, ...context}
 ```
 
 Fields must be unique, and later values overwrite earlier ones.
+
+Spreading `null` contributes no fields and emits no warning. Spreading any
+other non-record value emits a warning and contributes no fields.
 
 The spread operator `...` expands records:
 

--- a/src/content/docs/reference/expressions.mdx
+++ b/src/content/docs/reference/expressions.mdx
@@ -443,8 +443,8 @@ extended = [...base, ...extra, 3]
 }
 ```
 
-Use optional access, for example `...extra?`, when the list field might be
-missing.
+Use optional access on the access expression, for example `...event.tags?`, when
+the list field might be missing.
 
 ### Records
 

--- a/src/content/docs/reference/expressions.mdx
+++ b/src/content/docs/reference/expressions.mdx
@@ -424,27 +424,26 @@ Spreading `null` contributes no elements and emits no warning. Spreading any
 other non-list value emits a warning and contributes no elements.
 
 ```tql
-from {base: [1, 2], extra: null}
-extended = [...base, ...extra, 3]
+from {xs: [1, 2], ys: null}
+zs = [...xs, ...ys]
 ```
 
 ```tql
 {
-  base: [
+  xs: [
     1,
     2,
   ],
-  extra: null,
-  extended: [
+  ys: null,
+  zs: [
     1,
     2,
-    3,
   ],
 }
 ```
 
-Use optional access on the access expression, for example `...event.tags?`, when
-the list field might be missing.
+Use optional access on the access expression, for example `...x.ys?`, when the
+list field might be missing.
 
 ### Records
 

--- a/src/content/docs/reference/functions/append.mdx
+++ b/src/content/docs/reference/functions/append.mdx
@@ -15,6 +15,9 @@ append(xs:list, x:any) -> list
 The `append` function returns the list `xs` with `x` inserted at the end. The
 expression `xs.append(x)` is equivalent to `[...xs, x]`.
 
+If `xs` is `null`, it is treated like an empty list, so `null.append(x)` returns
+`[x]`.
+
 ## Examples
 
 ### Append a number to a list
@@ -26,6 +29,21 @@ xs = xs.append(3)
 
 ```tql
 {xs: [1, 2, 3]}
+```
+
+### Append to a nullable list
+
+```tql
+from {xs: null}
+xs = xs.append(3)
+```
+
+```tql
+{
+  xs: [
+    3,
+  ],
+}
 ```
 
 ## See Also

--- a/src/content/docs/reference/functions/concatenate.mdx
+++ b/src/content/docs/reference/functions/concatenate.mdx
@@ -16,6 +16,10 @@ The `concatenate` function returns a list containing all elements from the lists
 `xs` and `ys` in order. The expression `concatenate(xs, ys)` is equivalent to
 `[...xs, ...ys]`.
 
+If either argument is `null`, it contributes no elements. For example,
+`concatenate([1], null)` returns `[1]`, and `concatenate(null, [2])` returns
+`[2]`.
+
 ## Examples
 
 ### Concatenate two lists
@@ -30,6 +34,26 @@ zs = concatenate(xs, ys)
   xs: [1, 2],
   ys: [3, 4],
   zs: [1, 2, 3, 4]
+}
+```
+
+### Concatenate nullable lists
+
+```tql
+from {xs: null}
+left = concatenate([1], xs)
+right = concatenate(xs, [2])
+```
+
+```tql
+{
+  xs: null,
+  left: [
+    1,
+  ],
+  right: [
+    2,
+  ],
 }
 ```
 

--- a/src/content/docs/reference/functions/map.mdx
+++ b/src/content/docs/reference/functions/map.mdx
@@ -15,6 +15,9 @@ map(xs:list, capture:field, any->any) -> list
 The `map` function applies an expression to each element within a list,
 returning a list of the same length.
 
+If `xs` is `null`, `map` returns `null` without evaluating the lambda. When you
+spread that result into a list, the `null` contributes no elements.
+
 ### `xs: list`
 
 A list of values.
@@ -95,6 +98,28 @@ l = l.map(str => str.parse_grok($pattern))
   l: [
     null,
     { w: "world", n: 42, },
+  ],
+}
+```
+
+### Map a nullable list before spreading
+
+If the input list is `null`, <Fn>map</Fn> returns `null`, and list spread
+contributes no elements:
+
+```tql
+from {xs: null}
+ys = [
+  ...xs.map(x => x + 1),
+  0,
+]
+```
+
+```tql
+{
+  xs: null,
+  ys: [
+    0,
   ],
 }
 ```

--- a/src/content/docs/reference/functions/map.mdx
+++ b/src/content/docs/reference/functions/map.mdx
@@ -104,8 +104,8 @@ l = l.map(str => str.parse_grok($pattern))
 
 ### Map a nullable list before spreading
 
-If the input field exists but contains `null`, <Fn>map</Fn> returns `null`, and
-list spread contributes no elements:
+If the input list is `null`, <Fn>map</Fn> returns `null`, and list spread
+contributes no elements:
 
 ```tql
 from {xs: null}
@@ -123,8 +123,6 @@ ys = [
   ],
 }
 ```
-
-Use optional access, for example `xs?`, when the input field might be missing.
 
 ### Incompatible types between elements
 

--- a/src/content/docs/reference/functions/map.mdx
+++ b/src/content/docs/reference/functions/map.mdx
@@ -104,8 +104,8 @@ l = l.map(str => str.parse_grok($pattern))
 
 ### Map a nullable list before spreading
 
-If the input list is `null`, <Fn>map</Fn> returns `null`, and list spread
-contributes no elements:
+If the input field exists but contains `null`, <Fn>map</Fn> returns `null`, and
+list spread contributes no elements:
 
 ```tql
 from {xs: null}
@@ -123,6 +123,8 @@ ys = [
   ],
 }
 ```
+
+Use optional access, for example `xs?`, when the input field might be missing.
 
 ### Incompatible types between elements
 

--- a/src/content/docs/reference/functions/merge.mdx
+++ b/src/content/docs/reference/functions/merge.mdx
@@ -16,6 +16,9 @@ The `merge` function takes two records and returns a new record containing all
 fields from both records. If both records contain the same field, the value from
 the second record takes precedence.
 
+The expression `merge(x, y)` has the same field precedence and null handling as
+`{...x, ...y}`.
+
 ## Examples
 
 ### Basic record merging

--- a/src/content/docs/reference/functions/prepend.mdx
+++ b/src/content/docs/reference/functions/prepend.mdx
@@ -15,6 +15,9 @@ prepend(xs:list, x:any) -> list
 The `prepend` function returns the list `xs` with `x` inserted at the front.
 The expression `xs.prepend(y)` is equivalent to `[x, ...xs]`.
 
+If `xs` is `null`, it is treated like an empty list, so `null.prepend(x)`
+returns `[x]`.
+
 ## Examples
 
 ### Prepend a number to a list
@@ -26,6 +29,21 @@ xs = xs.prepend(3)
 
 ```tql
 {xs: [3, 1, 2]}
+```
+
+### Prepend to a nullable list
+
+```tql
+from {xs: null}
+xs = xs.prepend(3)
+```
+
+```tql
+{
+  xs: [
+    3,
+  ],
+}
 ```
 
 ## See Also

--- a/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
+++ b/src/content/docs/tutorials/learn-idiomatic-tql/index.mdx
@@ -145,6 +145,17 @@ from {status: 200, path: "/api"},
      {status: 404, path: "/missing"}  // No comma here
 ```
 
+```tql
+{
+  status: 200,
+  path: "/api",
+}
+{
+  status: 404,
+  path: "/missing",
+}
+```
+
 :::tip[Quick rule]
 Trailing commas are only allowed in contexts with parentheses ('()'), brackets
 ('[]'), or braces ('{}').
@@ -374,6 +385,21 @@ match action {
 }
 ```
 
+```tql
+{
+  action: "allow",
+  verdict: "allowed",
+}
+{
+  action: "deny",
+  verdict: "blocked",
+}
+{
+  action: "reset",
+  verdict: "unknown",
+}
+```
+
 Use guarded arms when the case also depends on another field:
 
 ```tql
@@ -394,6 +420,29 @@ match status {
   _ => {
     action = "ignore"
   }
+}
+```
+
+```tql
+{
+  status: 503,
+  retries: 1,
+  action: "retry",
+}
+{
+  status: 503,
+  retries: 0,
+  action: "page",
+}
+{
+  status: 429,
+  retries: 0,
+  action: "throttle",
+}
+{
+  status: 404,
+  retries: 0,
+  action: "ignore",
 }
 ```
 
@@ -477,12 +526,30 @@ overrides last.
 ❌ Nested function calls hide the target shape:
 
 ```tql
+from {
+  defaults: {host: "localhost", port: 80},
+  overrides: {port: 443},
+  base_tags: ["prod"],
+  extra_tags: ["api"],
+}
+
 service = merge(merge(defaults, overrides), {tls: true})
 tags = concatenate(concatenate(base_tags, ["monitored"]), extra_tags)
 ```
 
-When a fragment may be missing, use `...(record? else {})` for records and
-`...(list? else [])` for lists.
+```tql
+{
+  defaults: {host: "localhost", port: 80},
+  overrides: {port: 443},
+  base_tags: ["prod"],
+  extra_tags: ["api"],
+  service: {host: "localhost", port: 443, tls: true},
+  tags: ["prod", "monitored", "api"]
+}
+```
+
+When a fragment may be missing, use optional access such as `...profile?` or
+`...custom_tags?`.
 
 Keep <Fn>merge</Fn> and <Fn>concatenate</Fn> in mind when you read existing code
 or need an explicit two-argument function. For new transformations, prefer
@@ -555,6 +622,20 @@ replace content.field, what="-", with=null
 drop_null_fields content
 ```
 
+```tql
+{
+  content: {},
+}
+{
+  content: {},
+}
+{
+  content: {
+    field: "value",
+  },
+}
+```
+
 ❌ Complex conditional logic:
 
 ```tql
@@ -565,6 +646,20 @@ if content.has("field") {
   if content.field == "-" or content.field == null {
     drop content.field
   }
+}
+```
+
+```tql
+{
+  content: {},
+}
+{
+  content: {},
+}
+{
+  content: {
+    field: "value",
+  },
 }
 ```
 
@@ -1161,6 +1256,39 @@ match http_status {
   _ => {
     ocsf.status_id = 0  // Unknown
   }
+}
+```
+
+```tql
+{
+  http_status: 200,
+  ocsf: {
+    status_id: 1,
+  },
+}
+{
+  http_status: 302,
+  ocsf: {
+    status_id: 1,
+  },
+}
+{
+  http_status: 404,
+  ocsf: {
+    status_id: 2,
+  },
+}
+{
+  http_status: 503,
+  ocsf: {
+    status_id: 2,
+  },
+}
+{
+  http_status: 100,
+  ocsf: {
+    status_id: 0,
+  },
 }
 ```
 


### PR DESCRIPTION
## 🔍 Problem

- TNZ-692 changes list spread so `null` fragments contribute no elements without warning.
- The docs still recommended explicit `else []` and `else {}` fallbacks for optional spread fragments.
- The function references did not consistently explain how spread-equivalent helpers handle `null`.

## 🛠️ Solution

- Document null spread semantics for lists and records in the expression reference.
- Update transformation guides and the idiomatic TQL tutorial to prefer optional access for missing fragments.
- Align `concatenate`, `append`, `prepend`, `map`, and `merge` reference pages with spread behavior and runnable examples.

## 💬 Review

- Check whether the optional-access wording is clear enough: missing fields still need `?`, while `null` spread fragments are empty contributions.
- The changed runnable examples were executed with the matching `tenzir` build from tenzir/tenzir#6258.

<sub>
🎫 References TNZ-692<br>
📎 Related: tenzir/tenzir#6258
</sub>