### PR TITLE
Document reference year parsing

### DIFF
--- a/src/content/docs/reference/functions/parse_syslog.mdx
+++ b/src/content/docs/reference/functions/parse_syslog.mdx
@@ -200,6 +200,58 @@ output = input.parse_syslog()
 If the leading brackets don't contain valid structured data, the parser leaves
 the content intact and omits the `structured_data` field.
 
+### Parse an RFC 3164 timestamp
+
+RFC 3164/BSD syslog timestamps don't include a year or timezone, so
+`parse_syslog` keeps the timestamp as a string. Use <Fn>parse_time</Fn> with a
+`reference` timestamp to choose the closest year. For live ingestion, use
+`now()`:
+
+```tql
+from {
+  input: "<34>May  5 18:16:21 mymachine PROGRAM: Freeform message",
+}
+event = input.parse_syslog()
+event.timestamp = event.timestamp.parse_time(
+  "%b %e %H:%M:%S",
+  reference=now(),
+)
+```
+
+For historic data, pass a fixed reference to make the result deterministic:
+
+```tql
+event.timestamp = event.timestamp.parse_time(
+  "%b %e %H:%M:%S",
+  reference=2026-05-05T00:00:00Z,
+)
+```
+
+```tql
+{
+  input: "<34>May  5 18:16:21 mymachine PROGRAM: Freeform message",
+  event: {
+    facility: 4,
+    severity: 2,
+    timestamp: 2026-05-05T18:16:21Z,
+    hostname: "mymachine",
+    app_name: "PROGRAM",
+    process_id: null,
+    content: "Freeform message",
+  },
+}
+```
+
+If you know the sender's timezone, add the UTC offset to the string and include
+`%z` in the format:
+
+```tql
+event.timestamp = (event.timestamp + " -1000").parse_time(
+  "%b %e %H:%M:%S %z",
+  reference=2026-05-06T00:00:00Z,
+)
+```
+
 ## See Also
 
 - <Op>read_syslog</Op>

--- a/src/content/docs/reference/functions/parse_syslog.mdx
+++ b/src/content/docs/reference/functions/parse_syslog.mdx
@@ -221,6 +221,10 @@ event.timestamp = event.timestamp.parse_time(
 For historic data, pass a fixed reference to make the result deterministic:
 
 ```tql
+from {
+  input: "<34>May  5 18:16:21 mymachine PROGRAM: Freeform message",
+}
+event = input.parse_syslog()
 event.timestamp = event.timestamp.parse_time(
   "%b %e %H:%M:%S",
   reference=2026-05-05T00:00:00Z,

--- a/src/content/docs/reference/functions/parse_time.mdx
+++ b/src/content/docs/reference/functions/parse_time.mdx
@@ -65,9 +65,9 @@ allowed format specifiers are the same as for `strptime(3)`:
 
 ### `reference = time (optional)`
 
-An optional timestamp that provides date context for supported formats that
-don't include a complete date. Parsed date fields win, and missing time fields
-don't come from `reference`.
+An optional timestamp that provides date context for formats whose year is
+missing. Parsed date fields win, and missing time fields don't come from
+`reference`.
 
 If the input contains a month and day but no year, `parse_time` chooses the
 year that places the parsed timestamp closest to the reference time.
@@ -75,9 +75,7 @@ year that places the parsed timestamp closest to the reference time.
 If the input contains no date fields, `parse_time` uses the date from
 `reference`.
 
-`reference` doesn't fill only a missing month or only a missing day. It also
-doesn't resolve week-based dates such as formats using `%U`, `%V`, or `%W`
-without a year. In these cases, `parse_time` returns null and emits a warning.
+Other incomplete date formats return null and emit a warning.
 
 If `reference` is null and a date field is missing, `parse_time` returns null
 and emits a warning. If `format` includes a complete date, `parse_time` emits a

--- a/src/content/docs/reference/functions/parse_time.mdx
+++ b/src/content/docs/reference/functions/parse_time.mdx
@@ -65,12 +65,19 @@ allowed format specifiers are the same as for `strptime(3)`:
 
 ### `reference = time (optional)`
 
-An optional timestamp that provides date context for formats that don't include
-a complete date. Parsed date fields win. Missing year, month, and day fields
-come from `reference`; missing time fields do not.
+An optional timestamp that provides date context for supported formats that
+don't include a complete date. Parsed date fields win, and missing time fields
+don't come from `reference`.
 
-If the input contains month and day but no year, `parse_time` chooses the year
-that places the parsed timestamp closest to the reference time.
+If the input contains a month and day but no year, `parse_time` chooses the
+year that places the parsed timestamp closest to the reference time.
+
+If the input contains no date fields, `parse_time` uses the date from
+`reference`.
+
+`reference` doesn't fill only a missing month or only a missing day. It also
+doesn't resolve week-based dates such as formats using `%U`, `%V`, or `%W`
+without a year. In these cases, `parse_time` returns null and emits a warning.
 
 If `reference` is null and a date field is missing, `parse_time` returns null
 and emits a warning. If `format` includes a complete date, `parse_time` emits a

--- a/src/content/docs/reference/functions/parse_time.mdx
+++ b/src/content/docs/reference/functions/parse_time.mdx
@@ -72,10 +72,14 @@ missing. Parsed date fields win, and missing time fields don't come from
 If the input contains a month and day but no year, `parse_time` chooses the
 year that places the parsed timestamp closest to the reference time.
 
-If the input contains no date fields, `parse_time` uses the date from
-`reference`.
+If the input contains no date fields, `parse_time` chooses the date that
+places the parsed time of day closest to the reference time. Times shortly
+before or after midnight resolve to the adjacent day.
 
-Other incomplete date formats return null and emit a warning.
+Other incomplete date formats, including dates built from week numbers such as
+`%G %V %u`, return null and emit a warning. ISO week fields next to a complete
+calendar date need no filling, so `parse_time` parses the date and ignores
+`reference`.
 
 If `reference` is null and a date field is missing, `parse_time` returns null
 and emits a warning. If `format` includes a complete date, `parse_time` emits a
@@ -141,6 +145,26 @@ timestamp = (bsd_time + " +0400").parse_time(
 
 ```tql
 {timestamp: 2026-05-05T14:16:21Z}
+```
+
+### Parse a time without a date
+
+Formats without date fields take their date from `reference`, choosing the day
+that places the time of day closest to it. Here the reference is two seconds
+past midnight, so the timestamp resolves to the previous day:
+
+```tql
+from {
+  timestamp: "23:59:58",
+}
+timestamp = timestamp.parse_time(
+  "%H:%M:%S",
+  reference=2026-06-24T00:00:02Z,
+)
+```
+
+```tql
+{timestamp: 2026-06-23T23:59:58Z}
 ```
 
 ## See Also

--- a/src/content/docs/reference/functions/parse_time.mdx
+++ b/src/content/docs/reference/functions/parse_time.mdx
@@ -7,7 +7,7 @@ example: '"10/11/2012".parse_time("%d/%m/%Y")'
 Parses a time from a string that follows a specific format.
 
 ```tql
-parse_time(input: string, format: string) -> time
+parse_time(input: string, format: string, [reference=time]) -> time
 ```
 
 ## Description
@@ -63,6 +63,21 @@ allowed format specifiers are the same as for `strptime(3)`:
 |   `%z`    | UTC offset                             | `+0000`, `-0430`          |
 |   `%Z`    | Time zone abbreviation                 | `UTC`, `EST`              |
 
+### `reference = time (optional)`
+
+An optional timestamp that provides date context for formats that don't include
+a complete date. Parsed date fields win. Missing year, month, and day fields
+come from `reference`; missing time fields do not.
+
+If the input contains month and day but no year, `parse_time` chooses the year
+that places the parsed timestamp closest to the reference time.
+
+If `reference` is null and a date field is missing, `parse_time` returns null
+and emits a warning. If `format` includes a complete date, `parse_time` emits a
+warning that it ignored `reference`. If `format` doesn't include a year and you
+don't set `reference`, `parse_time` uses 1970 and emits a deprecation warning
+because this will become an error in a future release.
+
 ## Examples
 
 ### Parse a timestamp
@@ -76,6 +91,51 @@ x = x.parse_time("%Y-%m-%d+%H:%M:%S")
 
 ```tql
 {x: 2024-12-31T12:59:42.000000}
+```
+
+### Parse a BSD syslog timestamp
+
+BSD syslog timestamps don't include a year. Use `reference=now()` for live
+ingestion, or pass a fixed timestamp when you reprocess historic data.
+
+```tql
+from {
+  timestamp: "May  5 18:16:21",
+}
+timestamp = timestamp.parse_time("%b %e %H:%M:%S", reference=now())
+```
+
+When you pass a fixed reference, the result is deterministic:
+
+```tql
+from {
+  timestamp: "Dec 31 23:59:59",
+}
+timestamp = timestamp.parse_time(
+  "%b %e %H:%M:%S",
+  reference=2026-02-01T00:00:00Z,
+)
+```
+
+```tql
+{timestamp: 2025-12-31T23:59:59Z}
+```
+
+BSD syslog timestamps also don't include a timezone. If you know the sender's
+timezone, add the UTC offset to the string and parse it with `%z`:
+
+```tql
+from {
+  bsd_time: "May  5 18:16:21",
+}
+timestamp = (bsd_time + " +0400").parse_time(
+  "%b %e %H:%M:%S %z",
+  reference=2026-05-05T00:00:00Z,
+)
+```
+
+```tql
+{timestamp: 2026-05-05T14:16:21Z}
 ```
 
 ## See Also

--- a/src/content/docs/reference/operators/read_syslog.mdx
+++ b/src/content/docs/reference/operators/read_syslog.mdx
@@ -73,6 +73,27 @@ With this input, the parser will produce the following output, with the schema n
 }
 ```
 
+RFC 3164 timestamps don't include a year or timezone, so `read_syslog` keeps the
+timestamp as a string. Use <Fn>parse_time</Fn> with `reference` to convert it to
+a timestamp:
+
+```tql title="Pipeline"
+from_file "syslog.txt" {
+  read_syslog
+}
+timestamp = timestamp.parse_time("%b %e %H:%M:%S", reference=now())
+```
+
+If you know the sender's timezone, add the UTC offset to the string and include
+`%z` in the format:
+
+```tql
+timestamp = (timestamp + " +0400").parse_time(
+  "%b %e %H:%M:%S %z",
+  reference=now(),
+)
+```
+
 Some RFC 3164 emitters prepend structured-data blocks to the message content
 using syntax similar to RFC 5424. When the parser detects valid structured data
 at the start of the content field, it extracts the key-value pairs into a


### PR DESCRIPTION
## 🔍 Problem

- The parse_time reference did not explain how to resolve year-less timestamps.
- Syslog docs showed RFC 3164 timestamps as strings without a follow-up for converting them safely.

## 🛠️ Solution

- Document the `reference` argument for `parse_time`.
- Add BSD/RFC 3164 syslog examples for year resolution and explicit timezone offsets.
- Cross-link the guidance from `parse_syslog` and `read_syslog`.

## 💬 Review

- Check that the examples make the year and timezone assumptions explicit.

<sub>
⚙️ Code PR: tenzir/tenzir#6380
</sub>
