### PR TITLE
Document nested UDO field arguments

### DIFF
--- a/src/content/docs/guides/packages/add-operators.mdx
+++ b/src/content/docs/guides/packages/add-operators.mdx
@@ -224,6 +224,44 @@ acme::double_value count
 {count: 10, score: 10}
 ```
 
+To update a child field of the selected target, access it like any other field.
+Use dot syntax for ordinary field names, string-literal bracket syntax for names
+with punctuation, or an index expression that resolves to a field name:
+
+```tql title="operators/tag_nested.tql"
+---
+args:
+  positional:
+    - name: target
+      type: field
+    - name: name
+      type: string
+    - name: value
+      type: string
+---
+
+$target.status = $value
+$target["mapped-status"] = $value
+$target[$name] = $value
+```
+
+Using the operator:
+
+```tql
+from {event: {}}
+acme::tag_nested event, "dynamic-status", "ok"
+```
+
+```tql
+{
+  event: {
+    status: "ok",
+    "mapped-status": "ok",
+    "dynamic-status": "ok",
+  },
+}
+```
+
 ### Detect whether an argument was provided
 
 Any typed parameter supports `default: null`, making it optional without


### PR DESCRIPTION
## Summary

- Document that package UDO `field` parameters can be roots of nested assignment targets.
- Show dotted access, string-literal bracket access, and parameterized index expressions in the `add-operators` guide.

<sub>
⚙️ Code PR: tenzir/tenzir#6264
</sub>
