### PR TITLE
Document cumulative RC promotion in ship framework

### DIFF
--- a/src/content/docs/guides/packages/maintain-a-changelog.mdx
+++ b/src/content/docs/guides/packages/maintain-a-changelog.mdx
@@ -317,6 +317,10 @@ The RC workflow has three outcomes only:
 - Run `release create <new-version>` or a manual bump flag to leave the RC
   cycle and ship a different stable release instead.
 
+Promotion is cumulative: entries added to `unreleased/` after the last
+candidate snapshot are folded into the stable release and consumed from the
+queue, just as a follow-up candidate would include them.
+
 Promoting to stable closes the RC cycle and removes that cycle's
 `vX.Y.Z-rc.N` manifests from `releases/`. An explicit version matching the
 active RC base is rejected, and manual bump flags never promote the active RC.

--- a/src/content/docs/reference/ship-framework/index.mdx
+++ b/src/content/docs/reference/ship-framework/index.mdx
@@ -401,6 +401,9 @@ tenzir-ship release create --yes
 ```
 
 If an outstanding RC exists, this promotes the latest candidate automatically.
+Promotion is cumulative: entries added to `unreleased/` after the last
+candidate snapshot are folded into the stable release and consumed from the
+queue, just as a follow-up candidate would include them.
 
 #### After an RC exists
 


### PR DESCRIPTION
## 🔍 Problem

`tenzir-ship` now folds changelog entries added to `unreleased/` after the last release-candidate snapshot into the promoted stable release (tenzir/ship#28). The promotion sections in the changelog guide and the ship framework reference don't mention this.

## 🛠️ Solution

State the cumulative promotion behavior in both promotion sections: entries added after the last candidate snapshot are folded into the stable release and consumed from the queue, just as a follow-up candidate would include them.

<sub>
⚙️ Code PR: tenzir/ship#28<br>
🎫 References TNZ-702
</sub>