### PR TITLE
Add Tenzir Helm Charts to the changelog

### DIFF
--- a/src/changelog-projects.json
+++ b/src/changelog-projects.json
@@ -28,5 +28,10 @@
     "icon": "sun",
     "color": "yellow",
     "repository": "tenzir/tree-sitter-tql"
+  },
+  "tenzir-helm-charts": {
+    "icon": "server",
+    "color": "lightblue",
+    "repository": "tenzir/helm-charts"
   }
 }

--- a/src/components/ChangelogLanding.astro
+++ b/src/components/ChangelogLanding.astro
@@ -44,7 +44,7 @@ const hasGeneratedLanding = changelogLandingProjects.length > 0;
         ))}
       </div>
 
-      <hr />
+      <hr style="margin-block: var(--tnz-space-16) var(--tnz-space-10);" />
 
       <p>
         For general release announcements and deeper dives into selected


### PR DESCRIPTION
## 🔍 Problem

- The `tenzir/helm-charts` project shipped releases (now at v0.1.0) but was not registered in the changelog, so its release notes never appeared on the changelog overview.
- On the changelog landing page the divider sat flush against the project cards: the grid and `<hr>` are nested inside the landing component's root element, so Starlight's flow-spacing rule (direct children of `.sl-markdown-content` only) never applied vertical margin to the divider.

## 🛠️ Solution

- Register `tenzir-helm-charts` in `src/changelog-projects.json`, ordered last, with a generic `server` icon (matching the non-logo style of the other entries) and the `lightblue` brand color.
- Give the divider explicit margins via brand spacing tokens so it reads as centered between the cards and the footer text.

## 💬 Review

- The project key must match the `id` declared in `tenzir/news` (`helm-charts/changelog/config.yaml` → `tenzir-helm-charts`); the generated pages/feeds are gitignored and produced by `bun run generate:changelog` in CI.
- Divider spacing is intentionally asymmetric (`space-16` top / `space-10` bottom) to compensate for the footer space below, so it appears visually centered.
