### PR TITLE
Protect synced node configuration from direct edits

### DIFF
--- a/.github/workflows/protect-node-configuration.yaml
+++ b/.github/workflows/protect-node-configuration.yaml
@@ -1,0 +1,19 @@
+name: Protect Node Configuration
+
+on:
+  pull_request:
+    paths:
+      - tenzir.yaml.example
+
+permissions: {}
+
+jobs:
+  protect:
+    name: Protect Node Configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject direct edits
+        run: |
+          echo "::error::Do not edit tenzir.yaml.example in tenzir/docs directly."
+          echo "::error::Change tenzir.yaml.example in tenzir/tenzir instead; it syncs here after landing on main."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,10 @@ nested `AGENTS.md` files. Read the relevant reference before you edit that area.
 By default, use `bun run dev` to start a development server in the background
 for live preview during development.
 
+Do not edit `tenzir.yaml.example` directly in this repository. The file is
+synced from `tenzir/tenzir`. Make changes in the source repository instead.
+They will sync here automatically after landing on `main`.
+
 Only use `bun run build` when you actually need to inspect build artifacts.
 Output goes to `dist/`.
 


### PR DESCRIPTION
## 🔍 Problem

`tenzir.yaml.example` in this repository is synced from `tenzir/tenzir`. Direct docs-side edits can be overwritten by the next sync.

## 🛠️ Solution

- Add AGENTS.md guidance that directs agents to change the source copy in `tenzir/tenzir`.
- Add a PR-only guard that fails when a pull request edits `tenzir.yaml.example` directly in `tenzir/docs`.

## 💬 Review

The sync workflow is unaffected because it commits directly to `main`; the guard only runs on pull requests that touch `tenzir.yaml.example`.