### PR TITLE
Document drop_null_fields function

### DIFF
--- a/src/content/docs/reference/functions.mdx
+++ b/src/content/docs/reference/functions.mdx
@@ -551,6 +551,10 @@ functions:
     description: 'Removes top-level fields from a record when their names match a regular expression.'
     example: 'record.drop_matching("^debug_")'
     path: 'reference/functions/drop_matching'
+  - name: 'drop_null_fields'
+    description: 'Removes fields whose value is null from a record.'
+    example: 'drop_null_fields({a: null, b: 1})'
+    path: 'reference/functions/drop_null_fields'
   - name: 'get'
     description: 'Gets a field from a record or an element from a list'
     example: 'xs.get(index, fallback)'
@@ -1719,6 +1723,14 @@ record.print_yaml()
 
 ```tql
 record.drop_matching("^debug_")
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="drop_null_fields" description="Removes fields whose value is null from a record." href="/reference/functions/drop_null_fields">
+
+```tql
+drop_null_fields({a: null, b: 1})
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/functions/drop_null_fields.mdx
+++ b/src/content/docs/reference/functions/drop_null_fields.mdx
@@ -12,20 +12,22 @@ drop_null_fields(x:record, field:field...) -> record
 
 ## Description
 
-The `drop_null_fields` function mirrors the <Op>drop_null_fields</Op> operator,
-but operates on a record expression rather than a top-level event. It is useful
-for building API request bodies inline, for example as the `body=` argument to
-<Op>from_http</Op>, where optional fields default to `null` and must be omitted
-rather than sent as JSON `null`.
-
-Without explicit field selectors, every field of `x` is considered, including
-nested fields inside records. With selectors, only the named fields (and any
-fields nested within them) are considered for removal; other null fields are
-preserved.
+The `drop_null_fields` function returns a copy of `x` with every field whose
+value is `null` removed. Without explicit selectors, every field is considered,
+including fields nested inside record-typed values. With selectors, only the
+named fields (and any fields nested within them) are considered for removal;
+other null fields are preserved.
 
 Unlike `print_ndjson(strip_null_fields=true)`, the function never serializes
-the record, so `secret`-typed values flow through unchanged and reach the
-sink unredacted.
+the record, so `secret`-typed values flow through unchanged and reach the sink
+unredacted.
+
+:::tip[Operator equivalent]
+The function mirrors the <Op>drop_null_fields</Op> operator, but operates on a
+record expression rather than the top-level event. Use the function when you
+need to clean fields inline — for example as the `body=` argument to
+<Op>from_http</Op>.
+:::
 
 ### `x: record`
 
@@ -42,37 +44,36 @@ every field is considered.
 
 ```tql
 from {
-  license: secret("alphamountain_license"),
-  version: 1,
-  mapping: null,
+  id: 42,
+  status: "active",
+  comment: null,
 }
 this = drop_null_fields(this)
 ```
 
 ```tql
 {
-  license: "***",
-  version: 1,
+  id: 42,
+  status: "active",
 }
 ```
 
 ### Build an HTTP request body inline
 
-This is the canonical use case: cleaning optional `null` fields out of a body
-record while preserving a `secret`-typed license field.
+A common use case is cleaning optional `null` fields out of an inline body
+record before sending it to an API that rejects JSON `null` values:
 
 ```tql
 from_http "https://api.example.com/v1/lookup",
   method="POST",
   body=drop_null_fields({
-    license: secret("alphamountain_license"),
     version: 1,
-    mapping: null,
+    query: "example",
+    options: null,
   })
 ```
 
-The wire body sent to the API contains only `license` and `version`; `mapping`
-is omitted, and `license` retains its secret value.
+The wire body contains only `version` and `query`; `options` is omitted.
 
 ### Restrict the drop to specific fields
 

--- a/src/content/docs/reference/functions/drop_null_fields.mdx
+++ b/src/content/docs/reference/functions/drop_null_fields.mdx
@@ -1,0 +1,131 @@
+---
+title: drop_null_fields
+category: Record
+example: "drop_null_fields({a: null, b: 1})"
+---
+
+Returns a record with fields whose value is `null` removed.
+
+```tql
+drop_null_fields(x:record, field:field...) -> record
+```
+
+## Description
+
+The `drop_null_fields` function mirrors the <Op>drop_null_fields</Op> operator,
+but operates on a record expression rather than a top-level event. It is useful
+for building API request bodies inline, for example as the `body=` argument to
+<Op>from_http</Op>, where optional fields default to `null` and must be omitted
+rather than sent as JSON `null`.
+
+Without explicit field selectors, every field of `x` is considered, including
+nested fields inside records. With selectors, only the named fields (and any
+fields nested within them) are considered for removal; other null fields are
+preserved.
+
+Unlike `print_ndjson(strip_null_fields=true)`, the function never serializes
+the record, so `secret`-typed values flow through unchanged and reach the
+sink unredacted.
+
+### `x: record`
+
+The record from which to remove null fields.
+
+### `field: field... (optional)`
+
+A comma-separated list of field paths inside `x` to consider. When omitted,
+every field is considered.
+
+## Examples
+
+### Drop all null fields
+
+```tql
+from {
+  license: secret("alphamountain_license"),
+  version: 1,
+  mapping: null,
+}
+this = drop_null_fields(this)
+```
+
+```tql
+{
+  license: "***",
+  version: 1,
+}
+```
+
+### Build an HTTP request body inline
+
+This is the canonical use case: cleaning optional `null` fields out of a body
+record while preserving a `secret`-typed license field.
+
+```tql
+from_http "https://api.example.com/v1/lookup",
+  method="POST",
+  body=drop_null_fields({
+    license: secret("alphamountain_license"),
+    version: 1,
+    mapping: null,
+  })
+```
+
+The wire body sent to the API contains only `license` and `version`; `mapping`
+is omitted, and `license` retains its secret value.
+
+### Restrict the drop to specific fields
+
+```tql
+from {
+  a: null,
+  b: null,
+  c: null,
+  d: 1,
+}
+this = drop_null_fields(this, a, c)
+```
+
+```tql
+{
+  b: null,
+  d: 1,
+}
+```
+
+`b` stays in the result because it was not named in the selector list, even
+though it is `null`.
+
+### Recursive drop inside nested records
+
+```tql
+from {
+  metadata: {
+    created: "2024-01-01",
+    updated: null,
+  },
+  data: {
+    value: 42,
+    comment: null,
+  },
+}
+this = drop_null_fields(this)
+```
+
+```tql
+{
+  metadata: {
+    created: "2024-01-01",
+  },
+  data: {
+    value: 42,
+  },
+}
+```
+
+## See Also
+
+- <Op>drop_null_fields</Op>
+- <Fn>drop_matching</Fn>
+- <Fn>select_matching</Fn>
+- <Fn>has</Fn>

--- a/src/content/docs/reference/operators/drop_null_fields.mdx
+++ b/src/content/docs/reference/operators/drop_null_fields.mdx
@@ -166,6 +166,7 @@ In this example:
 
 ## See Also
 
+- <Fn>drop_null_fields</Fn>
 - <Op>drop</Op>
 - <Op>select</Op>
 - <Op>where</Op>


### PR DESCRIPTION
## 🔍 Problem

The new `drop_null_fields` function (companion code PR) introduces
user-facing TQL surface that needs a reference page on docs.tenzir.com.

## 🛠️ Solution

- New page under the Record category at `reference/functions/drop_null_fields`,
  mirroring the existing operator. Examples cover the canonical
  `from_http body=drop_null_fields({...})` use case and the
  secret-preservation contrast against `print_ndjson(strip_null_fields=true)`.
- Function index page (`reference/functions.mdx`) gets a frontmatter entry
  and a `<ReferenceCard>` in the Record section, alphabetically between
  `drop_matching` and `get`.
- Operator page gains a `<Fn>drop_null_fields</Fn>` cross-link in See Also.

## 💬 Review

- The function page leads with the secret-preservation contrast, which is
  the primary motivation. Worth confirming that framing reads cleanly.
- `bun run build` succeeds; `bun run lint:files` on the three changed
  paths passes.

<sub>
⚙️ Code PR: tenzir/tenzir#6261
</sub>