### PR TITLE
Document Kafka regex input topics

### DIFF
--- a/src/content/docs/reference/operators/from_kafka.mdx
+++ b/src/content/docs/reference/operators/from_kafka.mdx
@@ -46,6 +46,10 @@ Each consumed message is produced as an event with the following schema:
 
 The Kafka topic to consume from.
 
+If the topic starts with `^`, `from_kafka` treats it as a regular expression
+and subscribes to all matching topics. The regular expression must match the
+complete topic name, so use patterns like `^tenant-.*\.alerts$`.
+
 ### `count = int (optional)`
 
 Exit successfully after having consumed `count` messages.
@@ -53,6 +57,7 @@ Exit successfully after having consumed `count` messages.
 ### `exit = bool (optional)`
 
 Exit successfully after having received the last message from all partitions.
+This option isn't supported with regular expression topic subscriptions.
 
 Without this option, the operator waits for new messages after consuming the
 last one.
@@ -128,6 +133,12 @@ from_kafka "events", count=100, offset="beginning"
 
 ```tql
 from_kafka "alerts", exit=true
+```
+
+### Consume from topics that match a regular expression
+
+```tql
+from_kafka "^tenant-.*\\.alerts$", offset="beginning"
 ```
 
 ## See Also

--- a/src/content/docs/reference/operators/to_kafka.mdx
+++ b/src/content/docs/reference/operators/to_kafka.mdx
@@ -33,7 +33,8 @@ include them:
 
 ### `topic: string`
 
-The Kafka topic to send messages to.
+The exact Kafka topic to send messages to. Regular expressions aren't
+supported for producers.
 
 ### `message = blob|string (optional)`
 


### PR DESCRIPTION
## 🔍 Problem

- The Kafka operator docs don't describe the new regex topic behavior for `from_kafka`.
- The producer-side docs should make clear that `to_kafka` still targets an exact topic.

## 🛠️ Solution

- Document that `from_kafka` treats topic strings starting with `^` as regular expression subscriptions.
- Document that `exit=true` isn't supported with regex topic subscriptions.
- Clarify that `to_kafka` doesn't support regular expression topics.

## 💬 Review

- Check that the wording distinguishes native regex subscription from exact-topic publishing.

<sub>
⚙️ Code PR: tenzir/tenzir#6262
</sub>
