### PR TITLE
Correct TLS and memory options in tenzir.yaml.example

### DIFF
--- a/src/content/docs/explanations/configuration.mdx
+++ b/src/content/docs/explanations/configuration.mdx
@@ -158,7 +158,7 @@ connections:
 ```yaml title="<configdir>/tenzir/tenzir.yaml"
 tenzir:
   tls:
-    min-version: "1.2"
+    tls-min-version: "1.2"
 ```
 
 Valid values are `"1.0"`, `"1.1"`, `"1.2"`, and `"1.3"`. We recommend using
@@ -176,7 +176,7 @@ You can specify which cipher suites to use for TLS connections:
 ```yaml title="<configdir>/tenzir/tenzir.yaml"
 tenzir:
   tls:
-    ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
+    tls-ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
 ```
 
 The cipher list format follows OpenSSL cipher list syntax. See the [OpenSSL
@@ -284,7 +284,7 @@ tls-ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256"
 
 These options only affect the connection from the node to the Tenzir Platform.
 If not specified, the settings fall back to the node-level
-`tenzir.tls.min-version` and `tenzir.tls.ciphers` settings.
+`tenzir.tls.tls-min-version` and `tenzir.tls.tls-ciphers` settings.
 
 ### List plugins
 

--- a/src/content/docs/guides/edge-storage/transform-data-at-rest.mdx
+++ b/src/content/docs/guides/edge-storage/transform-data-at-rest.mdx
@@ -38,7 +38,7 @@ tenzir:
     # size falls below this value.
     disk-budget-low: 0K
     # Seconds between successive disk space checks.
-    disk-budget-check-interval: 90
+    disk-budget-check-interval: 60
 ```
 
 :::note

--- a/src/content/docs/guides/node-setup/configure-tls.mdx
+++ b/src/content/docs/guides/node-setup/configure-tls.mdx
@@ -40,6 +40,7 @@ These settings apply automatically to operators that use TLS, including:
 | `cacert`                 | Path to a CA certificate bundle for server verification             |
 | `certfile`               | Path to a client certificate file                                   |
 | `keyfile`                | Path to a client private key file                                   |
+| `password`               | Password to decrypt the private key in `keyfile`, if encrypted      |
 | `tls-min-version`        | Minimum TLS protocol version: `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` |
 | `tls-ciphers`            | OpenSSL cipher list string                                          |
 
@@ -68,36 +69,36 @@ tenzir:
     certfile: "/etc/tenzir/server.crt"
     keyfile: "/etc/tenzir/server.key"
     tls-client-ca: "/etc/tenzir/client-ca.crt"
-    tls-require-client-cert: true
+    require-client-cert: true
 ```
 
-| Option                    | Description                                                           |
-| ------------------------- | --------------------------------------------------------------------- |
-| `tls-client-ca`           | Path to a CA certificate for validating client certificates           |
-| `tls-require-client-cert` | Require clients to present valid certificates signed by the client CA |
+| Option                | Description                                                           |
+| --------------------- | --------------------------------------------------------------------- |
+| `tls-client-ca`       | Path to a CA certificate for validating client certificates           |
+| `require-client-cert` | Require clients to present valid certificates signed by the client CA |
 
-When `tls-require-client-cert` is enabled, connections from clients without
+When `require-client-cert` is enabled, connections from clients without
 valid certificates are rejected.
 
 ## Platform connection TLS
 
 When connecting a node to the Tenzir Platform, you can configure TLS settings
-specifically for this connection under `plugins.platform`. All options have the
-same semantics as the [node-level TLS config](#node-level-tls-configuration),
-but only apply to the node &harr; platform connection.
+specifically for this connection under `plugins.platform`. These options share
+the semantics of the corresponding [node-level TLS
+settings](#node-level-tls-configuration), but apply only to the node &harr;
+platform connection. The node connects to the platform as an outbound client, so
+the server-side mTLS options (`tls-client-ca`, `require-client-cert`) and the
+`enable` toggle do not apply here.
 
 ```yaml title="tenzir.yaml"
 plugins:
   platform:
-    enable: true
     skip-peer-verification: false
     cacert: "/etc/ssl/certs/ca-certificates.crt"
     certfile: "/etc/tenzir/platform-client.crt"
     keyfile: "/etc/tenzir/platform-client.key"
     tls-min-version: "1.2"
     tls-ciphers: "HIGH:!aNULL:!MD5"
-    tls-client-ca: "/etc/tenzir/platform-ca.crt"
-    tls-require-client-cert: false
 ```
 
 Any option specified here overrides the corresponding node-level

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -406,7 +406,7 @@ tenzir:
       # The definition of the pipeline. Configured pipelines that fail to start
       # cause the node to fail to start.
       definition: |
-        load_tcp "0.0.0.0:34343" { read_suricata schema_only=true }
+        accept_tcp "0.0.0.0:34343" { read_suricata schema_only=true }
         | where event_type != "stats"
         | publish "suricata"
       # Pipelines that encounter an error stop running and show an error state.

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -30,7 +30,7 @@ tenzir:
     # entirely.
     # WARNING: A low retention period may negatively impact the usability of
     # pipeline activity in the Tenzir Platform.
-    #metrics: 7d
+    #metrics: 16d
 
     # How long to keep legacy operator metrics for. Set to 0s to avoid storing
     # these heavy metrics while still making live metrics available.
@@ -356,7 +356,7 @@ tenzir:
     disk-budget-low: 0GiB
 
     # Seconds between successive disk space checks.
-    disk-budget-check-interval: 90
+    disk-budget-check-interval: 60
 
     # When erasing, how many partitions to erase in one go before rechecking
     # the size of the database directory.

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -66,7 +66,7 @@ tenzir:
   #cacert:
 
   # TLS configuration that applies to all operators supporting TLS, such as
-  # from_http, load_tcp, save_tcp, to_opensearch, from_opensearch, to_splunk,
+  # from_http, accept_tcp, to_tcp, to_opensearch, from_opensearch, to_splunk,
   # save_email, and to_fluent_bit. Operators can override these settings
   # individually via their `tls` option.
   tls:
@@ -85,6 +85,9 @@ tenzir:
     # Path to a client private key file.
     #keyfile:
 
+    # Password to decrypt the private key in `keyfile`, if it is encrypted.
+    #password:
+
     # Minimum TLS protocol version.
     # Valid values: "1.0", "1.1", "1.2", "1.3".
     #tls-min-version:
@@ -98,7 +101,7 @@ tenzir:
 
     # Require clients to present valid certificates signed by the client CA
     # (mTLS). Only applies to operators that accept incoming connections.
-    #tls-require-client-cert: false
+    #require-client-cert: false
 
   # The file system path used for persistent state.
   # Defaults to one of the following paths, selecting the first that is
@@ -437,25 +440,21 @@ tenzir:
   secrets:
     # my-secret-name: my-secret-value
 
-  # Configure the interval for experimental trimming of unused memory.
-  malloc-trim-interval: 10min
-
 # Plugin-specific configuration.
 plugins:
   # TLS settings for the connection from the node to the Tenzir Platform.
-  # All options have the same semantics as the node-level tenzir.tls config
-  # block, but only apply to the node <-> platform connection. Any option
-  # specified here overrides the corresponding node-level setting.
+  # These options share the semantics of the corresponding node-level
+  # tenzir.tls settings, but apply only to the node <-> platform connection and
+  # override the matching node-level setting. The node connects to the platform
+  # as an outbound client, so the server-side mTLS options (`tls-client-ca`,
+  # `require-client-cert`) and the `enable` toggle do not apply here.
   platform:
-    #enable:
     #skip-peer-verification:
     #cacert:
     #certfile:
     #keyfile:
     #tls-min-version:
     #tls-ciphers:
-    #tls-client-ca:
-    #tls-require-client-cert:
 
 # The below settings are internal to CAF, and aren't checked by Tenzir directly.
 # Please be careful when changing these options. Note that some CAF options may


### PR DESCRIPTION
Mirrors the corrected example configuration from the code repo and fixes the same documented-vs-actual mismatches in the docs, so docs.tenzir.com matches what the node reads. Verified against the source and a running node (v6.2.0).

**Example configuration (`tenzir.yaml.example`):**

- `tls-require-client-cert` → `require-client-cert` (the prefixed key was ignored, so mTLS was never enforced).
- Document `tenzir.tls.password` (decrypts an encrypted `keyfile`).
- Drop `tenzir.malloc-trim-interval` — read only from `TENZIR_ALLOC_TRIM_INTERVAL` (default `1min`), never the configuration file.
- `plugins.platform`: drop `enable`, `tls-client-ca`, `tls-require-client-cert` — not honored by the outbound platform connection.
- Reference `accept_tcp`/`to_tcp` instead of the removed `load_tcp`/`save_tcp`.
- Correct two defaults: `retention.metrics` (`16d`) and `disk-budget-check-interval` (`60`).

**Guides / explanation:**

- `configure-tls`, `configuration`: correct node-level cipher/version keys to `tls-ciphers`/`tls-min-version`, plus the same `require-client-cert`, `password`, and `plugins.platform` corrections.
- `transform-data-at-rest`: `disk-budget-check-interval` default `60`.

<sub>
⚙️ Code PR: tenzir/tenzir#6365<br>
🎫 References TNZ-728
</sub>
