### PR TITLE
Link Tenzir Helm chart to its reference page

### DIFF
--- a/src/content/docs/guides/node-setup/deploy-a-node/index.mdx
+++ b/src/content/docs/guides/node-setup/deploy-a-node/index.mdx
@@ -454,12 +454,12 @@ now up and running.
 ## Kubernetes
 
 Deploy one or more `tenzir-node` instances on a Kubernetes cluster with the
-Tenzir Helm chart. The chart deploys nodes only — it does not deploy the
-Tenzir Platform. Each node connects out to a Platform you have already
-provisioned, either cloud-hosted at `app.tenzir.com` or self-hosted through
-the Sovereign Edition. Each entry in the chart's `nodes` list renders as
-its own `StatefulSet` with a persistent volume and a Kubernetes `Service`.
-See <Reference>node/helm-chart</Reference> for the full option surface.
+[Tenzir Helm chart](/reference/node/helm-chart). The chart deploys nodes only
+— it does not deploy the Tenzir Platform. Each node connects out to a
+Platform you have already provisioned, either cloud-hosted at
+`app.tenzir.com` or self-hosted through the Sovereign Edition. Each entry in
+the chart's `nodes` list renders as its own `StatefulSet` with a persistent
+volume and a Kubernetes `Service`.
 
 The chart is distributed as an OCI artifact at
 `oci://ghcr.io/tenzir/charts/tenzir-node`. You need Kubernetes 1.27 or


### PR DESCRIPTION
## 🔍 Problem

Reviewer noted that in the Deploy a node guide's Kubernetes section, the phrase "Tenzir Helm chart" was bare text rather than linking to the chart's reference page on docs.tenzir.com — the natural cross-reference target. Follow-up to tenzir/docs#403, which was merged before the fix landed.

## 🛠️ Solution

Inline-link "Tenzir Helm chart" to `/reference/node/helm-chart`. With the in-paragraph cross-reference in place, the trailing "See [Reference] for the full option surface" sentence becomes redundant and is removed.

## 💬 Review

One-paragraph change, no other content edits.

<sub>
📎 Related: tenzir/docs#403<br>
Assisted-by: Claude Opus 4.7 (Claude Code)
</sub>