### PR TITLE
Document ignore_case string functions

### DIFF
--- a/src/content/docs/guides/transformation/manipulate-strings.mdx
+++ b/src/content/docs/guides/transformation/manipulate-strings.mdx
@@ -214,6 +214,43 @@ Pattern matching functions:
 - <Fn>starts_with</Fn> - Check string prefix
 - <Fn>ends_with</Fn> - Check string suffix
 
+## Match case-insensitively
+
+Many string functions accept an `ignore_case` argument so you can match without
+first normalizing case with <Fn>to_lower</Fn>. Comparison uses full Unicode case
+folding, so it handles cases like the German `ß` folding to `ss`:
+
+```tql
+from {method: "Get", host: "Example.COM", street: "STRASSE"}
+is_get = method.starts_with("get", ignore_case=true)
+same_host = equals(host, "example.com", ignore_case=true)
+has_strasse = street.contains("straße", ignore_case=true)
+```
+
+```tql
+{
+  method: "Get",
+  host: "Example.COM",
+  street: "STRASSE",
+  is_get: true,
+  same_host: true,
+  has_strasse: true,
+}
+```
+
+Functions that support `ignore_case`:
+
+- <Fn>starts_with</Fn> - Check string prefix
+- <Fn>ends_with</Fn> - Check string suffix
+- <Fn>contains</Fn> - Search for a substring
+- <Fn>equals</Fn> - Compare two strings for equality
+- <Fn>replace</Fn> - Replace a literal substring
+- <Fn>split</Fn> - Split on a literal delimiter
+
+The argument defaults to `false`, preserving case-sensitive matching. For regex
+functions such as <Fn>match_regex</Fn>, <Fn>replace_regex</Fn>, and
+<Fn>split_regex</Fn>, use the inline `(?i)` flag instead.
+
 ## Validate string content
 
 Check what type of characters a string contains:

--- a/src/content/docs/guides/transformation/manipulate-strings.mdx
+++ b/src/content/docs/guides/transformation/manipulate-strings.mdx
@@ -221,17 +221,15 @@ first normalizing case with <Fn>to_lower</Fn>. Comparison uses full Unicode case
 folding, so it handles cases like the German `ß` folding to `ss`:
 
 ```tql
-from {method: "Get", host: "Example.COM", street: "STRASSE"}
-is_get = method.starts_with("get", ignore_case=true)
-same_host = equals(host, "example.com", ignore_case=true)
-has_strasse = street.contains("straße", ignore_case=true)
+from {
+  is_get: "Get".starts_with("get", ignore_case=true),
+  same_host: "Example.COM".equals("example.com", ignore_case=true),
+  has_strasse: "STRASSE".contains("straße", ignore_case=true),
+}
 ```
 
 ```tql
 {
-  method: "Get",
-  host: "Example.COM",
-  street: "STRASSE",
   is_get: true,
   same_host: true,
   has_strasse: true,

--- a/src/content/docs/reference/functions.mdx
+++ b/src/content/docs/reference/functions.mdx
@@ -475,6 +475,10 @@ functions:
     description: 'Checks if a string ends with a specified substring.'
     example: '"hello".ends_with("lo")'
     path: 'reference/functions/ends_with'
+  - name: 'equals'
+    description: 'Checks whether two strings are equal.'
+    example: 'equals("Get", "GET", ignore_case=true)'
+    path: 'reference/functions/equals'
   - name: 'is_alnum'
     description: 'Checks if a string is alphanumeric.'
     example: '"hello123".is_alnum()'
@@ -2144,6 +2148,14 @@ parent_dir("/path/to/log.json")
 
 ```tql
 "hello".ends_with("lo")
+```
+
+</ReferenceCard>
+
+<ReferenceCard title="equals" description="Checks whether two strings are equal." href="/reference/functions/equals">
+
+```tql
+equals("Get", "GET", ignore_case=true)
 ```
 
 </ReferenceCard>

--- a/src/content/docs/reference/functions/contains.mdx
+++ b/src/content/docs/reference/functions/contains.mdx
@@ -4,10 +4,10 @@ category: Utility
 example: 'this.contains("value")'
 ---
 
-Searches for a value within data structures recursively.
+Searches recursively for a value within data structures.
 
 ```tql
-contains(input:any, target:any, [exact:bool]) -> bool
+contains(input:any, target:any, [exact:bool], [ignore_case:bool]) -> bool
 ```
 
 ## Description
@@ -15,6 +15,8 @@ contains(input:any, target:any, [exact:bool]) -> bool
 The `contains` function returns `true` if the `target` value is found anywhere within the `input` data structure, and `false` otherwise. The search is performed recursively, meaning it will look inside nested records, lists, and other compound data structures.
 
 By default, strings match via substring search and subnets use containment checks. When `exact` is set to `true`, only exact matches are considered.
+
+Set `ignore_case=true` to compare strings using full Unicode case folding instead of case-sensitive matching.
 
 ### `input: any`
 
@@ -30,6 +32,12 @@ Controls the matching behavior:
 
 - When `false` (default): strings match via substring search, and subnets/IPs use containment checks
 - When `true`: only exact equality matches are considered
+
+### `ignore_case: bool` (optional)
+
+If `true`, string comparisons use full Unicode case folding.
+
+Defaults to `false`.
 
 ## Examples
 
@@ -168,6 +176,30 @@ exact_no_match = contains(message, "Hello, World", exact=true)
   exact_match: false,
   partial_no_match: false,
   exact_no_match: false,
+}
+```
+
+### Search case-insensitively
+
+```tql
+from {
+  record: {host: "HOST-A"},
+  value: "STRASSE",
+}
+record_match = contains(record, "host-a", ignore_case=true)
+value_match = contains(value, "straße", ignore_case=true)
+exact_match = contains(value, "straße", exact=true, ignore_case=true)
+```
+
+```tql
+{
+  record: {
+    host: "HOST-A",
+  },
+  value: "STRASSE",
+  record_match: true,
+  value_match: true,
+  exact_match: true,
 }
 ```
 

--- a/src/content/docs/reference/functions/contains.mdx
+++ b/src/content/docs/reference/functions/contains.mdx
@@ -223,5 +223,7 @@ exact_subnet = contains(subnet, 10.0.0.0/8, exact=true)
 
 ## See Also
 
+- <Fn>equals</Fn>
 - <Fn>has</Fn>
 - <Fn>match_regex</Fn>
+- <Guide>transformation/manipulate-strings</Guide>

--- a/src/content/docs/reference/functions/contains.mdx
+++ b/src/content/docs/reference/functions/contains.mdx
@@ -7,7 +7,7 @@ example: 'this.contains("value")'
 Searches recursively for a value within data structures.
 
 ```tql
-contains(input:any, target:any, [exact:bool], [ignore_case:bool]) -> bool
+contains(input:any, target:any, [exact=bool], [ignore_case=bool]) -> bool
 ```
 
 ## Description

--- a/src/content/docs/reference/functions/ends_with.mdx
+++ b/src/content/docs/reference/functions/ends_with.mdx
@@ -7,7 +7,7 @@ example: '"hello".ends_with("lo")'
 Checks whether a string ends with a specified substring.
 
 ```tql
-ends_with(x:string, suffix:string, [ignore_case:bool]) -> bool
+ends_with(x:string, suffix:string, [ignore_case=bool]) -> bool
 ```
 
 ## Description

--- a/src/content/docs/reference/functions/ends_with.mdx
+++ b/src/content/docs/reference/functions/ends_with.mdx
@@ -4,16 +4,19 @@ category: String/Inspection
 example: '"hello".ends_with("lo")'
 ---
 
-Checks if a string ends with a specified substring.
+Checks whether a string ends with a specified substring.
 
 ```tql
-ends_with(x:string, suffix:string) -> bool
+ends_with(x:string, suffix:string, [ignore_case:bool]) -> bool
 ```
 
 ## Description
 
 The `ends_with` function returns `true` if `x` ends with `suffix` and `false`
 otherwise.
+
+Set `ignore_case=true` to compare using full Unicode case folding instead of
+case-sensitive matching.
 
 ## Examples
 
@@ -25,6 +28,22 @@ from {x: "hello".ends_with("lo")}
 
 ```tql
 {x: true}
+```
+
+### Compare case-insensitively
+
+```tql
+from {
+  ascii: "/API/v1/Users".ends_with("USERS", ignore_case=true),
+  unicode: "Fußstraße".ends_with("STRASSE", ignore_case=true),
+}
+```
+
+```tql
+{
+  ascii: true,
+  unicode: true,
+}
 ```
 
 ## See Also

--- a/src/content/docs/reference/functions/equals.mdx
+++ b/src/content/docs/reference/functions/equals.mdx
@@ -7,7 +7,7 @@ example: 'equals("Get", "GET", ignore_case=true)'
 Checks whether two strings are equal.
 
 ```tql
-equals(x:string, y:string, [ignore_case:bool]) -> bool
+equals(x:string, y:string, [ignore_case=bool]) -> bool
 ```
 
 ## Description

--- a/src/content/docs/reference/functions/equals.mdx
+++ b/src/content/docs/reference/functions/equals.mdx
@@ -1,0 +1,74 @@
+---
+title: equals
+category: String/Inspection
+example: 'equals("Get", "GET", ignore_case=true)'
+---
+
+Checks whether two strings are equal.
+
+```tql
+equals(x:string, y:string, [ignore_case:bool]) -> bool
+```
+
+## Description
+
+The `equals` function returns `true` if `x` and `y` are equal and `false`
+otherwise.
+
+Set `ignore_case=true` to compare using full Unicode case folding instead of
+case-sensitive matching.
+
+### `x: string`
+
+The left-hand string to compare.
+
+### `y: string`
+
+The right-hand string to compare.
+
+### `ignore_case: bool` (optional)
+
+If `true`, compares strings using full Unicode case folding.
+
+Defaults to `false`.
+
+## Examples
+
+### Compare strings case-sensitively
+
+```tql
+from {
+  same: equals("abc", "abc"),
+  different: equals("abc", "ABC"),
+}
+```
+
+```tql
+{
+  same: true,
+  different: false,
+}
+```
+
+### Compare strings case-insensitively
+
+```tql
+from {
+  ascii: equals("Get", "GET", ignore_case=true),
+  unicode: equals("STRASSE", "straße", ignore_case=true),
+}
+```
+
+```tql
+{
+  ascii: true,
+  unicode: true,
+}
+```
+
+## See Also
+
+- <Fn>contains</Fn>
+- <Fn>ends_with</Fn>
+- <Fn>starts_with</Fn>
+- <Guide>transformation/manipulate-strings</Guide>

--- a/src/content/docs/reference/functions/replace.mdx
+++ b/src/content/docs/reference/functions/replace.mdx
@@ -7,7 +7,7 @@ example: '"hello".replace("o", "a")'
 Replaces literal substrings within a string.
 
 ```tql
-replace(x:string, pattern:string, replacement:string, [max:int], [ignore_case:bool]) -> string
+replace(x:string, pattern:string, replacement:string, [max=int], [ignore_case=bool]) -> string
 ```
 
 ## Description

--- a/src/content/docs/reference/functions/replace.mdx
+++ b/src/content/docs/reference/functions/replace.mdx
@@ -4,10 +4,10 @@ category: String/Transformation
 example: '"hello".replace("o", "a")'
 ---
 
-Replaces characters within a string.
+Replaces literal substrings within a string.
 
 ```tql
-replace(x:string, pattern:string, replacement:string, [max=int]) -> string
+replace(x:string, pattern:string, replacement:string, [max:int], [ignore_case:bool]) -> string
 ```
 
 ## Description
@@ -15,6 +15,9 @@ replace(x:string, pattern:string, replacement:string, [max=int]) -> string
 The `replace` function returns a new string where occurrences of `pattern` in `x`
 are replaced with `replacement`, up to `max` times. If `max` is omitted, all
 occurrences are replaced.
+
+Set `ignore_case=true` to match using full Unicode case folding instead of
+case-sensitive matching.
 
 ### `x: string`
 
@@ -33,6 +36,12 @@ The replacement value for `pattern`.
 The maximum number of replacements to perform.
 
 If the option is not set, all occurrences are replaced.
+
+### `ignore_case: bool` (optional)
+
+If `true`, matches the literal `pattern` using full Unicode case folding.
+
+Defaults to `false`.
 
 ## Examples
 
@@ -54,6 +63,22 @@ from {x: "hello".replace("l", "r", max=1)}
 
 ```tql
 {x: "herlo"}
+```
+
+### Replace case-insensitively
+
+```tql
+from {
+  ascii: "Connection ERROR".replace("error", "warning", ignore_case=true),
+  unicode: "Fußstraße".replace("STRASSE", "weg", ignore_case=true),
+}
+```
+
+```tql
+{
+  ascii: "Connection warning",
+  unicode: "Fußweg",
+}
 ```
 
 ## See Also

--- a/src/content/docs/reference/functions/split.mdx
+++ b/src/content/docs/reference/functions/split.mdx
@@ -7,7 +7,7 @@ example: 'split("a,b,c", ",")'
 Splits a string into substrings.
 
 ```tql
-split(x:string, pattern:string, [max:int], [reverse:bool], [ignore_case:bool]) -> list
+split(x:string, pattern:string, [max=int], [reverse=bool], [ignore_case=bool]) -> list
 ```
 
 ## Description

--- a/src/content/docs/reference/functions/split.mdx
+++ b/src/content/docs/reference/functions/split.mdx
@@ -7,14 +7,15 @@ example: 'split("a,b,c", ",")'
 Splits a string into substrings.
 
 ```tql
-split(x:string, pattern:string, [max:int], [reverse:bool]) -> list
+split(x:string, pattern:string, [max:int], [reverse:bool], [ignore_case:bool]) -> list
 ```
 
 ## Description
 
 The `split` function splits the input string `x` into a list of substrings
 using the specified `pattern`. Optional arguments allow limiting the number
-of splits (`max`) and reversing the splitting direction (`reverse`).
+of splits (`max`), reversing the splitting direction (`reverse`), and
+matching the literal delimiter case-insensitively (`ignore_case`).
 
 ### `x: string`
 
@@ -33,6 +34,12 @@ Defaults to `0`, meaning no limit.
 ### `reverse: bool (optional)`
 
 If `true`, splits from the end of the string.
+
+Defaults to `false`.
+
+### `ignore_case: bool` (optional)
+
+If `true`, matches the literal `pattern` using full Unicode case folding.
 
 Defaults to `false`.
 
@@ -56,6 +63,22 @@ from {xs: split("a-b-c", "-", max=1)}
 
 ```tql
 {xs: ["a", "b-c"]}
+```
+
+### Split case-insensitively
+
+```tql
+from {
+  ascii: split("/API/v1/Users", "api", ignore_case=true),
+  unicode: split("Fußstraße", "STRASSE", ignore_case=true),
+}
+```
+
+```tql
+{
+  ascii: ["/", "/v1/Users"],
+  unicode: ["Fuß", ""],
+}
 ```
 
 ## See Also

--- a/src/content/docs/reference/functions/starts_with.mdx
+++ b/src/content/docs/reference/functions/starts_with.mdx
@@ -4,16 +4,19 @@ category: String/Inspection
 example: '"hello".starts_with("he")'
 ---
 
-Checks if a string starts with a specified substring.
+Checks whether a string starts with a specified substring.
 
 ```tql
-starts_with(x:string, prefix:string) -> bool
+starts_with(x:string, prefix:string, [ignore_case:bool]) -> bool
 ```
 
 ## Description
 
 The `starts_with` function returns `true` if `x` starts with `prefix` and
 `false` otherwise.
+
+Set `ignore_case=true` to compare using full Unicode case folding instead of
+case-sensitive matching.
 
 ## Examples
 
@@ -25,6 +28,22 @@ from {x: "hello".starts_with("he")}
 
 ```tql
 {x: true}
+```
+
+### Compare case-insensitively
+
+```tql
+from {
+  ascii: "Get".starts_with("get", ignore_case=true),
+  unicode: "STRASSE".starts_with("straße", ignore_case=true),
+}
+```
+
+```tql
+{
+  ascii: true,
+  unicode: true,
+}
 ```
 
 ## See Also

--- a/src/content/docs/reference/functions/starts_with.mdx
+++ b/src/content/docs/reference/functions/starts_with.mdx
@@ -7,7 +7,7 @@ example: '"hello".starts_with("he")'
 Checks whether a string starts with a specified substring.
 
 ```tql
-starts_with(x:string, prefix:string, [ignore_case:bool]) -> bool
+starts_with(x:string, prefix:string, [ignore_case=bool]) -> bool
 ```
 
 ## Description


### PR DESCRIPTION
## 🔍 Problem

- The docs do not describe the new `ignore_case` argument on string functions.
- There is no reference page yet for `equals`.

## 🛠️ Solution

- Document `ignore_case` on `starts_with`, `ends_with`, `contains`,
  `replace`, and `split`.
- Add a new `equals` reference page.
- Add examples for both ASCII and Unicode case-folding behavior.

## 💬 Review

- Focus on the signatures and examples for the new case-insensitive behavior.
- `replace_regex` and `split_regex` are intentionally unchanged here as well.

<sub>
⚙️ Code PR: tenzir/tenzir#6378<br>
🎫 References TNZ-696
</sub>
