### PR TITLE
Clarify when to write Sigma detections directly in TQL

### DIFF
--- a/src/content/docs/guides/enrichment/execute-sigma-rules.mdx
+++ b/src/content/docs/guides/enrichment/execute-sigma-rules.mdx
@@ -245,6 +245,12 @@ still inspect `System` and `EventData` after a match.
 
 ## Transpile a process rule to OCSF TQL
 
+You can also implement a Sigma detection in TQL directly, without going
+through the <Op>sigma</Op> operator. This keeps your events in their canonical
+shape — useful when you've normalized to a schema such as OCSF and don't want
+to rename fields back to Sigma's Windows-style selectors only to satisfy a
+rule.
+
 A recent upstream Sigma process-creation rule,
 `proc_creation_win_print_dump_sensitive_files.yml` (`Sensitive File Dump Via
 Print.EXE`, April 28, 2026), detects `print.exe` abuse for copying sensitive


### PR DESCRIPTION
## 🔍 Problem

The "Transpile a process rule to OCSF TQL" section in `execute-sigma-rules.mdx` jumped straight into a rule rewrite without telling the reader why this approach exists. After reading the prior section on field renaming, a reader had no signal for what this third option is actually for.

## 🛠️ Solution

- Add a short intro paragraph under the section heading that:
  - Positions native TQL as a positive capability ("you can also implement a Sigma detection in TQL directly"), not a fallback.
  - Names the trade-off versus the previous section: keep events in their canonical OCSF shape, rather than renaming fields back to Sigma's Windows-style selectors.

## 💬 Review

Single-paragraph docs change. The example code, comments, and surrounding sections are unchanged.