### PR TITLE
[codex] Document outbound HTTP proxy settings

### DIFF
--- a/src/content/docs/explanations/configuration.mdx
+++ b/src/content/docs/explanations/configuration.mdx
@@ -135,6 +135,59 @@ Sometimes, users may wish to run Tenzir without side effects, e.g., when
 wrapping Tenzir in their own scripts. Run with `--bare-mode` to disable looking
 at all system- and user-specified configuration paths.
 
+## Outbound Proxy Configuration
+
+Tenzir can route outbound HTTP, HTTPS, and gRPC traffic through an HTTP proxy.
+Configure `tenzir.http-proxy` for `http://` targets and `tenzir.https-proxy`
+for `https://` and gRPC targets:
+
+```yaml title="<configdir>/tenzir/tenzir.yaml"
+tenzir:
+  http-proxy: http://proxy.example.com:3128
+  https-proxy: http://user:password@proxy.example.com:3128
+  no-proxy: .internal,10.0.0.0/8
+```
+
+Proxy URLs must include an explicit port. They may use `http://` or
+`https://`; for gRPC-backed clients, use an `http://` proxy URL because gRPC
+Core rejects `https://` proxy URLs.
+
+If your deployment sets gRPC-specific environment variables such as
+`grpc_proxy` or `no_grpc_proxy`, gRPC Core may prefer those over the standard
+proxy environment variables that Tenzir mirrors from its configuration.
+
+If the Tenzir settings are unset, Tenzir falls back to the corresponding
+environment variables:
+
+- `tenzir.http-proxy`: `TENZIR_HTTP_PROXY`, `HTTP_PROXY`, then `http_proxy`
+- `tenzir.https-proxy`: `TENZIR_HTTPS_PROXY`, `HTTPS_PROXY`, then
+  `https_proxy`
+- `tenzir.no-proxy`: `TENZIR_NO_PROXY`, `NO_PROXY`, then `no_proxy`
+
+Only the generic proxy variables have lowercase aliases; the `TENZIR_*`
+variables are uppercase-only.
+
+Empty proxy environment variables are ignored, except that an explicitly empty
+`tenzir.no-proxy` or `TENZIR_NO_PROXY` disables fallback to the generic
+`NO_PROXY` and `no_proxy` environment variables.
+
+The `tenzir.no-proxy` setting accepts comma-separated entries with the same
+matching behavior as libcurl's `NO_PROXY`: host and domain entries match on
+label boundaries, `*` matches every host, and CIDR entries match IP literals.
+Loopback destinations such as `localhost`, `127.0.0.1`, and `::1` always bypass
+the proxy.
+
+At startup, Tenzir also mirrors the resolved proxy settings into the standard
+proxy environment variables, so outbound integrations follow the same
+configuration.
+
+For normal `s3://bucket/...` URLs, `from_s3` and `to_s3` select the proxy from
+the S3 request scheme rather than matching `no-proxy` against the URI host,
+because that host is the bucket name and not the actual service endpoint. When
+`endpoint_override` is set, Tenzir can apply `no-proxy` to the override host.
+Google Cloud Storage and Azure Blob Storage apply `no-proxy` to the real service
+endpoint host.
+
 ## TLS Configuration
 
 Tenzir provides node-level TLS configuration that applies to all operators and

--- a/src/content/docs/guides/node-setup/configure-a-node.mdx
+++ b/src/content/docs/guides/node-setup/configure-a-node.mdx
@@ -35,6 +35,25 @@ enable this feature, which is disabled by default.
 Learn more about [pipeline subprocesses](/explanations/node#pipeline-subprocesses)
 and their trade-offs.
 
+## Route outbound traffic through an HTTP proxy
+
+Configure `tenzir.http-proxy` and `tenzir.https-proxy` when outbound operators
+must reach external services through a proxy:
+
+```yaml title="<configdir>/tenzir/tenzir.yaml"
+tenzir:
+  http-proxy: http://proxy.example.com:3128
+  https-proxy: http://proxy.example.com:3128
+  no-proxy: .internal,10.0.0.0/8
+```
+
+The proxy URL must include an explicit port. Use `tenzir.no-proxy` to bypass
+the proxy for internal hosts or IP ranges.
+
+See <Explanation>configuration#outbound-proxy-configuration</Explanation> for
+the full precedence rules, environment variable fallbacks, and how proxy
+settings apply.
+
 ## Configure the platform TLS connection
 
 By default, the platform connection uses TLS and picks up the settings from the

--- a/src/content/docs/integrations/http.mdx
+++ b/src/content/docs/integrations/http.mdx
@@ -53,6 +53,13 @@ that turns incoming requests into pipeline events. This is useful for receiving
 webhooks, building custom API endpoints, or ingesting data pushed by external
 systems.
 
+## Proxies
+
+Outbound HTTP requests from <Op>from_http</Op> and <Op>to_http</Op> use the
+node-level HTTP proxy settings. See
+<Explanation>configuration#outbound-proxy-configuration</Explanation> to
+configure proxy URLs, bypass rules, and environment variable fallbacks.
+
 ## SSL/TLS
 
 All HTTP operators support TLS. Pass `tls={}` to enable TLS with defaults, or

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -24,6 +24,44 @@ tenzir:
   # without retries.
   connection-retry-delay: 3s
 
+  # URL of an HTTP/HTTPS proxy used for outbound `http://` targets. The URL
+  # must include an explicit port, and may carry Basic-auth userinfo
+  # (`http://user:pw@proxy.example.com:3128`). If unset,
+  # `TENZIR_HTTP_PROXY`, `HTTP_PROXY`, or `http_proxy` from the environment are
+  # used as a fallback, in that order.
+  #http-proxy: http://http-proxy.example.com:3128
+
+  # URL of an HTTP/HTTPS proxy used for outbound `https://` and gRPC targets.
+  # The URL must include an explicit port. gRPC Core accepts only `http://`
+  # proxy URLs; `https://` proxy URLs are rejected by gRPC's own proxy mapper.
+  # If unset, `TENZIR_HTTPS_PROXY`, `HTTPS_PROXY`, or `https_proxy` from the
+  # environment are used as a fallback, in that order.
+  #https-proxy: http://https-proxy.example.com:3128
+
+  # Comma-separated list of hostnames to bypass the proxy for, using the same
+  # semantics as libcurl's `NO_PROXY`: domain entries match the hostname itself
+  # and subdomains on a label boundary (`internal` matches `internal`,
+  # `host.internal`, and `a.b.internal`, but not `notinternal`); `*` matches
+  # everything; CIDR entries match IP-literal hosts only; `localhost` and
+  # IPv4/IPv6 loopback addresses always bypass.
+  # Falls back to `TENZIR_NO_PROXY`, `NO_PROXY`, or `no_proxy` from the
+  # environment when unset, in that order. An explicitly empty
+  # `TENZIR_NO_PROXY` or configured `no-proxy` value disables fallback to the
+  # generic `NO_PROXY` / `no_proxy` environment variables.
+  # Lowercase aliases exist only for the generic proxy variables; the
+  # `TENZIR_*` names are uppercase-only.
+  #
+  # Note on cloud schemes: for normal `s3://bucket/...` URLs, `from_s3` /
+  # `to_s3` select the proxy from the request scheme because the URI host is
+  # the bucket name rather than the real S3 endpoint. When `endpoint_override`
+  # is set, Tenzir can apply `no-proxy` to the override host.
+  # `from_google_cloud_storage` and `from_azure_blob_storage` route
+  # through libcurl-backed SDKs that pick up the proxy from the
+  # `HTTPS_PROXY` / `NO_PROXY` environment mirror and therefore *do*
+  # honour `no-proxy` against the real endpoint hostname
+  # (`storage.googleapis.com`, `blob.core.windows.net`, etc.).
+  #no-proxy: .internal,10.0.0.0/8
+
   # Configure retention policies.
   retention:
     # How long to keep metrics for. Set to 0s to disable metrics retention


### PR DESCRIPTION
## Summary

- Document `tenzir.http-proxy`, `tenzir.https-proxy`, and `tenzir.no-proxy` in the node configuration reference.
- Add an outbound proxy configuration section that explains precedence, environment fallback, gRPC caveats, no-proxy matching, and affected outbound operators.
- Add practical pointers from the node setup guide and HTTP integration page.

