### PR TITLE
List available agent skills

### DIFF
--- a/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
+++ b/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
@@ -23,35 +23,45 @@ Tenzir publishes the following skills:
 
 ### 🧬 Schemas
 
-| Skill         | Description                                                                                |
-| ------------- | ------------------------------------------------------------------------------------------ |
-| `tenzir-asim` | Microsoft Sentinel ASIM schema and mapping guidance for schemas, fields, aliases, and roles |
-| `tenzir-cef`  | ArcSight CEF reference for headers, the extension dictionary, the ESM event schema, and timestamps |
-| `tenzir-cim`  | Splunk CIM data models, datasets, fields, tags, constraints, lookups, and mapping guidance  |
-| `tenzir-ecs`  | ECS fields, fieldsets, categorization values, custom fields, and OpenTelemetry alignment    |
-| `tenzir-edm`  | FortiSIEM Event Data Model reference for data models, event attributes, types, and names    |
-| `tenzir-leef` | IBM QRadar LEEF reference for headers, delimiters, predefined event attributes, and timestamps |
-| `tenzir-ocsf` | OCSF schema reference for event classes, objects, attributes, profiles, and extensions      |
-| `tenzir-udm`  | Google SecOps UDM schema and normalization guidance for fields, event types, and entities   |
+- `tenzir-asim`: Microsoft Sentinel ASIM schema and mapping guidance for
+  schemas, fields, aliases, and roles.
+- `tenzir-cef`: ArcSight CEF reference for headers, the extension dictionary,
+  the ESM event schema, and timestamps.
+- `tenzir-cim`: Splunk CIM data models, datasets, fields, tags, constraints,
+  lookups, and mapping guidance.
+- `tenzir-ecs`: ECS fields, fieldsets, categorization values, custom fields,
+  and OpenTelemetry alignment.
+- `tenzir-edm`: FortiSIEM Event Data Model reference for data models, event
+  attributes, types, and names.
+- `tenzir-leef`: IBM QRadar LEEF reference for headers, delimiters, predefined
+  event attributes, and timestamps.
+- `tenzir-ocsf`: OCSF schema reference for event classes, objects, attributes,
+  profiles, and extensions.
+- `tenzir-udm`: Google SecOps UDM schema and normalization guidance for fields,
+  event types, and entities.
 
 ### 🛡️ Tenzir Users
 
-| Skill                    | Description                                                                                 |
-| ------------------------ | ------------------------------------------------------------------------------------------- |
-| `tenzir-docs`            | Tenzir documentation for TQL, operators, functions, integrations, and deployment             |
-| `tenzir-manage-packages` | Package lifecycle routing for manifests, operators, pipelines, tests, and schema mappings   |
+- `tenzir-docs`: Tenzir documentation for TQL, operators, functions,
+  integrations, and deployment.
+- `tenzir-manage-packages`: Package lifecycle routing for manifests, operators,
+  pipelines, tests, and schema mappings.
 
 ### 🏗️ Tenzir Contributors
 
-| Skill                         | Description                                                              |
-| ----------------------------- | ------------------------------------------------------------------------ |
-| `tenzir-commit-changes`       | Stage, split, and commit changes with clean messages                     |
-| `tenzir-create-pull-requests` | Open pull requests, add changelog entries, and link documentation PRs    |
-| `tenzir-review-changes`       | Review code with severity ratings and structured findings                |
-| `tenzir-design-system`        | Use frontend design tokens, components, and brand assets                 |
-| `tenzir-ship`                 | Write changelog entries, release notes, and GitHub releases              |
-| `tenzir-update-docs`          | Coordinate docs.tenzir.com updates alongside code changes                |
-| `tenzir-technical-writing`    | Write documentation in Tenzir's technical writing style                  |
+- `tenzir-commit-changes`: Stage, split, and commit changes with clean
+  messages.
+- `tenzir-create-pull-requests`: Open pull requests, add changelog entries, and
+  link documentation PRs.
+- `tenzir-review-changes`: Review code with severity ratings and structured
+  findings.
+- `tenzir-design-system`: Use frontend design tokens, components, and brand
+  assets.
+- `tenzir-ship`: Write changelog entries, release notes, and GitHub releases.
+- `tenzir-update-docs`: Coordinate docs.tenzir.com updates alongside code
+  changes.
+- `tenzir-technical-writing`: Write documentation in Tenzir's technical writing
+  style.
 
 ## Install skills
 


### PR DESCRIPTION
## 🔍 Problem

- The available agent skills overview uses tables for simple name-and-description content.
- The table layout is heavier than needed for scanning grouped skill categories.

## 🛠️ Solution

- Convert the grouped skill tables into bullet lists.
- Keep the existing skill names, descriptions, and category structure.

## 💬 Review

- Focus on whether the list formatting reads better in the guide and preserves the intended descriptions.