### PR TITLE
Test node config protection

### DIFF
--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -621,3 +621,5 @@ caf:
 
     # Colon-separated list of OpenSSL cipher strings to use.
     cipher-list:
+
+# temporary protection test


### PR DESCRIPTION
Temporary test PR to verify that the Protect Node Configuration workflow rejects direct edits to `tenzir.yaml.example` in docs.