### PR TITLE
Document package lockfile version bumps

### DIFF
--- a/src/content/docs/guides/packages/maintain-a-changelog.mdx
+++ b/src/content/docs/guides/packages/maintain-a-changelog.mdx
@@ -226,6 +226,8 @@ the latest release, including release candidates.
 By default, `release create` also updates common package-manager version files
 (`package.json`, `pyproject.toml`, `project.toml`, `Cargo.toml`) when present
 in the changelog root or, for `changelog/` projects, in the parent directory.
+When `package.json` has a sibling `package-lock.json`, the lockfile's root
+package version metadata is updated as part of the same release step.
 For advanced repositories with custom release scripts, disable built-in bumps in
 `config.yaml`:
 

--- a/src/content/docs/guides/packages/maintain-a-changelog.mdx
+++ b/src/content/docs/guides/packages/maintain-a-changelog.mdx
@@ -228,6 +228,8 @@ By default, `release create` also updates common package-manager version files
 in the changelog root or, for `changelog/` projects, in the parent directory.
 When `package.json` has a sibling `package-lock.json`, the lockfile's root
 package version metadata is updated as part of the same release step.
+When `pyproject.toml` has a sibling `uv.lock`, `release create` runs `uv lock`
+after updating the manifest so uv regenerates the lockfile metadata.
 For advanced repositories with custom release scripts, disable built-in bumps in
 `config.yaml`:
 

--- a/src/content/docs/reference/ship-framework/index.mdx
+++ b/src/content/docs/reference/ship-framework/index.mdx
@@ -864,7 +864,8 @@ In auto mode, files without a static version field are skipped gracefully:
   `[workspace.package].version` for workspace root manifests. Skips files
   where neither section has a version field.
 - **package.json**: Updates the top-level `version` field. Skips files without
-  one.
+  one. When a sibling `package-lock.json` exists, updates the lockfile's root
+  package version metadata to match.
 - **project.toml**: Same behavior as `pyproject.toml`.
 
 #### Explicit version files
@@ -1171,6 +1172,8 @@ When `modules` is configured, `tenzir-ship validate` checks:
   CLI must parse every detected/configured version file. Use supported files
   (`package.json`, `pyproject.toml`, `project.toml`, `Cargo.toml`) or set
   `release.version_bump_mode: off` and handle updates in your workflow script.
+  When `package.json` has a sibling `package-lock.json`, tenzir-ship also parses
+  the lockfile to keep root package version metadata in sync.
 
 ## Further reading
 

--- a/src/content/docs/reference/ship-framework/index.mdx
+++ b/src/content/docs/reference/ship-framework/index.mdx
@@ -859,7 +859,9 @@ In auto mode, files without a static version field are skipped gracefully:
 
 - **pyproject.toml**: Updates `[project].version`. Falls back to
   `[tool.poetry].version` when `[project]` has `dynamic = ["version"]` or is
-  absent. Skips files where neither section has a static version.
+  absent. Skips files where neither section has a static version. When a
+  sibling `uv.lock` exists, runs `uv lock` after updating the manifest so uv
+  regenerates the lockfile metadata.
 - **Cargo.toml**: Updates `[package].version`. Falls back to
   `[workspace.package].version` for workspace root manifests. Skips files
   where neither section has a version field.
@@ -1174,6 +1176,8 @@ When `modules` is configured, `tenzir-ship validate` checks:
   `release.version_bump_mode: off` and handle updates in your workflow script.
   When `package.json` has a sibling `package-lock.json`, tenzir-ship also parses
   the lockfile to keep root package version metadata in sync.
+  When `pyproject.toml` has a sibling `uv.lock`, tenzir-ship requires `uv` on
+  `PATH` and runs `uv lock` after updating the manifest.
 
 ## Further reading
 


### PR DESCRIPTION
## Summary

- Document that `release create` updates sibling `package-lock.json` root package metadata when bumping `package.json`.
- Document that `release create` runs `uv lock` for `pyproject.toml` projects with sibling `uv.lock` files.
- Add the behavior notes to the package changelog guide and ship framework reference.

## Review

- Check that the wording matches the new `tenzir-ship` behavior and stays scoped to package lockfile version metadata.

<sub>
⚙️ Code PR: tenzir/ship#30
</sub>