### PR TITLE
Harden PR preview cleanup

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yaml
+++ b/.github/workflows/pr-preview-cleanup.yaml
@@ -126,6 +126,7 @@ jobs:
             fi
 
             echo "Remote changed while cleaning up preview; retrying"
+            sleep $((attempt * 2))
           done
 
       - name: Comment on PR

--- a/.github/workflows/pr-preview-cleanup.yaml
+++ b/.github/workflows/pr-preview-cleanup.yaml
@@ -69,24 +69,46 @@ jobs:
         run: |
           set -e
           if ! git clone --depth 1 --branch gh-pages \
-            https://x-access-token:${GH_TOKEN}@github.com/tenzir/docs-previews.git preview-repo; then
+            "https://x-access-token:${GH_TOKEN}@github.com/tenzir/docs-previews.git" preview-repo; then
             echo "Could not clone docs-previews repo, nothing to clean up"
             exit 0
           fi
           cd preview-repo
 
           PREVIEW_DIR="${{ steps.pr.outputs.number }}"
-          if [ -d "$PREVIEW_DIR" ]; then
+          if [ ! -d "$PREVIEW_DIR" ]; then
+            echo "Preview not found: $PREVIEW_DIR"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          for attempt in 1 2 3 4 5; do
+            git fetch origin gh-pages
+            git reset --hard origin/gh-pages
+
+            if [ ! -d "$PREVIEW_DIR" ]; then
+              echo "Preview already removed: $PREVIEW_DIR"
+              exit 0
+            fi
+
             rm -rf "$PREVIEW_DIR"
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
             git add -A
             git commit -m "Remove preview for PR #${{ steps.pr.outputs.number }}"
-            git push
-            echo "Removed preview: $PREVIEW_DIR"
-          else
-            echo "Preview not found: $PREVIEW_DIR"
-          fi
+
+            if git push origin HEAD:gh-pages; then
+              echo "Removed preview: $PREVIEW_DIR"
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 5 ]; then
+              echo "Could not push preview cleanup after $attempt attempts"
+              exit 1
+            fi
+
+            echo "Remote changed while cleaning up preview; retrying"
+          done
 
       - name: Comment on PR
         if: steps.pr.outputs.skip != 'true' && steps.check.outputs.skip != 'true'

--- a/.github/workflows/pr-preview-cleanup.yaml
+++ b/.github/workflows/pr-preview-cleanup.yaml
@@ -6,6 +6,11 @@ on:
   workflow_run:
     workflows: ["Build & Deploy"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number whose preview should be removed"
+        required: true
 
 permissions:
   actions: read
@@ -15,19 +20,31 @@ jobs:
   cleanup:
     name: Clean up PR preview
     runs-on: ubuntu-latest
-    # Run if: PR closed directly, OR build completed for a closed PR
+    # Run if: PR closed directly, cleanup dispatched explicitly, OR build
+    # completed for a closed PR
     if: |
       github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request')
     steps:
       - name: Get PR info
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISPATCH_PR: ${{ inputs.pr }}
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "state=closed" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if ! [[ "$DISPATCH_PR" =~ ^[0-9]+$ ]]; then
+              echo "Invalid PR number: $DISPATCH_PR"
+              exit 1
+            fi
+            PR_NUMBER="$DISPATCH_PR"
           else
             # Extract PR number from workflow_run
             PR_NUMBER=$(echo '${{ toJson(github.event.workflow_run.pull_requests) }}' | jq -r '.[0].number // empty')
@@ -36,11 +53,12 @@ jobs:
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            # Check if PR is closed
-            PR_STATE=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.state')
-            echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-            echo "state=$PR_STATE" >> "$GITHUB_OUTPUT"
           fi
+
+          # Check if PR is closed
+          PR_STATE=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.state')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "state=$PR_STATE" >> "$GITHUB_OUTPUT"
 
       - name: Check if cleanup needed
         id: check

--- a/.github/workflows/pr-preview-deploy.yaml
+++ b/.github/workflows/pr-preview-deploy.yaml
@@ -49,7 +49,20 @@ jobs:
             echo "status_url=https://preview.docs.tenzir.com/$number/__preview.json"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Check PR state
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.preview.outputs.number }}
+        run: |
+          state=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.state')
+          echo "state=$state" >> "$GITHUB_OUTPUT"
+          if [[ "$state" != "open" ]]; then
+            echo "PR #$PR_NUMBER is $state; skipping preview deployment"
+          fi
+
       - name: Generate app token
+        if: steps.pr.outputs.state == 'open'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
@@ -58,6 +71,7 @@ jobs:
           repositories: docs-previews
 
       - name: Comment PR as deploying
+        if: steps.pr.outputs.state == 'open'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.preview.outputs.number }}
@@ -98,6 +112,7 @@ jobs:
             }
 
       - name: Deploy PR Preview
+        if: steps.pr.outputs.state == 'open'
         id: deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:
@@ -110,7 +125,7 @@ jobs:
 
       - name: Wait for preview readiness
         id: readiness
-        if: steps.deploy.conclusion == 'success'
+        if: steps.pr.outputs.state == 'open' && steps.deploy.conclusion == 'success'
         uses: actions/github-script@v7
         env:
           STATUS_URL: ${{ steps.preview.outputs.status_url }}
@@ -159,7 +174,7 @@ jobs:
 
       - name: Check if preview run is still current
         id: current
-        if: always()
+        if: always() && steps.pr.outputs.state == 'open'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.preview.outputs.number }}
@@ -184,7 +199,7 @@ jobs:
             }
 
       - name: Comment PR with preview status
-        if: always() && steps.current.outputs.is_current == 'true'
+        if: always() && steps.pr.outputs.state == 'open' && steps.current.outputs.is_current == 'true'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.preview.outputs.number }}

--- a/.github/workflows/pr-preview-deploy.yaml
+++ b/.github/workflows/pr-preview-deploy.yaml
@@ -42,6 +42,13 @@ jobs:
             echo "Missing preview metadata in dist/__preview.json"
             exit 1
           fi
+          # The artifact comes from an unprivileged pull_request build; reject
+          # malformed values before they reach privileged API calls and the
+          # deploy target folder.
+          if ! [[ "$number" =~ ^[0-9]+$ ]] || ! [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Malformed preview metadata in dist/__preview.json"
+            exit 1
+          fi
           {
             echo "number=$number"
             echo "sha=$sha"

--- a/.github/workflows/pr-preview-deploy.yaml
+++ b/.github/workflows/pr-preview-deploy.yaml
@@ -7,7 +7,7 @@ on:
       - completed
 
 permissions:
-  actions: read # needed for downloading artifacts from triggering workflow
+  actions: write # needed for downloading artifacts and dispatching cleanup
   pull-requests: write # needed for commenting on PRs
 
 jobs:
@@ -196,14 +196,32 @@ jobs:
               pull_number: prNumber,
             });
             const currentSha = pr.head.sha;
-            const isCurrent = currentSha === expectedSha;
+            const isCurrent = currentSha === expectedSha && pr.state === 'open';
 
             core.setOutput('is_current', isCurrent ? 'true' : 'false');
-            if (!isCurrent) {
+            core.setOutput('pr_state', pr.state);
+            if (pr.state !== 'open') {
+              core.notice(
+                `PR #${prNumber} is ${pr.state}; skipping final preview status update.`
+              );
+            } else if (!isCurrent) {
               core.notice(
                 `Skipping final preview status update for superseded build ${expectedSha.slice(0, 7)}; PR head is ${currentSha.slice(0, 7)}.`
               );
             }
+
+      - name: Trigger cleanup for PR closed during deployment
+        if: >-
+          always() &&
+          steps.pr.outputs.state == 'open' &&
+          steps.deploy.conclusion == 'success' &&
+          steps.current.outputs.pr_state == 'closed'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.preview.outputs.number }}
+        run: |
+          echo "PR #$PR_NUMBER closed during deployment; dispatching preview cleanup"
+          gh workflow run pr-preview-cleanup.yaml --ref main -f pr="$PR_NUMBER"
 
       - name: Comment PR with preview status
         if: always() && steps.pr.outputs.state == 'open' && steps.current.outputs.is_current == 'true'


### PR DESCRIPTION
## 🔍 Problem

- The preview cleanup workflow can fail when another workflow pushes to `tenzir/docs-previews:gh-pages` between clone and push.
- Late successful PR build artifacts can deploy previews after the source PR has already closed, recreating stale preview directories.
- The privileged deploy workflow trusts the `__preview.json` metadata produced by the unprivileged PR build.

## 🛠️ Solution

- Re-check PR state before deploying previews and skip deployment unless the PR is still open.
- Re-check PR state again after the deploy and dispatch the cleanup workflow (new `workflow_dispatch` trigger) when the PR closed mid-deploy, so no stale preview survives the race.
- Make cleanup retry against the latest `gh-pages` state when concurrent writes move the remote branch.
- Validate that the artifact's PR number and commit hash are well-formed before they reach privileged API calls and the deploy target folder.
- Quote the preview-repo clone URL so shell validation passes cleanly.

## 💬 Review

- Validation: `actionlint .github/workflows/pr-preview-cleanup.yaml .github/workflows/pr-preview-deploy.yaml`.
- Review the retry behavior around concurrent `docs-previews` writes.
- Review the post-deploy state re-check and cleanup dispatch path.
