### PR TITLE
Document ClickHouse JSON support

### DIFF
--- a/src/content/docs/integrations/clickhouse.mdx
+++ b/src/content/docs/integrations/clickhouse.mdx
@@ -121,9 +121,9 @@ to determine the schema. Make sure the first event doesn't contain untyped nulls
 or empty records. <Op>ocsf::cast</Op> helps because it gives expected OCSF
 fields explicit types before the table is created.
 
-Using `json=unmapped` here allows sending the OCSF `unmapped` field as ClickHouse
-JSON, retaining structural properties without having to rely on <Op>ocsf::cast</Op>
-to `encode_variants` (turning the field into a `string`).
+The `json=unmapped` option creates the OCSF `unmapped` field as a ClickHouse
+`JSON` column, preserving its nested structure so you can query into its fields
+directly.
 
 After the data lands, query it directly in ClickHouse:
 

--- a/src/content/docs/integrations/clickhouse.mdx
+++ b/src/content/docs/integrations/clickhouse.mdx
@@ -110,9 +110,9 @@ with typed nulls.
 
 ```tql
 from_file "ocsf_network_activity.json"
-ocsf::cast encode_variants=true, null_fill=true
+ocsf::cast null_fill=true
 to_clickhouse table=f"ocsf.{class_name.replace(" ","_")}",
-              primary=time, json=unmapped
+              primary=time, json=unmapped,
               tls=false
 ```
 
@@ -123,7 +123,7 @@ fields explicit types before the table is created.
 
 Using `json=unmapped` here allows sending the OCSF `unmapped` field as ClickHouse
 JSON, retaining structural properties without having to rely on <Op>ocsf::cast</Op>
-to `encode_variants` (turning the field into a `string`)
+to `encode_variants` (turning the field into a `string`).
 
 After the data lands, query it directly in ClickHouse:
 

--- a/src/content/docs/integrations/clickhouse.mdx
+++ b/src/content/docs/integrations/clickhouse.mdx
@@ -105,14 +105,14 @@ enabled.
 
 Use this path when ClickHouse is your security data lake. Tenzir can create
 tables from incoming events, and <Op>ocsf::cast</Op> keeps the ClickHouse schema
-stable by casting events to the selected OCSF class, encoding variant fields,
-and filling missing fields with typed nulls.
+stable by casting events to the selected OCSF class and filling missing fields
+with typed nulls.
 
 ```tql
 from_file "ocsf_network_activity.json"
 ocsf::cast encode_variants=true, null_fill=true
 to_clickhouse table=f"ocsf.{class_name.replace(" ","_")}",
-              primary=time,
+              primary=time, json=unmapped
               tls=false
 ```
 
@@ -120,6 +120,10 @@ When creating a table, the <Op>to_clickhouse</Op> operator uses the first event
 to determine the schema. Make sure the first event doesn't contain untyped nulls
 or empty records. <Op>ocsf::cast</Op> helps because it gives expected OCSF
 fields explicit types before the table is created.
+
+Using `json=unmapped` here allows sending the OCSF `unmapped` field as ClickHouse
+JSON, retaining structural properties without having to rely on <Op>ocsf::cast</Op>
+to `encode_variants` (turning the field into a `string`)
 
 After the data lands, query it directly in ClickHouse:
 

--- a/src/content/docs/reference/operators/to_clickhouse.mdx
+++ b/src/content/docs/reference/operators/to_clickhouse.mdx
@@ -89,11 +89,11 @@ well as for `mode = "create_append"` if the table does not yet exist.
 
 ### `json = field|[field] (optional)`
 
-When using `mode = "create"` or `mode = "create_append"`, columns listed in the
-`json` argument will be created as the ClickHouse `JSON` type rather than being
-inferred from the first event. A listed field is created as a `JSON` column even
-if it is absent from that event. Because `json` only affects table creation,
-combining it with `mode = "append"` is an error.
+When using `mode = "create"` or `mode = "create_append"`, the operator creates
+the columns listed in the `json` argument as the ClickHouse `JSON` type instead
+of inferring them from the first event. The operator creates a listed field as a
+`JSON` column even when the event omits it. Because `json` only affects table
+creation, combining it with `mode = "append"` is an error.
 
 This is useful when sending heterogeneous data, such as for OCSF `unmapped`.
 
@@ -212,17 +212,14 @@ This writes to `security.alerts`.
 ### Send OCSF data to ClickHouse
 
 When sending OCSF data to ClickHouse, it is important to ensure that a consistent
-schema is sent. For this, we can use <Op>ocsf::cast</Op>.
-This allows us fill any missing fields with `null`, ensuring a single schema.
+schema is sent. For this, we can use <Op>ocsf::cast</Op>. This fills any missing
+fields with `null`, ensuring a single schema.
 
 ```tql
 subscribe "ocsf"
 ocsf::cast null_fill=true
 to_clickhouse table=f"ocsf.{class_name.replace(" ","_")}", primary=time, json=unmapped
 ```
-
-Another alternative would be to directly turn the `unmapped` field into a `string`
-by using `ocsf::cast null_fill=true, encode_variants=true`.
 
 ### Create a new table with multiple fields
 

--- a/src/content/docs/reference/operators/to_clickhouse.mdx
+++ b/src/content/docs/reference/operators/to_clickhouse.mdx
@@ -87,6 +87,14 @@ Defaults to `"create_append"`.
 The primary key to use when creating a table. Required for `mode = "create"` as
 well as for `mode = "create_append"` if the table does not yet exist.
 
+### `json = field|[field] (optional)`
+
+When using `mode = "create"` or `mode = "create_append"`, columns listed in the
+`json` argument will be created as the ClickHouse `JSON` type rather than being
+inferred from the first event.
+
+This is useful when sending heterogeneous data, such as for OCSF `unmapped`.
+
 import TLSOptions from '@partials/operators/TLSOptions.mdx';
 
 <TLSOptions tls_default="true" />
@@ -113,10 +121,19 @@ translation from Tenzir's types to ClickHouse:
 | `list<T>`  | `Array(T)`                     |                                                                                                       |
 | `blob`     | `Array(UInt8)`                 | Blobs that are `null` will be represented by an empty array                                           |
 
+### Nullable
+
 Tenzir also supports `Nullable` versions of the above types (or their nested types).
 If a `list` itself is `null`, it will be represented by an empty `Array`.
 If a `record` is `null`, all elements of the `Tuple` will be null, if possible.
 Otherwise the event will be dropped.
+
+### Clickhouse JSON
+
+<Op>to_clickhouse</Op> can also write records to the ClickHouse JSON type for
+columns that already have this type in the table. By default, <Op>to_clickhouse</Op>
+will not create JSON columns on its own. Use the explicit [json][#json] option
+or create the table on the server ahead of time.
 
 ### Table Creation
 
@@ -194,14 +211,16 @@ This writes to `security.alerts`.
 
 When sending OCSF data to ClickHouse, it is important to ensure that a consistent
 schema is sent. For this, we can use <Op>ocsf::cast</Op>.
-This allows us to encode the `unmapped` field as JSON and fill any missing fields
-with `null`, ensuring a single schema.
+This allows us fill any missing fields with `null`, ensuring a single schema.
 
 ```tql
 subscribe "ocsf"
-ocsf::cast encode_variants=true, null_fill=true
-to_clickhouse table=f"ocsf.{class_name.replace(" ","_")}", primary=time
+ocsf::cast null_fill=true
+to_clickhouse table=f"ocsf.{class_name.replace(" ","_")}", primary=time, json=unmapped
 ```
+
+Another alternative would be to directly turn the `unmapped` field into a `string`
+by using `ocsf::cast null_fill=true, encode_variants=true`.
 
 ### Create a new table with multiple fields
 

--- a/src/content/docs/reference/operators/to_clickhouse.mdx
+++ b/src/content/docs/reference/operators/to_clickhouse.mdx
@@ -9,7 +9,7 @@ Sends events to a ClickHouse table.
 ```tql
 to_clickhouse table=string,
               [uri=string | (host=string, port=int, user=string, password=string)],
-              [mode=string, primary=field, tls=bool|record]
+              [mode=string, primary=field, json=field|[field], tls=bool|record]
 ```
 
 ## Description
@@ -91,7 +91,9 @@ well as for `mode = "create_append"` if the table does not yet exist.
 
 When using `mode = "create"` or `mode = "create_append"`, columns listed in the
 `json` argument will be created as the ClickHouse `JSON` type rather than being
-inferred from the first event.
+inferred from the first event. A listed field is created as a `JSON` column even
+if it is absent from that event. Because `json` only affects table creation,
+combining it with `mode = "append"` is an error.
 
 This is useful when sending heterogeneous data, such as for OCSF `unmapped`.
 
@@ -132,7 +134,7 @@ Otherwise the event will be dropped.
 
 <Op>to_clickhouse</Op> can also write records to the ClickHouse JSON type for
 columns that already have this type in the table. By default, <Op>to_clickhouse</Op>
-will not create JSON columns on its own. Use the explicit [json][#json] option
+will not create JSON columns on its own. Use the explicit `json` option
 or create the table on the server ahead of time.
 
 ### Table Creation


### PR DESCRIPTION
Documents the `json` argument and JSON-column support added in tenzir/tenzir#6381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)