### PR TITLE
Improve Worktrunk docs setup

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,13 +1,17 @@
-# Worktrunk project configuration
-# https://worktrunk.dev/reference/hook
+[aliases]
+bootstrap = "bun run lefthook:install"
+setup = "wt hook pre-start --yes"
+run = "wt step tether -- bun run dev -- --port {{ (repo ~ '-' ~ branch) | hash_port }}"
 
-# Prepare new worktrees before follow-up commands run.
-[[pre-start]]
+[pre-start]
+copy = "wt step copy-ignored"
 deps = "bun install"
 
-[[pre-start]]
-lefthook = "bun run lefthook:install"
+[post-start]
+docs = "wt -y run"
 
-# Gate Worktrunk merges with the same harness used by Git pre-push and CI.
-[[pre-merge]]
+[pre-merge]
 lint = "bun run lint"
+
+[list]
+url = "http://localhost:{{ (repo ~ '-' ~ branch) | hash_port }}"


### PR DESCRIPTION
## 🔍 Problem

- New docs worktrees lack the same Worktrunk ergonomics as the content repo.
- The existing project config installs dependencies and gates merges, but does not expose setup/run aliases, branch-specific preview URLs, or dev-server startup.

## 🛠️ Solution

- Add Worktrunk aliases for one-time Lefthook bootstrap, setup, and running the docs server.
- Configure `pre-start` as parallel `copy` and `deps = bun install` entries, so `wt setup` includes dependency installation.
- Start Astro from `post-start` via `wt -y run`, keeping the dev-server command in one alias while avoiding an interactive alias approval prompt in the background hook.
- Show the matching branch-specific preview URL in `wt list`.

## 💬 Review

- Check that the hook timing is appropriate for docs worktrees.
- Confirm `bun run lint` remains the right merge gate.