### PR TITLE
Document selector defaults for UDO field parameters

### DIFF
--- a/src/content/docs/guides/packages/add-operators.mdx
+++ b/src/content/docs/guides/packages/add-operators.mdx
@@ -63,7 +63,7 @@ definition syntax:
 
 | Type       | Description                                                           |
 | ---------- | --------------------------------------------------------------------- |
-| `field`    | A field selector (for example, `name`). Cannot have non-null defaults |
+| `field`    | A field selector (for example, `name`). Defaults must be `null` or a selector |
 | `string`   | A string literal or expression                                        |
 | `int`      | A signed integer value                                                |
 | `uint`     | An unsigned integer value                                             |
@@ -262,14 +262,60 @@ acme::tag_nested event, "dynamic-status", "ok"
 }
 ```
 
+### Default to a selector
+
+Field parameters accept a selector as default value, such as `this`,
+`this.name`, or `foo.bar`. This makes it easy to write operators that work on
+the entire event by default but can be scoped to a specific field on demand:
+
+```tql title="operators/wrap.tql"
+---
+args:
+  named:
+    - name: field
+      type: field
+      default: this
+---
+
+this = {wrapped: $field}
+```
+
+Calling the operator without arguments wraps the whole event:
+
+```tql
+from {name: "Alice"}
+acme::wrap
+```
+
+```tql
+{
+  wrapped: {
+    name: "Alice",
+  },
+}
+```
+
+Passing an explicit selector wraps just that field:
+
+```tql
+from {name: "Alice"}
+acme::wrap field=name
+```
+
+```tql
+{
+  wrapped: "Alice",
+}
+```
+
 ### Detect whether an argument was provided
 
 Any typed parameter supports `default: null`, making it optional without
 requiring a concrete fallback value. Inside the operator body, compare the
 parameter against `null` to check whether the caller provided it.
 
-This is especially useful for `field` parameters, which cannot have non-null
-defaults because a field selector is not a constant value:
+This is especially useful for `field` parameters whose behavior should change
+entirely depending on whether the caller selected a field:
 
 ```tql title="operators/redact.tql"
 ---


### PR DESCRIPTION
## 🔍 Problem

The package operator guide states that `field` parameters cannot have non-null defaults, which is no longer true.

## 🛠️ Solution

- Add a "Default to a selector" section showing a `default: this` operator that works on the whole event by default and can be scoped via `field=name`.
- Update the type table and the `default: null` section accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>
⚙️ Code PR: tenzir/tenzir#6352
</sub>