### PR TITLE
Document event-scoped package mappers

### DIFF
--- a/public/packages/zeek/operators/ocsf/base.tql
+++ b/public/packages/zeek/operators/ocsf/base.tql
@@ -1,8 +1,16 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
+
 @name = "ocsf.base_event"
 
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.activity_id = 0
-ocsf.type_uid = 0
-ocsf.severity_id = 0
-ocsf.time = now()
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.type_uid = 0
+$event.ocsf.severity_id = 0
+$event.ocsf.time = now()

--- a/public/packages/zeek/operators/ocsf/events/conn.tql
+++ b/public/packages/zeek/operators/ocsf/events/conn.tql
@@ -1,29 +1,37 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
+
 // --- OCSF: classification attributes ----------
 
 @name = "ocsf.network_activity"
-ocsf.activity_id = 6
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 6
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: occurrence attributes --------------
 
-ocsf.time = move zeek.ts
-if zeek.duration != null {
-  ocsf.end_time = ocsf.time + zeek.duration
-  ocsf.duration = count_milliseconds(move zeek.duration).round()
+$event.ocsf.time = move $event.zeek.ts
+if $event.zeek.duration != null {
+  $event.ocsf.end_time = $event.ocsf.time + $event.zeek.duration
+  $event.ocsf.duration = count_milliseconds(move $event.zeek.duration).round()
 } else {
-  drop zeek.duration
+  drop $event.zeek.duration
 }
-ocsf.start_time = ocsf.time
+$event.ocsf.start_time = $event.ocsf.time
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "conn.log"
-ocsf.metadata.logged_time = move zeek._write_ts?
-ocsf.metadata.original_event_uid = move zeek.uid
-drop zeek._path?
-ocsf.app_protocol_name = move zeek.service
+$event.ocsf.metadata.log_name = "conn.log"
+$event.ocsf.metadata.logged_time = move $event.zeek._write_ts?
+$event.ocsf.metadata.original_event_uid = move $event.zeek.uid
+drop $event.zeek._path?
+$event.ocsf.app_protocol_name = move $event.zeek.service
 
 // --- OCSF: primary attributes -----------------
 
@@ -34,82 +42,82 @@ let $proto_nums = {
   icmpv6: 58,
   ipv6: 41,
 }
-ocsf.src_endpoint = {
-  ip: move zeek.id.orig_h,
-  port: move zeek.id.orig_p,
+$event.ocsf.src_endpoint = {
+  ip: move $event.zeek.id.orig_h,
+  port: move $event.zeek.id.orig_p,
 }
-ocsf.dst_endpoint = {
-  ip: move zeek.id.resp_h,
-  port: move zeek.id.resp_p,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.zeek.id.resp_h,
+  port: move $event.zeek.id.resp_p,
 }
-ocsf.is_src_dst_assignment_known = true
-ocsf.src_endpoint.mac = move zeek.orig_l2_addr?
-ocsf.dst_endpoint.mac = move zeek.resp_l2_addr?
-if zeek.geo.orig? != null {
-  ocsf.src_endpoint.location = {
-    country: move zeek.geo.orig.country_code?,
-    region: move zeek.geo.orig.region?,
-    city: move zeek.geo.orig.city?,
-    lat: move zeek.geo.orig.latitude?,
-    long: move zeek.geo.orig.longitude?,
+$event.ocsf.is_src_dst_assignment_known = true
+$event.ocsf.src_endpoint.mac = move $event.zeek.orig_l2_addr?
+$event.ocsf.dst_endpoint.mac = move $event.zeek.resp_l2_addr?
+if $event.zeek.geo.orig? != null {
+  $event.ocsf.src_endpoint.location = {
+    country: move $event.zeek.geo.orig.country_code?,
+    region: move $event.zeek.geo.orig.region?,
+    city: move $event.zeek.geo.orig.city?,
+    lat: move $event.zeek.geo.orig.latitude?,
+    long: move $event.zeek.geo.orig.longitude?,
   }
 }
-if zeek.geo.resp? != null {
-  ocsf.dst_endpoint.location = {
-    country: move zeek.geo.resp.country_code?,
-    region: move zeek.geo.resp.region?,
-    city: move zeek.geo.resp.city?,
-    lat: move zeek.geo.resp.latitude?,
-    long: move zeek.geo.resp.longitude?,
+if $event.zeek.geo.resp? != null {
+  $event.ocsf.dst_endpoint.location = {
+    country: move $event.zeek.geo.resp.country_code?,
+    region: move $event.zeek.geo.resp.region?,
+    city: move $event.zeek.geo.resp.city?,
+    lat: move $event.zeek.geo.resp.latitude?,
+    long: move $event.zeek.geo.resp.longitude?,
   }
 }
-drop zeek.geo?
-ocsf.connection_info = {
-  community_uid: move zeek.community_id?,
-  flag_history: move zeek.history,
-  protocol_name: move zeek.proto,
+drop $event.zeek.geo?
+$event.ocsf.connection_info = {
+  community_uid: move $event.zeek.community_id?,
+  flag_history: move $event.zeek.history,
+  protocol_name: move $event.zeek.proto,
 }
-ocsf.connection_info.protocol_num = $proto_nums[ocsf.connection_info.protocol_name]? else -1
-if ocsf.src_endpoint.ip.is_v6() or ocsf.dst_endpoint.ip.is_v6() {
-  ocsf.connection_info.protocol_ver_id = 6
+$event.ocsf.connection_info.protocol_num = $proto_nums[$event.ocsf.connection_info.protocol_name]? else -1
+if $event.ocsf.src_endpoint.ip.is_v6() or $event.ocsf.dst_endpoint.ip.is_v6() {
+  $event.ocsf.connection_info.protocol_ver_id = 6
 } else {
-  ocsf.connection_info.protocol_ver_id = 4
+  $event.ocsf.connection_info.protocol_ver_id = 4
 }
-drop zeek.id
-match ({orig: zeek.local_orig, resp: zeek.local_resp}) {
+drop $event.zeek.id
+match ({orig: $event.zeek.local_orig, resp: $event.zeek.local_resp}) {
   {orig: true, resp: true} => {
-    ocsf.connection_info.direction_id = 3
+    $event.ocsf.connection_info.direction_id = 3
   }
   {orig: true, resp: false} => {
-    ocsf.connection_info.direction_id = 2
+    $event.ocsf.connection_info.direction_id = 2
   }
   {orig: false, resp: true} => {
-    ocsf.connection_info.direction_id = 1
+    $event.ocsf.connection_info.direction_id = 1
   }
   _ => {
-    ocsf.connection_info.direction_id = 0
+    $event.ocsf.connection_info.direction_id = 0
   }
 }
-drop zeek.local_orig, zeek.local_resp
-ocsf.status_code = move zeek.conn_state
-ocsf.status_id = 99
-ocsf.traffic = {
-  bytes_in: move zeek.resp_bytes,
-  bytes_out: move zeek.orig_bytes,
-  bytes_missed: move zeek.missed_bytes,
-  packets_in: move zeek.resp_pkts,
-  packets_out: move zeek.orig_pkts,
+drop $event.zeek.local_orig, $event.zeek.local_resp
+$event.ocsf.status_code = move $event.zeek.conn_state
+$event.ocsf.status_id = 99
+$event.ocsf.traffic = {
+  bytes_in: move $event.zeek.resp_bytes,
+  bytes_out: move $event.zeek.orig_bytes,
+  bytes_missed: move $event.zeek.missed_bytes,
+  packets_in: move $event.zeek.resp_pkts,
+  packets_out: move $event.zeek.orig_pkts,
 }
-if ocsf.traffic.bytes_out? != null and ocsf.traffic.bytes_in? != null {
-  ocsf.traffic.bytes = ocsf.traffic.bytes_out + ocsf.traffic.bytes_in
+if $event.ocsf.traffic.bytes_out? != null and $event.ocsf.traffic.bytes_in? != null {
+  $event.ocsf.traffic.bytes = $event.ocsf.traffic.bytes_out + $event.ocsf.traffic.bytes_in
 }
-ocsf.traffic.packets = ocsf.traffic.packets_out + ocsf.traffic.packets_in
-if zeek.tunnel_parents? == null {
-  drop zeek.tunnel_parents?
+$event.ocsf.traffic.packets = $event.ocsf.traffic.packets_out + $event.ocsf.traffic.packets_in
+if $event.zeek.tunnel_parents? == null {
+  drop $event.zeek.tunnel_parents?
 }
-if zeek.vlan? == null {
-  drop zeek.vlan?
+if $event.zeek.vlan? == null {
+  drop $event.zeek.vlan?
 }
-if zeek.inner_vlan? == null {
-  drop zeek.inner_vlan?
+if $event.zeek.inner_vlan? == null {
+  drop $event.zeek.inner_vlan?
 }

--- a/public/packages/zeek/operators/ocsf/map.tql
+++ b/public/packages/zeek/operators/ocsf/map.tql
@@ -1,8 +1,17 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
+---
+
 // Keep the parsed source event around while event-specific operators move
 // fields into their OCSF homes.
-this = { zeek: this }
+$event = {...$event, zeek: $event, ocsf: {}}
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   product: {
     name: "Zeek",
     vendor_name: "Zeek",
@@ -11,22 +20,26 @@ ocsf.metadata = {
   version: "1.8.0",
 }
 
-ocsf.severity_id = 1
+$event.ocsf.severity_id = 1
 
 // Dispatch mappings based on schema name. This assumes that you've parsed the
 // input logs and added the appropriate @name based on the log type. The
 // read_zeek_tsv operator does this automatically. You could also dispatch based
 // on any other stable discriminator, such as _path or event_type.
-match @name {
+match $event.zeek._path? else @name {
+  "conn" => {
+    // Map "conn.log" events
+    zeek::ocsf::events::conn event=$event
+  }
   "zeek.conn" => {
     // Map "conn.log" events
-    zeek::ocsf::events::conn
+    zeek::ocsf::events::conn event=$event
   }
   _ => {
     // Base Event: unknown or unsupported Zeek log type
-    zeek::ocsf::base
+    zeek::ocsf::base event=$event
   }
 }
 
 // Return the mapped OCSF event from the operator.
-this = {...ocsf, unmapped: zeek}
+$event = {...$event.ocsf, unmapped: $event.zeek}

--- a/src/content/docs/guides/normalization/index.mdx
+++ b/src/content/docs/guides/normalization/index.mdx
@@ -42,17 +42,22 @@ A typical normalization pipeline follows this structure:
 // 1. Collect raw data
 from_kafka "raw-events"
 
-// 2. Parse into structured events
-this = message.parse_json()
+// 2. Parse into a structured event
+event = message.parse_json()
 
 // 3. Clean up values
-replace what="N/A", with=null
-replace what="-", with=null
+replace event, what="N/A", with=null
+replace event, what="-", with=null
 
 // 4. Map to target schema
-my_source::ocsf::map
+my_source::ocsf::map event=event
 
-// 5. Output normalized events
+// 5. Preserve the raw payload after mapping
+event.raw_data = move message
+event.raw_data_size = event.raw_data.length_bytes()
+this = event
+
+// 6. Output normalized events
 publish "normalized-events"
 ```
 

--- a/src/content/docs/guides/normalization/map-to-asim.mdx
+++ b/src/content/docs/guides/normalization/map-to-asim.mdx
@@ -42,26 +42,23 @@ For a `NetworkSession` event, start with these core fields:
 
 ## Write a small mapping
 
-The following example maps a parsed firewall connection event to an ASIM
-`NetworkSession` record. It keeps the source data under `fw`, sets the ASIM
+The following example shows a package mapper that maps a parsed firewall
+connection event to an ASIM `NetworkSession` record. It keeps all mapping work
+inside the `event` argument, puts the source data under `fw`, sets the ASIM
 schema constants, normalizes the device action and result, maps source and
 destination fields, and preserves unmapped residue in `AdditionalFields`.
 
 ```tql
-from {
-  ts: 2024-01-15T10:30:45Z,
-  action: "allowed",
-  src_ip: "10.0.0.5",
-  src_port: 51544,
-  dst_ip: "203.0.113.10",
-  dst_port: 443,
-  proto: "tcp",
-  bytes_out: 1280,
-  bytes_in: 8192,
-  device: "edge-fw-01",
-}
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
+---
 
-this = {fw: this}
+$event = {...$event, fw: $event, asim: {}}
 
 let $actions = {
   allow: "Allow",
@@ -85,30 +82,35 @@ let $results = {
   dropped: "Failure",
 }
 
-asim.EventSchema = "NetworkSession"
-asim.EventSchemaVersion = "0.2.7"
-asim.EventType = "NetworkSession"
-asim.EventCount = 1
-asim.EventStartTime = fw.ts
-asim.EventEndTime = move fw.ts
-asim.EventVendor = "Example Networks"
-asim.EventProduct = "Example Firewall"
-asim.Dvc = fw.device
-asim.DvcHostname = move fw.device
-asim.DvcAction = $actions[fw.action.to_lower()]? else fw.action
-asim.EventResult = $results[fw.action.to_lower()]? else "NA"
-asim.DvcOriginalAction = move fw.action
-asim.SrcIpAddr = move fw.src_ip
-asim.SrcPortNumber = move fw.src_port
-asim.DstIpAddr = move fw.dst_ip
-asim.DstPortNumber = move fw.dst_port
-asim.NetworkProtocol = (move fw.proto).to_upper()
-asim.SrcBytes = move fw.bytes_out
-asim.DstBytes = move fw.bytes_in
-asim.NetworkBytes = asim.SrcBytes + asim.DstBytes
+$event.asim.EventSchema = "NetworkSession"
+$event.asim.EventSchemaVersion = "0.2.7"
+$event.asim.EventType = "NetworkSession"
+$event.asim.EventCount = 1
+$event.asim.EventStartTime = $event.fw.ts
+$event.asim.EventEndTime = move $event.fw.ts
+$event.asim.EventVendor = "Example Networks"
+$event.asim.EventProduct = "Example Firewall"
+$event.asim.Dvc = $event.fw.device
+$event.asim.DvcHostname = move $event.fw.device
+$event.asim.DvcAction = $actions[$event.fw.action.to_lower()]? else $event.fw.action
+$event.asim.EventResult = $results[$event.fw.action.to_lower()]? else "NA"
+$event.asim.DvcOriginalAction = move $event.fw.action
+$event.asim.SrcIpAddr = move $event.fw.src_ip
+$event.asim.SrcPortNumber = move $event.fw.src_port
+$event.asim.DstIpAddr = move $event.fw.dst_ip
+$event.asim.DstPortNumber = move $event.fw.dst_port
+$event.asim.NetworkProtocol = (move $event.fw.proto).to_upper()
+$event.asim.SrcBytes = move $event.fw.bytes_out
+$event.asim.DstBytes = move $event.fw.bytes_in
+$event.asim.NetworkBytes = $event.asim.SrcBytes + $event.asim.DstBytes
 
-this = {...asim, AdditionalFields: fw}
+$event = {...$event.asim, AdditionalFields: $event.fw}
 ```
+
+A call with a firewall event such as `{ts: 2024-01-15T10:30:45Z, action:
+"allowed", src_ip: "10.0.0.5", src_port: 51544, dst_ip: "203.0.113.10",
+dst_port: 443, proto: "tcp", bytes_out: 1280, bytes_in: 8192, device:
+"edge-fw-01"}` produces an ASIM event like this:
 
 ```tql
 {
@@ -141,7 +143,10 @@ this = {...asim, AdditionalFields: fw}
 
 Use the same structure for larger mappings:
 
-- **Keep a source namespace**: Move the parsed event under a short namespace
+- **Use the event scope**: Package mappers accept a named `event` field
+  argument with `default: this`, create source and target namespaces with an
+  initial spread, and mutate only fields below `$event`.
+- **Keep a source namespace**: Keep the parsed event under a short namespace
   such as `fw`, `dns`, `edr`, or `event` before you create ASIM fields.
 - **Set the schema fields early**: Let `EventSchema` and
   `EventSchemaVersion` drive which field records, constants, and conditional

--- a/src/content/docs/guides/normalization/map-to-cim.mdx
+++ b/src/content/docs/guides/normalization/map-to-cim.mdx
@@ -42,26 +42,23 @@ For `Network_Traffic / All_Traffic`, start with these fields and tags:
 
 ## Write a small mapping
 
-The following example maps a parsed firewall connection event to CIM Network
-Traffic fields. It keeps the source data under `fw`, applies the dataset tags,
+The following example shows a package mapper that maps a parsed firewall
+connection event to CIM Network Traffic fields. It keeps all mapping work inside
+the `event` argument, puts the source data under `fw`, applies the dataset tags,
 normalizes action and transport values, maps endpoint fields, and preserves
 unmapped residue for review.
 
 ```tql
-from {
-  ts: 2024-01-15T10:30:45Z,
-  action: "allowed",
-  src_ip: "10.0.0.5",
-  src_port: 51544,
-  dst_ip: "203.0.113.10",
-  dst_port: 443,
-  proto: "tcp",
-  bytes_out: 1280,
-  bytes_in: 8192,
-  device: "edge-fw-01",
-}
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
+---
 
-this = {fw: this}
+$event = {...$event, fw: $event, cim: {}}
 
 let $actions = {
   allow: "allowed",
@@ -75,29 +72,34 @@ let $actions = {
   teardown: "teardown",
 }
 
-cim._time = move fw.ts
-cim.tag = ["network", "communicate"]
-cim.host = fw.device
-cim.source = "example-firewall"
-cim.sourcetype = "example:firewall"
-cim.vendor_product = "Example Networks Example Firewall"
-cim.action = $actions[fw.action.to_lower()]? else fw.action.to_lower()
-cim.src = fw.src_ip
-cim.src_ip = move fw.src_ip
-cim.src_port = move fw.src_port
-cim.dest = fw.dst_ip
-cim.dest_ip = move fw.dst_ip
-cim.dest_port = move fw.dst_port
-cim.transport = (move fw.proto).to_lower()
-cim.bytes_out = move fw.bytes_out
-cim.bytes_in = move fw.bytes_in
-cim.bytes = cim.bytes_in + cim.bytes_out
-cim.dvc = move fw.device
+$event.cim._time = move $event.fw.ts
+$event.cim.tag = ["network", "communicate"]
+$event.cim.host = $event.fw.device
+$event.cim.source = "example-firewall"
+$event.cim.sourcetype = "example:firewall"
+$event.cim.vendor_product = "Example Networks Example Firewall"
+$event.cim.action = $actions[$event.fw.action.to_lower()]? else $event.fw.action.to_lower()
+$event.cim.src = $event.fw.src_ip
+$event.cim.src_ip = move $event.fw.src_ip
+$event.cim.src_port = move $event.fw.src_port
+$event.cim.dest = $event.fw.dst_ip
+$event.cim.dest_ip = move $event.fw.dst_ip
+$event.cim.dest_port = move $event.fw.dst_port
+$event.cim.transport = (move $event.fw.proto).to_lower()
+$event.cim.bytes_out = move $event.fw.bytes_out
+$event.cim.bytes_in = move $event.fw.bytes_in
+$event.cim.bytes = $event.cim.bytes_in + $event.cim.bytes_out
+$event.cim.dvc = move $event.fw.device
 
-drop fw.action
+drop $event.fw.action
 
-this = {...cim, unmapped: fw}
+$event = {...$event.cim, unmapped: $event.fw}
 ```
+
+A call with a firewall event such as `{ts: 2024-01-15T10:30:45Z, action:
+"allowed", src_ip: "10.0.0.5", src_port: 51544, dst_ip: "203.0.113.10",
+dst_port: 443, proto: "tcp", bytes_out: 1280, bytes_in: 8192, device:
+"edge-fw-01"}` produces a CIM event like this:
 
 ```tql
 {
@@ -130,7 +132,10 @@ this = {...cim, unmapped: fw}
 
 Use the same structure for larger mappings:
 
-- **Keep a source namespace**: Move the parsed event under a short namespace
+- **Use the event scope**: Package mappers accept a named `event` field
+  argument with `default: this`, create source and target namespaces with an
+  initial spread, and mutate only fields below `$event`.
+- **Keep a source namespace**: Keep the parsed event under a short namespace
   such as `fw`, `dns`, `edr`, or `event` before you create CIM fields.
 - **Choose the dataset first**: Let the CIM data model, dataset tags, and
   constraints drive the mapping.
@@ -157,6 +162,12 @@ to_splunk "https://splunk.example.com:8088",
   host=host,
   source=source,
   sourcetype=sourcetype
+```
+
+If the parsed source event lives in a nested field, pass that field explicitly:
+
+```tql
+my_source::cim::map event=parsed
 ```
 
 Use the `index` option when the destination index differs per event.

--- a/src/content/docs/guides/normalization/map-to-cim.mdx
+++ b/src/content/docs/guides/normalization/map-to-cim.mdx
@@ -164,10 +164,18 @@ to_splunk "https://splunk.example.com:8088",
   sourcetype=sourcetype
 ```
 
-If the parsed source event lives in a nested field, pass that field explicitly:
+If the parsed source event lives in a nested field, pass that field explicitly
+and promote the mapped CIM event before the sink reads top-level metadata:
 
 ```tql
 my_source::cim::map event=parsed
+this = parsed
+to_splunk "https://splunk.example.com:8088",
+  hec_token=secret("splunk-hec-token"),
+  time=_time,
+  host=host,
+  source=source,
+  sourcetype=sourcetype
 ```
 
 Use the `index` option when the destination index differs per event.

--- a/src/content/docs/guides/normalization/map-to-ecs.mdx
+++ b/src/content/docs/guides/normalization/map-to-ecs.mdx
@@ -170,10 +170,15 @@ to_elasticsearch "https://elasticsearch.example.com:9200",
   index="ecs-events"
 ```
 
-If the parsed source event lives in a nested field, pass that field explicitly:
+If the parsed source event lives in a nested field, pass that field explicitly
+and promote the mapped ECS document before indexing:
 
 ```tql
 my_source::ecs::map event=parsed
+this = parsed
+to_elasticsearch "https://elasticsearch.example.com:9200",
+  action="index",
+  index="ecs-events"
 ```
 
 Use <Op>to_opensearch</Op> instead when the destination is OpenSearch.

--- a/src/content/docs/guides/normalization/map-to-ecs.mdx
+++ b/src/content/docs/guides/normalization/map-to-ecs.mdx
@@ -39,26 +39,23 @@ For a firewall connection event, choose `event.kind: event`,
 
 ## Write a small mapping
 
-The following example maps a parsed firewall connection event to ECS. It keeps
-the source data under `fw`, sets ECS categorization fields, maps network
+The following example shows a package mapper that maps a parsed firewall
+connection event to ECS. It keeps all mapping work inside the `event` argument,
+puts the source data under `fw`, sets ECS categorization fields, maps network
 participants, normalizes the transport protocol, and preserves unmapped residue
 under a custom namespace.
 
 ```tql
-from {
-  ts: 2024-01-15T10:30:45Z,
-  action: "allowed",
-  src_ip: "10.0.0.5",
-  src_port: 51544,
-  dst_ip: "203.0.113.10",
-  dst_port: 443,
-  proto: "tcp",
-  bytes_out: 1280,
-  bytes_in: 8192,
-  device: "edge-fw-01",
-}
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
+---
 
-this = {fw: this}
+$event = {...$event, fw: $event, ecs: {}}
 
 let $event_types = {
   allow: ["connection", "allowed"],
@@ -71,26 +68,31 @@ let $event_types = {
   dropped: ["connection", "denied"],
 }
 
-ecs["@timestamp"] = move fw.ts
-ecs.ecs.version = "9.4.0"
-ecs.event.kind = "event"
-ecs.event.category = ["network"]
-ecs.event.type = $event_types[fw.action.to_lower()]? else ["connection"]
-ecs.event.action = (move fw.action).to_lower()
-ecs.source.ip = move fw.src_ip
-ecs.source.port = move fw.src_port
-ecs.source.bytes = move fw.bytes_out
-ecs.destination.ip = move fw.dst_ip
-ecs.destination.port = move fw.dst_port
-ecs.destination.bytes = move fw.bytes_in
-ecs.network.transport = (move fw.proto).to_lower()
-ecs.network.bytes = ecs.source.bytes + ecs.destination.bytes
-ecs.observer.hostname = move fw.device
-ecs.observer.vendor = "Example Networks"
-ecs.observer.product = "Example Firewall"
+$event.ecs["@timestamp"] = move $event.fw.ts
+$event.ecs.ecs.version = "9.4.0"
+$event.ecs.event.kind = "event"
+$event.ecs.event.category = ["network"]
+$event.ecs.event.type = $event_types[$event.fw.action.to_lower()]? else ["connection"]
+$event.ecs.event.action = (move $event.fw.action).to_lower()
+$event.ecs.source.ip = move $event.fw.src_ip
+$event.ecs.source.port = move $event.fw.src_port
+$event.ecs.source.bytes = move $event.fw.bytes_out
+$event.ecs.destination.ip = move $event.fw.dst_ip
+$event.ecs.destination.port = move $event.fw.dst_port
+$event.ecs.destination.bytes = move $event.fw.bytes_in
+$event.ecs.network.transport = (move $event.fw.proto).to_lower()
+$event.ecs.network.bytes = $event.ecs.source.bytes + $event.ecs.destination.bytes
+$event.ecs.observer.hostname = move $event.fw.device
+$event.ecs.observer.vendor = "Example Networks"
+$event.ecs.observer.product = "Example Firewall"
 
-this = {...ecs, example: {unmapped: fw}}
+$event = {...$event.ecs, example: {unmapped: $event.fw}}
 ```
+
+A call with a firewall event such as `{ts: 2024-01-15T10:30:45Z, action:
+"allowed", src_ip: "10.0.0.5", src_port: 51544, dst_ip: "203.0.113.10",
+dst_port: 443, proto: "tcp", bytes_out: 1280, bytes_in: 8192, device:
+"edge-fw-01"}` produces an ECS event like this:
 
 ```tql
 {
@@ -138,7 +140,10 @@ this = {...ecs, example: {unmapped: fw}}
 
 Use the same structure for larger mappings:
 
-- **Keep a source namespace**: Move the parsed event under a short namespace
+- **Use the event scope**: Package mappers accept a named `event` field
+  argument with `default: this`, create source and target namespaces with an
+  initial spread, and mutate only fields below `$event`.
+- **Keep a source namespace**: Keep the parsed event under a short namespace
   such as `fw`, `dns`, `edr`, or `event` before you create ECS fields.
 - **Populate required fields first**: Set `@timestamp` and `ecs.version` before
   you map event-specific fieldsets.
@@ -163,6 +168,12 @@ my_source::ecs::map
 to_elasticsearch "https://elasticsearch.example.com:9200",
   action="index",
   index="ecs-events"
+```
+
+If the parsed source event lives in a nested field, pass that field explicitly:
+
+```tql
+my_source::ecs::map event=parsed
 ```
 
 Use <Op>to_opensearch</Op> instead when the destination is OpenSearch.

--- a/src/content/docs/guides/normalization/map-to-ocsf.mdx
+++ b/src/content/docs/guides/normalization/map-to-ocsf.mdx
@@ -39,63 +39,72 @@ We recommend organizing fields by OCSF attribute groups: classification,
 occurrence, context, primary.
 
 ```tql
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
+---
+
 // --- Preamble ---------------------------------
 
-// Keep source data in a source-specific working namespace.
-this = { panos: this }
+// Keep all mapping work inside the explicit event scope.
+$event = {...$event, panos: $event, ocsf: {}}
 
 // --- OCSF: classification attributes ----------
 
 @name = "ocsf.network_activity"
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.activity_id = 6
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.activity_id = 6
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: occurrence attributes --------------
 
-ocsf.time = move panos.time_generated
-ocsf.start_time = move panos.start
-if panos.elapsed != null {
-  ocsf.end_time = ocsf.start_time + panos.elapsed
-  ocsf.duration = count_milliseconds(move panos.elapsed).round()
+$event.ocsf.time = move $event.panos.time_generated
+$event.ocsf.start_time = move $event.panos.start
+if $event.panos.elapsed != null {
+  $event.ocsf.end_time = $event.ocsf.start_time + $event.panos.elapsed
+  $event.ocsf.duration = count_milliseconds(move $event.panos.elapsed).round()
 }
 
 // --- OCSF: context attributes -----------------
 
 // Metadata about the event source.
-ocsf.metadata = {
+$event.ocsf.metadata = {
   log_name: "traffic",
   product: {
     cpe_name: "cpe:/a:paloaltonetworks:pan-os",
     name: "NGFW",
     vendor_name: "Palo Alto Networks",
   },
-  original_event_uid: move panos.sessionid,
+  original_event_uid: move $event.panos.sessionid,
   version: "1.8.0",
 }
-ocsf.app_name = move panos.app
+$event.ocsf.app_name = move $event.panos.app
 
 // --- OCSF: primary attributes -----------------
 
 // Primary attributes reflect the core semantic meaning of the event.
 
-ocsf.src_endpoint = {
-  ip: move panos.src,
-  port: move panos.sport,
+$event.ocsf.src_endpoint = {
+  ip: move $event.panos.src,
+  port: move $event.panos.sport,
 }
 
-ocsf.dst_endpoint = {
-  ip: move panos.dst,
-  port: move panos.dport,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.panos.dst,
+  port: move $event.panos.dport,
 }
 
 let $proto_nums = {tcp: 6, udp: 17, icmp: 1}
-ocsf.connection_info = {
-  protocol_name: (move panos.proto).to_lower(),
+$event.ocsf.connection_info = {
+  protocol_name: (move $event.panos.proto).to_lower(),
 }
-ocsf.connection_info.protocol_num = $proto_nums[ocsf.connection_info.protocol_name]? else -1
+$event.ocsf.connection_info.protocol_num = $proto_nums[$event.ocsf.connection_info.protocol_name]? else -1
 
 // --- OCSF: profile-specific attributes --------
 
@@ -106,22 +115,21 @@ ocsf.connection_info.protocol_num = $proto_nums[ocsf.connection_info.protocol_na
 // --- Epilogue ---------------------------------
 
 // Return the mapped OCSF event and preserve mapping residue.
-this = {...ocsf, unmapped: panos}
-
-// Derive sibling fields and validate the final shape.
-ocsf::derive
-ocsf::cast
+$event = {...$event.ocsf, unmapped: $event.panos}
 ```
 
 ### Key principles
 
-- **Use a source namespace**: Move the input under a short descriptor such as
-  `panos`, `zeek`, `okta`, or the generic `event` before mapping. This prevents
-  name clashes with OCSF fields and keeps the remaining source fields ready for
-  `unmapped`.
+- **Use the event scope**: Mapping UDOs accept a named `event` field argument
+  that defaults to `this`. Start with a spread such as
+  `$event = {...$event, panos: $event, ocsf: {}}`, then mutate only fields under
+  `$event`.
+- **Use a source namespace**: Keep the input under a short descriptor such as
+  `panos`, `zeek`, `okta`, or the generic `event`. This prevents name clashes
+  with OCSF fields and keeps the remaining source fields ready for `unmapped`.
 - **Use `move`**: Transfer fields with `move` to simultaneously assign and
   remove from source, for example
-  `ocsf.time = move panos.time_generated`.
+  `$event.ocsf.time = move $event.panos.time_generated`.
 - **Only use `drop` for multi-use fields**: When a field appears in multiple
   mappings, drop it after the last use. Prefer `move` and single assignments.
 - **Keep unmapped residue**: Fields left under the source namespace still need
@@ -138,13 +146,17 @@ OCSF mapping is a bipartite graph transformation: source fields form one vertex
 set, OCSF attributes form another, and your mapping defines the edges. Edges can
 be 1:1 (direct assignment), 1:n (field splitting), n:1 (aggregation), or n:m
 (complex transformation). Fields with no outgoing edges remain in the source
-namespace and become `unmapped` when the mapper returns the OCSF event.
+  namespace and become `unmapped` when the mapper returns the OCSF event.
 :::
 
 ### Package structure
 
 Organize OCSF mappings as a package with a dispatcher and per-event-type
 operators:
+
+Put the target schema first in mapping namespaces. Source-to-OCSF packages use
+`paloalto::ngfw::ocsf::map`. Cross-schema mappings keep the same rule, for
+example `paloalto::ngfw::asim::ocsf::map` for OCSF-to-ASIM mapping.
 
 import { FileTree } from '@astrojs/starlight/components';
 
@@ -185,9 +197,18 @@ source-specific cleanup and shared OCSF setup, dispatches events based on the
 event type, and returns the mapped OCSF event:
 
 ```tql
-this = { panos: this }
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
+---
 
-ocsf.metadata = {
+$event = {...$event, panos: $event, ocsf: {}}
+
+$event.ocsf.metadata = {
   product: {
     cpe_name: "cpe:/a:paloaltonetworks:pan-os",
     name: "NGFW",
@@ -195,24 +216,24 @@ ocsf.metadata = {
   },
   version: "1.8.0",
 }
-ocsf.severity_id = 1
+$event.ocsf.severity_id = 1
 
-match panos.type {
+match $event.panos.type {
   "TRAFFIC" => {
-    paloalto::ngfw::ocsf::events::network
+    paloalto::ngfw::ocsf::events::network event=$event
   }
   "DNS" => {
-    paloalto::ngfw::ocsf::events::dns
+    paloalto::ngfw::ocsf::events::dns event=$event
   }
   "THREAT" => {
-    paloalto::ngfw::ocsf::events::threat
+    paloalto::ngfw::ocsf::events::threat event=$event
   }
   _ => {
-    paloalto::ngfw::ocsf::base
+    paloalto::ngfw::ocsf::base event=$event
   }
 }
 
-this = {...ocsf, unmapped: panos}
+$event = {...$event.ocsf, unmapped: $event.panos}
 ```
 
 If the parser package does not set a type field, dispatch on a different field
@@ -234,6 +255,23 @@ ocsf::cast
 This requires that your test file has a sibling `.input` file that the [test
 framework](/guides/testing/write-tests) exposes through `TENZIR_INPUT`. Use the
 reader that matches your fixture format.
+
+When a caller parses into a nested field or wants to add raw data after mapping,
+pass the mapping scope explicitly and add the additional attributes after the
+mapper returns:
+
+```tql
+from_file env("TENZIR_INPUT") {
+  read_lines
+}
+panos = line.parse_json()
+paloalto::ngfw::ocsf::map event=panos
+panos.raw_data = move line
+panos.raw_data_size = panos.raw_data.length_bytes()
+this = panos
+ocsf::derive
+ocsf::cast
+```
 
 ### Validation gate
 

--- a/src/content/docs/guides/normalization/map-to-ocsf.mdx
+++ b/src/content/docs/guides/normalization/map-to-ocsf.mdx
@@ -141,6 +141,14 @@ $event = {...$event.ocsf, unmapped: $event.panos}
 - **Validate the result**: Run <Op>ocsf::derive</Op> and <Op>ocsf::cast</Op>
   after the mapper returns the OCSF event.
 
+:::note[Why use `$event`?]
+TQL has user-defined operators, but not user-defined functions yet. The explicit
+`event` field argument gives each mapping operator one mutable record scope that
+callers can pass explicitly when the parsed source event lives in a field. Keep
+all mapper state below `$event` until TQL has function-like abstractions for
+record-to-record mappings.
+:::
+
 :::note[Think in graphs]
 OCSF mapping is a bipartite graph transformation: source fields form one vertex
 set, OCSF attributes form another, and your mapping defines the edges. Edges can

--- a/src/content/docs/guides/normalization/map-to-udm.mdx
+++ b/src/content/docs/guides/normalization/map-to-udm.mdx
@@ -46,24 +46,22 @@ For a `NETWORK_CONNECTION` event, UDM expects these core sections:
 
 ## Write a small mapping
 
-The following example maps a parsed firewall connection event to UDM. It keeps
-the source data under `fw`, moves one-use fields into UDM, converts source
+The following example shows a package mapper that maps a parsed firewall
+connection event to UDM. It keeps all mapping work inside the `event` argument,
+puts the source data under `fw`, moves one-use fields into UDM, converts source
 strings to UDM enum values, and preserves unmapped residue in `additional`.
 
 ```tql
-from {
-  ts: 2024-01-15T10:30:45Z,
-  action: "allowed",
-  src_ip: "10.0.0.5",
-  src_port: 51544,
-  dst_ip: "203.0.113.10",
-  dst_port: 443,
-  proto: "tcp",
-  bytes_out: 1280,
-  bytes_in: 8192,
-}
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
+---
 
-this = {fw: this}
+$event = {...$event, fw: $event, udm: {}}
 
 let $ip_protocols = {
   tcp: "TCP",
@@ -80,37 +78,42 @@ let $actions = {
   blocked: "BLOCK",
 }
 
-udm.metadata = {
-  eventTimestamp: move fw.ts,
+$event.udm.metadata = {
+  eventTimestamp: move $event.fw.ts,
   eventType: "NETWORK_CONNECTION",
   vendorName: "Example Networks",
   productName: "Example Firewall",
-  productEventType: fw.action,
+  productEventType: $event.fw.action,
 }
 
-udm.principal = {
-  ip: [move fw.src_ip],
-  port: move fw.src_port,
+$event.udm.principal = {
+  ip: [move $event.fw.src_ip],
+  port: move $event.fw.src_port,
 }
 
-udm.target = {
-  ip: [move fw.dst_ip],
-  port: move fw.dst_port,
+$event.udm.target = {
+  ip: [move $event.fw.dst_ip],
+  port: move $event.fw.dst_port,
 }
 
-udm.network = {
-  ipProtocol: $ip_protocols[(move fw.proto).to_lower()]? else "UNKNOWN_IP_PROTOCOL",
-  sentBytes: move fw.bytes_out,
-  receivedBytes: move fw.bytes_in,
+$event.udm.network = {
+  ipProtocol: $ip_protocols[(move $event.fw.proto).to_lower()]? else "UNKNOWN_IP_PROTOCOL",
+  sentBytes: move $event.fw.bytes_out,
+  receivedBytes: move $event.fw.bytes_in,
 }
 
-udm.securityResult = [{
-  action: [$actions[fw.action.to_lower()]? else "UNKNOWN_ACTION"],
-  actionDetails: move fw.action,
+$event.udm.securityResult = [{
+  action: [$actions[$event.fw.action.to_lower()]? else "UNKNOWN_ACTION"],
+  actionDetails: move $event.fw.action,
 }]
 
-this = {...udm, additional: fw}
+$event = {...$event.udm, additional: $event.fw}
 ```
+
+A call with a firewall event such as `{ts: 2024-01-15T10:30:45Z, action:
+"allowed", src_ip: "10.0.0.5", src_port: 51544, dst_ip: "203.0.113.10",
+dst_port: 443, proto: "tcp", bytes_out: 1280, bytes_in: 8192}` produces a UDM
+event like this:
 
 ```tql
 {
@@ -154,7 +157,10 @@ this = {...udm, additional: fw}
 
 Use the same structure for larger mappings:
 
-- **Keep a source namespace**: Move the parsed event under a short namespace
+- **Use the event scope**: Package mappers accept a named `event` field
+  argument with `default: this`, create source and target namespaces with an
+  initial spread, and mutate only fields below `$event`.
+- **Keep a source namespace**: Keep the parsed event under a short namespace
   such as `fw`, `dns`, `edr`, or `event` before you create UDM fields.
 - **Set `metadata.eventType` early**: Let the UDM event type drive which
   participant nouns and protocol fields you populate.

--- a/src/content/docs/guides/packages/add-operators.mdx
+++ b/src/content/docs/guides/packages/add-operators.mdx
@@ -553,6 +553,11 @@ publish "ocsf"
 The parser stays with the source operator, while `acme::ocsf::map` owns cleanup,
 shared OCSF setup, and dispatch.
 
+This explicit event scope is a package convention while TQL has user-defined
+operators but not user-defined functions. Passing `event` gives each mapper one
+mutable record scope, keeps internal helper operators from touching unrelated
+fields, and lets callers map a parsed record that lives in a field.
+
 ### Design principles
 
 When building operator hierarchies, follow these guidelines:

--- a/src/content/docs/guides/packages/add-operators.mdx
+++ b/src/content/docs/guides/packages/add-operators.mdx
@@ -443,66 +443,94 @@ specialized mappers based on a stable event discriminator, and returns the
 mapped OCSF event:
 
 ```tql title="operators/ocsf/map.tql"
-this = { acme: this }
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
+---
 
-ocsf.metadata = {
+$event = {...$event, acme: $event, ocsf: {}}
+
+$event.ocsf.metadata = {
   product: {
     name: "ACME Logs",
     vendor_name: "ACME",
   },
   version: "1.8.0",
 }
-ocsf.severity_id = 1
+$event.ocsf.severity_id = 1
 
-match acme.event_type {
+match $event.acme.event_type {
   "dns" => {
-    acme::ocsf::events::dns
+    acme::ocsf::events::dns event=$event
   }
   "http" => {
-    acme::ocsf::events::http
+    acme::ocsf::events::http event=$event
   }
   "auth" => {
-    acme::ocsf::events::auth
+    acme::ocsf::events::auth event=$event
   }
   _ => {
-    acme::ocsf::base
+    acme::ocsf::base event=$event
   }
 }
 
-this = {...ocsf, unmapped: acme}
+$event = {...$event.ocsf, unmapped: $event.acme}
 ```
 
 The fallback operator ensures that unrecognized events still conform to OCSF by
 mapping them to the Base Event class:
 
 ```tql title="operators/ocsf/base.tql"
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
+
 @name = "ocsf.base_event"
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.activity_id = 0
-ocsf.type_uid = 0
-ocsf.severity_id = 0
-ocsf.time = now()
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.type_uid = 0
+$event.ocsf.severity_id = 0
+$event.ocsf.time = now()
 ```
 
 Each leaf operator handles one specific event type:
 
 ```tql title="operators/ocsf/events/dns.tql"
-@name = "ocsf.dns_activity"
-ocsf.category_uid = 4
-ocsf.class_uid = 4003
-ocsf.activity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 
-ocsf.query.hostname = move acme.query_name
-ocsf.query.type = move acme.query_type
-ocsf.answers = move acme.dns_answers
+@name = "ocsf.dns_activity"
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4003
+$event.ocsf.activity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+
+$event.ocsf.query.hostname = move $event.acme.query_name
+$event.ocsf.query.type = move $event.acme.query_type
+$event.ocsf.answers = move $event.acme.dns_answers
 // ... additional field mappings
 ```
 
-After the package mapper runs, callers can run the shared OCSF helpers. The
-mapper should produce minimal OCSF, and <Op>ocsf::derive</Op> expands it with
-derived sibling fields before <Op>ocsf::cast</Op> validates the final shape:
+After the package mapper runs, callers can run the shared OCSF helpers. Public
+mappers should accept a named `event` field argument with `default: this`.
+Internal mappers receive the current mapping scope explicitly via
+`event=$event`. The mapper should produce minimal OCSF, and
+<Op>ocsf::derive</Op> expands it with derived sibling fields before
+<Op>ocsf::cast</Op> validates the final shape:
 
 ```tql
 acme::ocsf::map
@@ -530,9 +558,15 @@ shared OCSF setup, and dispatch.
 When building operator hierarchies, follow these guidelines:
 
 - **Expose one mapper contract**: Accept parsed source events through a main
-  package mapper, for example `acme::ocsf::map`.
+  package mapper, for example `acme::ocsf::map`, with `event=this` as the
+  default scope.
+- **Name the target schema first**: Put the target namespace before any source
+  schema namespace. For example, use `acme::ocsf::map` for source-to-OCSF
+  mapping and `acme::cim::ocsf::map` for OCSF-to-CIM mapping.
 - **Keep cleanup close to mapping**: Put source-specific normalization and
   shared OCSF setup in the main mapper before dispatch.
+- **Stay inside `$event`**: Use an initial spread to create source and target
+  namespaces, then only mutate fields below `$event` inside mapping UDOs.
 - **Produce minimal OCSF**: Set identifiers and source-derived attributes in
   the mapper, then use <Op>ocsf::derive</Op> to add derived sibling fields.
 - **Use dispatchers for routing**: Route events based on type or other criteria.

--- a/src/content/docs/guides/packages/add-pipelines.mdx
+++ b/src/content/docs/guides/packages/add-pipelines.mdx
@@ -34,6 +34,27 @@ only when the package should take action as soon as it is installed. Ship
 optional operational workflows as disabled templates unless automatic execution
 is the package's core behavior.
 
+Public mapping UDOs should default to mapping the current event, so
+`acme::ocsf::map` works when the source operator already emits parsed source
+events. If your pipeline keeps the parsed source event in a field, pass that
+field explicitly and add extra attributes after the mapper returns:
+
+```tql title="pipelines/fetch-raw-and-normalize.tql"
+every 1h {
+  from_http "https://api.example.com/events" {
+    read_lines
+  }
+}
+event = line.parse_json()
+acme::ocsf::map event=event
+event.raw_data = move line
+event.raw_data_size = event.raw_data.length_bytes()
+this = event
+ocsf::derive
+ocsf::cast
+publish "normalized-events"
+```
+
 ## Configure pipeline behavior
 
 Configure pipelines using YAML frontmatter at the beginning of the TQL file.

--- a/src/content/docs/guides/packages/create-a-package.mdx
+++ b/src/content/docs/guides/packages/create-a-package.mdx
@@ -103,9 +103,14 @@ short usage snippets, and tests as the executable contract.
 
 - Put reusable package capabilities under `operators/`.
 - If the package maps to OCSF, expose a main mapper such as `acme::ocsf::map`
-  that accepts parsed source events, performs source-specific cleanup and shared
-  OCSF setup, produces minimal OCSF, and dispatches to event-specific operators
-  under a local namespace such as `operators/ocsf/events/`.
+  that accepts a named `event` field argument with `default: this`, creates a
+  source namespace and an OCSF target namespace with an initial spread, performs
+  source-specific cleanup and shared OCSF setup inside `$event`, produces
+  minimal OCSF, and dispatches to event-specific operators under a local
+  namespace such as `operators/ocsf/events/`.
+- If the package maps between normalized schemas, put the target schema before
+  the source schema in the operator namespace, for example
+  `acme::cim::ocsf::map` for OCSF-to-CIM mapping.
 - Put complete workflows with an input and output under `pipelines/`. Disable
   optional operational pipelines by default with `disabled: true`.
 - Put focused snippets under `examples/` so users can quickly try the package

--- a/src/content/docs/guides/packages/test-packages.mdx
+++ b/src/content/docs/guides/packages/test-packages.mdx
@@ -138,6 +138,23 @@ ocsf::derive
 ocsf::cast
 ```
 
+Public mapping UDOs use `event=this` by default, so this form maps the current
+record. If the test parses the source event into a field, pass the mapping scope
+explicitly and add raw payload attributes after the mapper returns:
+
+```tql title="tests/ocsf/auth-raw.tql"
+from_file env("TENZIR_INPUT") {
+  read_lines
+}
+event = line.parse_json()
+acme::ocsf::map event=event
+event.raw_data = move line
+event.raw_data_size = event.raw_data.length_bytes()
+this = event
+ocsf::derive
+ocsf::cast
+```
+
 Use <Op>ocsf::derive</Op> to populate sibling enum fields and
 <Op>ocsf::cast</Op> to validate the mapped event against the OCSF schema. This
 lets the mapper stay minimal while the baseline captures the comprehensive OCSF

--- a/src/content/docs/tutorials/map-data-to-ocsf/index.mdx
+++ b/src/content/docs/tutorials/map-data-to-ocsf/index.mdx
@@ -577,6 +577,11 @@ ocsf::cast
 to_stdout
 ```
 
+Public mapping operators accept a named `event` field argument that defaults to
+`this`, so `zeek::ocsf::map` maps the current event in this pipeline. When a
+pipeline keeps the parsed source event in a field, call the mapper with
+`event=<field>` and add additional attributes after the mapper returns.
+
 All you have to do to get there is create a package with following directory
 structure:
 
@@ -607,8 +612,9 @@ hierarchy:
 </FileTree>
 
 Since operators fully compose, you can implement `zeek::ocsf::map` as one main
-mapper that performs source-specific cleanup, sets shared fields in the `ocsf`
-record, and dispatches to event-specific operators for each log type.
+mapper that performs source-specific cleanup, creates source and OCSF target
+namespaces inside `$event`, sets shared fields in `$event.ocsf`, and dispatches
+to event-specific operators for each log type.
 
 import mapTql from '/public/packages/zeek/operators/ocsf/map.tql?raw';
 
@@ -629,8 +635,8 @@ In this layout, you'd put the mapping operators in the following directories:
 
 </FileTree>
 
-The mapper keeps intermediate results under `ocsf` internally and returns a
-minimal OCSF event. Callers then run shared OCSF helpers such as
+The mapper keeps intermediate results under `$event.ocsf` internally and returns
+a minimal OCSF event. Callers then run shared OCSF helpers such as
 <Op>ocsf::derive</Op> and <Op>ocsf::cast</Op> to expand and validate the final
 shape. This mirrors how larger package mappers handle cleanup, shared fields,
 fallback Base Event mapping, and event-specific mappings.


### PR DESCRIPTION
## 🔍 Problem

- The mapping tutorial and package guides still described the older global `this` mapper convention.
- The docs did not explain when callers should pass an explicit mapping scope.

## 🛠️ Solution

- Document `event=this` mapper arguments and `$event` source/target namespaces across normalization and package guides.
- Show explicit `event=<field>` calls for pipelines that parse into a nested field and add raw payload attributes after mapping.
- Update the embedded Zeek tutorial package snippets to match the new mapper shape.

## 💬 Review

- Focus on whether the event-scoped examples are clear and consistent across OCSF and non-OCSF schema guides.

<sub>
⚙️ Code PR: tenzir/library#157
</sub>
