### PR TITLE
Fix docs page actions and footer links

### DIFF
--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -626,6 +626,7 @@ for (let i = 0; i < segments.length; i++) {
     flex: 1;
     min-width: 0;
     margin-top: 0;
+    margin-bottom: 0;
     font-size: var(--sl-text-h1);
     line-height: var(--sl-line-height-headings);
     font-weight: var(--tnz-font-semibold);
@@ -966,19 +967,13 @@ for (let i = 0; i < segments.length; i++) {
 
   @media (max-width: 50rem) {
     .page-heading-row {
-      flex-direction: column;
       align-items: flex-start;
-      gap: var(--tnz-space-2);
+      gap: var(--tnz-space-3);
       margin-top: var(--tnz-space-2);
     }
 
     .page-actions {
-      margin-top: 0;
-    }
-
-    .page-actions__menu {
-      inset-inline-start: 0;
-      inset-inline-end: auto;
+      margin-top: 0.25em;
     }
 
     .c-breadcrumbs {

--- a/src/components/TenzirFooter.astro
+++ b/src/components/TenzirFooter.astro
@@ -27,7 +27,7 @@ const resolveHref = (href: string) => {
 const footerSections: Record<string, FooterLink[]> = {
   Product: [
     { text: "Overview", href: "https://tenzir.com" },
-    { text: "Integrations", href: "https://tenzir.com/integrations" },
+    { text: "Integrations", href: "https://tenzir.com/product/integrations" },
   ],
   Resources: [
     { text: "Blog", href: "https://tenzir.com/blog" },
@@ -65,9 +65,15 @@ const footerSections: Record<string, FooterLink[]> = {
 };
 
 const legalLinks = [
-  { text: "Legal Notice", href: "https://tenzir.com/legal" },
-  { text: "Terms and Conditions", href: "https://tenzir.com/terms" },
-  { text: "Privacy Statement", href: "https://tenzir.com/privacy" },
+  { text: "Legal Notice", href: "https://tenzir.com/legal/notice" },
+  {
+    text: "Terms and Conditions",
+    href: "https://tenzir.com/legal/terms-and-conditions",
+  },
+  {
+    text: "Privacy Statement",
+    href: "https://tenzir.com/legal/privacy-statement",
+  },
 ];
 ---
 


### PR DESCRIPTION
## 🔍 Problem

- The new copy-for-LLM action drops below page titles on mobile.
- Several footer links point at stale Tenzir website routes.

## 🛠️ Solution

- Keep page title actions in the mobile title row.
- Update footer links to the current integrations and legal page routes.

## 💬 Review

- Focus on the mobile title layout and whether the footer route choices match the current website IA.