### PR TITLE
Add IBM QRadar integration docs

### DIFF
--- a/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
+++ b/src/content/docs/guides/ai-workbench/use-agent-skills.mdx
@@ -264,7 +264,8 @@ npx skills add tenzir/skills@tenzir-leef
 The `tenzir-leef` skill is generated from the official IBM LEEF Version 2
 format guide. It documents the LEEF 1.0 and 2.0 headers, delimiter rules,
 all 45 predefined event attributes with types and limits, custom event key
-guidelines, and `devTime`/`devTimeFormat` timestamp patterns.
+guidelines, and `devTime`/`devTimeFormat` timestamp patterns. For
+QRadar-specific delivery examples, see <Integration>qradar</Integration>.
 
 Tell the agent which context you want:
 

--- a/src/content/docs/integrations/qradar.excalidraw
+++ b/src/content/docs/integrations/qradar.excalidraw
@@ -1,0 +1,3531 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://app.excalidraw.com",
+  "elements": [
+    {
+      "id": "uUfCBwn0GAw2kwU39ikCx",
+      "type": "arrow",
+      "x": 1141.358913,
+      "y": 306.46315313306945,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "muxISWjQ6Eq2MOeGgGoJ_"
+      ],
+      "frameId": null,
+      "index": "Zy",
+      "roundness": null,
+      "seed": 1743409196,
+      "version": 558,
+      "versionNonce": 266236101,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782731729177,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "xYZwPy8nxOtfnJd2uUBkS",
+      "type": "ellipse",
+      "x": 1184.895324360456,
+      "y": 297.24993599999993,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "muxISWjQ6Eq2MOeGgGoJ_"
+      ],
+      "frameId": null,
+      "index": "Zz",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 1963420332,
+      "version": 557,
+      "versionNonce": 940681739,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782731729177,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "pSMoGMJoGaxjWTY-D9sQa",
+      "type": "arrow",
+      "x": 1144.503272723286,
+      "y": 305.74074670364894,
+      "width": 165.87852050331384,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a0",
+      "roundness": null,
+      "seed": 1018931109,
+      "version": 512,
+      "versionNonce": 469220485,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "gaPCazAeQBDKJp1mhX02a"
+        }
+      ],
+      "updated": 1782731779964,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          165.87852050331384,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false,
+      "moveMidPointsWithElement": false
+    },
+    {
+      "id": "gaPCazAeQBDKJp1mhX02a",
+      "type": "text",
+      "x": 1196.3145327155435,
+      "y": 285.74074670364894,
+      "width": 62.25600051879883,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a1",
+      "roundness": null,
+      "seed": 412183301,
+      "version": 137,
+      "versionNonce": 2130608395,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731779039,
+      "link": null,
+      "locked": false,
+      "text": "NetFlow\nIPFIX",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "pSMoGMJoGaxjWTY-D9sQa",
+      "originalText": "NetFlow\nIPFIX",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "type": "rectangle",
+      "version": 356,
+      "versionNonce": 2104412485,
+      "index": "a2",
+      "isDeleted": false,
+      "id": "0AE9QFF5aC8mjSvVlSHTb",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 380,
+      "y": 60,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "width": 760,
+      "height": 300,
+      "seed": 968486311,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [
+        {
+          "id": "Zlrz7VoiudLcyK0h-KVgG",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782731006169,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "Up8h-Uq4cIQi8CFlZuKUy",
+      "type": "text",
+      "x": 814.8240463913917,
+      "y": 130.508102,
+      "width": 90.35190761089325,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e7f5ff",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "ai",
+      "roundness": null,
+      "seed": 935331705,
+      "version": 122,
+      "versionNonce": 966678085,
+      "isDeleted": true,
+      "boundElements": [
+        {
+          "id": "dB_pGly2bELmP31vkapKB",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "text": "Filter Rules",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Filter Rules",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "ki2ZEMNIueQ-r9ElJUOFV",
+      "type": "rectangle",
+      "x": 920,
+      "y": 280,
+      "width": 160,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "an",
+      "roundness": {
+        "type": 3
+      },
+      "seed": 1665927995,
+      "version": 88,
+      "versionNonce": 1993137291,
+      "isDeleted": true,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "IqgKXla_2OG2nqXg7ymDD"
+        },
+        {
+          "id": "dB_pGly2bELmP31vkapKB",
+          "type": "arrow"
+        },
+        {
+          "id": "YhKW4tV5GuCyZYI4eLj_u",
+          "type": "arrow"
+        },
+        {
+          "id": "LSihc8V3zPmiRPseb8h_h",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "IqgKXla_2OG2nqXg7ymDD",
+      "type": "text",
+      "x": 967.5840273499489,
+      "y": 290,
+      "width": 64.83194530010223,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e7f5ff",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "ao",
+      "roundness": null,
+      "seed": 1438444507,
+      "version": 124,
+      "versionNonce": 1315259813,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "text": "Outputs",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "ki2ZEMNIueQ-r9ElJUOFV",
+      "originalText": "Outputs",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "9NKfDnDSLFz-mP6dXUg5A",
+      "type": "image",
+      "x": 658.8703009999999,
+      "y": 69.47044899999999,
+      "width": 161.97385561020877,
+      "height": 52.03765317301663,
+      "angle": 0,
+      "strokeColor": "transparent",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "ap",
+      "roundness": null,
+      "seed": 780219029,
+      "version": 666,
+      "versionNonce": 240244395,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782730671445,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "04b37ee9ce1e4dcf97d5152953256bf7da6deb05fffe6c895de91cd53295b391ad1757b896367a7df7a706a07f485a2b",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "type": "arrow",
+      "version": 799,
+      "versionNonce": 699863851,
+      "index": "aq",
+      "isDeleted": true,
+      "id": "dB_pGly2bELmP31vkapKB",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 880,
+      "y": 180,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "width": 40,
+      "height": 0,
+      "seed": 468265415,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "PBHd5ogt2k8S8xV5j5kqd",
+        "mode": "orbit",
+        "fixedPoint": [
+          0.5001,
+          0.5001
+        ]
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": "triangle",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          0
+        ]
+      ]
+    },
+    {
+      "id": "8eQAvWM7d8xjBITfzYPyJ",
+      "type": "rectangle",
+      "x": 920,
+      "y": 220,
+      "width": 160,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "ar",
+      "roundness": {
+        "type": 3
+      },
+      "seed": 2055071419,
+      "version": 99,
+      "versionNonce": 1062684933,
+      "isDeleted": true,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "wgdDXJHh-Gf20jUJNy-6q"
+        },
+        {
+          "id": "95FwMSKH6CQXyhRTEtVG-",
+          "type": "arrow"
+        },
+        {
+          "id": "LSihc8V3zPmiRPseb8h_h",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "wgdDXJHh-Gf20jUJNy-6q",
+      "type": "text",
+      "x": 956.2080285698175,
+      "y": 230,
+      "width": 87.58394286036491,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e7f5ff",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "as",
+      "roundness": null,
+      "seed": 1898403675,
+      "version": 146,
+      "versionNonce": 2069984715,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "text": "Index Sets",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "8eQAvWM7d8xjBITfzYPyJ",
+      "originalText": "Index Sets",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "PBHd5ogt2k8S8xV5j5kqd",
+      "type": "rectangle",
+      "x": 920,
+      "y": 160,
+      "width": 160,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "at",
+      "roundness": {
+        "type": 3
+      },
+      "seed": 1237310101,
+      "version": 141,
+      "versionNonce": 2113003621,
+      "isDeleted": true,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "e93NlY7LydjEFLdAdSJnC"
+        },
+        {
+          "id": "dB_pGly2bELmP31vkapKB",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "e93NlY7LydjEFLdAdSJnC",
+      "type": "text",
+      "x": 932.2880706787109,
+      "y": 170,
+      "width": 135.42385864257812,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e7f5ff",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "au",
+      "roundness": null,
+      "seed": 1316077557,
+      "version": 173,
+      "versionNonce": 2061927531,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "text": "Data Warehouses",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "PBHd5ogt2k8S8xV5j5kqd",
+      "originalText": "Data Warehouses",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "type": "arrow",
+      "version": 737,
+      "versionNonce": 1879215045,
+      "index": "av",
+      "isDeleted": true,
+      "id": "95FwMSKH6CQXyhRTEtVG-",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 880,
+      "y": 240,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "width": 40,
+      "height": 0,
+      "seed": 1019663643,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "8eQAvWM7d8xjBITfzYPyJ",
+        "mode": "orbit",
+        "fixedPoint": [
+          0.5001,
+          0.5001
+        ]
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": "triangle",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 755,
+      "versionNonce": 1880145675,
+      "index": "aw",
+      "isDeleted": true,
+      "id": "YhKW4tV5GuCyZYI4eLj_u",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 880,
+      "y": 300,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "width": 40,
+      "height": 0,
+      "seed": 1647458779,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "ki2ZEMNIueQ-r9ElJUOFV",
+        "mode": "orbit",
+        "fixedPoint": [
+          0.5001,
+          0.5001
+        ]
+      },
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": "triangle",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          0
+        ]
+      ]
+    },
+    {
+      "id": "Dspbr4NoPt1DWuVai1r11",
+      "type": "text",
+      "x": 950.2000429214478,
+      "y": 130.508102,
+      "width": 99.59991455078125,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e7f5ff",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "ax",
+      "roundness": null,
+      "seed": 1141522293,
+      "version": 210,
+      "versionNonce": 1705429797,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "text": "Destinations",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Destinations",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "uLJ5nSCJh-shDkpZ8gIzx",
+      "type": "ellipse",
+      "x": 840,
+      "y": 160,
+      "width": 40,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "ay",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 1948231125,
+      "version": 108,
+      "versionNonce": 837728331,
+      "isDeleted": true,
+      "boundElements": [
+        {
+          "id": "ONH3e-XX5e3i5hUDeM0AE",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "_Roq2x_pcEy1Kma8sPWjn",
+      "type": "ellipse",
+      "x": 840,
+      "y": 220,
+      "width": 40,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "az",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 999120149,
+      "version": 112,
+      "versionNonce": 1709179205,
+      "isDeleted": true,
+      "boundElements": [
+        {
+          "id": "nXc7xM-E9LCUKneTV2bQ8",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "ITa_0wew-g4XTbbsO_BTB",
+      "type": "ellipse",
+      "x": 840,
+      "y": 280,
+      "width": 40,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b00",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 1215021179,
+      "version": 116,
+      "versionNonce": 459339819,
+      "isDeleted": true,
+      "boundElements": [
+        {
+          "id": "Zlrz7VoiudLcyK0h-KVgG",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "n8laQOXrQR3Vyz9nSOSMi",
+      "type": "rectangle",
+      "x": 900,
+      "y": 160,
+      "width": 200,
+      "height": 140,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b03",
+      "roundness": {
+        "type": 3
+      },
+      "seed": 1644424411,
+      "version": 196,
+      "versionNonce": 2101819723,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "7mkY0H4M1UMzmSW1LogNs"
+        },
+        {
+          "id": "bFkpKNJwIMCRgF3U0RIUd",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782731076102,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "7mkY0H4M1UMzmSW1LogNs",
+      "type": "text",
+      "x": 924.3039932250977,
+      "y": 165,
+      "width": 151.3920135498047,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e7f5ff",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b04",
+      "roundness": null,
+      "seed": 575117691,
+      "version": 253,
+      "versionNonce": 1222382821,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731076102,
+      "link": null,
+      "locked": false,
+      "text": "Storage & Indexing",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": "n8laQOXrQR3Vyz9nSOSMi",
+      "originalText": "Storage & Indexing",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "ONH3e-XX5e3i5hUDeM0AE",
+      "type": "arrow",
+      "x": 765,
+      "y": 239.9,
+      "width": 70.00020000080008,
+      "height": 60,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b05",
+      "roundness": null,
+      "seed": 528955739,
+      "version": 64,
+      "versionNonce": 23737349,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          35,
+          0
+        ],
+        [
+          35,
+          -60
+        ],
+        [
+          70.00020000080008,
+          -60
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": {
+        "elementId": "n8laQOXrQR3Vyz9nSOSMi",
+        "focus": -0.004999999999999716,
+        "gap": 5,
+        "fixedPoint": [
+          1.05,
+          0.49750000000000016
+        ],
+        "mode": "orbit"
+      },
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": "triangle",
+      "elbowed": true,
+      "fixedSegments": null
+    },
+    {
+      "id": "nXc7xM-E9LCUKneTV2bQ8",
+      "type": "arrow",
+      "x": 765,
+      "y": 239.9,
+      "width": 70.00020000080008,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b06",
+      "roundness": null,
+      "seed": 1829843765,
+      "version": 79,
+      "versionNonce": 1216789195,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          70.00020000080008,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": {
+        "elementId": "n8laQOXrQR3Vyz9nSOSMi",
+        "focus": -0.004999999999999716,
+        "gap": 5,
+        "fixedPoint": [
+          1.05,
+          0.49750000000000016
+        ],
+        "mode": "orbit"
+      },
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": "triangle",
+      "elbowed": true,
+      "fixedSegments": null
+    },
+    {
+      "id": "Zlrz7VoiudLcyK0h-KVgG",
+      "type": "arrow",
+      "x": 765,
+      "y": 239.9,
+      "width": 70.00020000080008,
+      "height": 59.99999999999997,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b07",
+      "roundness": null,
+      "seed": 2049167995,
+      "version": 104,
+      "versionNonce": 1953459045,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782730886781,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          35,
+          0
+        ],
+        [
+          35,
+          59.99999999999997
+        ],
+        [
+          70.00020000080008,
+          59.99999999999997
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": {
+        "elementId": "n8laQOXrQR3Vyz9nSOSMi",
+        "focus": -0.004999999999999716,
+        "gap": 5,
+        "fixedPoint": [
+          1.05,
+          0.49750000000000016
+        ],
+        "mode": "orbit"
+      },
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": "triangle",
+      "elbowed": true,
+      "fixedSegments": null
+    },
+    {
+      "id": "rJGFFVu0NQyzvel-jAGt_",
+      "type": "rectangle",
+      "x": 420,
+      "y": 160,
+      "width": 200.00000000000003,
+      "height": 140,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b08",
+      "roundness": {
+        "type": 3
+      },
+      "seed": 2067207739,
+      "version": 183,
+      "versionNonce": 1380440043,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "cnpFT5gSoqMuaT8rTksmF"
+        },
+        {
+          "id": "bFkpKNJwIMCRgF3U0RIUd",
+          "type": "arrow"
+        },
+        {
+          "id": "S15tDFmTRU41pUFhEpacZ",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782731076102,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "cnpFT5gSoqMuaT8rTksmF",
+      "type": "text",
+      "x": 456.9839973449707,
+      "y": 165,
+      "width": 126.0320053100586,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e7f5ff",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b09",
+      "roundness": null,
+      "seed": 1913558747,
+      "version": 253,
+      "versionNonce": 951201861,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731076102,
+      "link": null,
+      "locked": false,
+      "text": "Event Ingestion",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": "rJGFFVu0NQyzvel-jAGt_",
+      "originalText": "Event Ingestion",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "gzGmVNNyhiJ86kZPsOyqn",
+      "type": "rectangle",
+      "x": 660,
+      "y": 160,
+      "width": 200.00000000000003,
+      "height": 140,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0A",
+      "roundness": {
+        "type": 3
+      },
+      "seed": 475186267,
+      "version": 68,
+      "versionNonce": 117154443,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "E57cYXaFXsGwgLjVDyxYV"
+        },
+        {
+          "id": "bFkpKNJwIMCRgF3U0RIUd",
+          "type": "arrow"
+        },
+        {
+          "id": "S15tDFmTRU41pUFhEpacZ",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1782731076102,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "E57cYXaFXsGwgLjVDyxYV",
+      "type": "text",
+      "x": 728.9120006561279,
+      "y": 165,
+      "width": 62.17599868774414,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0B",
+      "roundness": null,
+      "seed": 1965403003,
+      "version": 69,
+      "versionNonce": 837672869,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731076102,
+      "link": null,
+      "locked": false,
+      "text": "Streams",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "containerId": "gzGmVNNyhiJ86kZPsOyqn",
+      "originalText": "Streams",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "type": "arrow",
+      "version": 841,
+      "versionNonce": 932400517,
+      "index": "b0C",
+      "isDeleted": true,
+      "id": "qB21CvJ-WuxmPN7LusFc6",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 900.1498389658052,
+      "y": 180.7364198878873,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "width": 40,
+      "height": 0,
+      "seed": 369316251,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1782730995508,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": "triangle",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "arrow",
+      "version": 863,
+      "versionNonce": 1130191621,
+      "index": "b0D",
+      "isDeleted": true,
+      "id": "E0h1nXwftglqSkhgIexDb",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 480,
+      "y": -60,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "width": 100,
+      "height": 0,
+      "seed": 1912498171,
+      "groupIds": [],
+      "frameId": null,
+      "roundness": {
+        "type": 2
+      },
+      "boundElements": [],
+      "updated": 1782731301589,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": "triangle",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          100,
+          0
+        ]
+      ]
+    },
+    {
+      "type": "line",
+      "version": 1175,
+      "versionNonce": 1449938283,
+      "isDeleted": false,
+      "id": "YcO91MeAXRDt-i2GUgFRb",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 1384.5126189324476,
+      "y": 269.6215481509989,
+      "strokeColor": "#000000",
+      "backgroundColor": "#e9ecef",
+      "width": 160,
+      "height": 80,
+      "seed": 2091768791,
+      "groupIds": [
+        "yg_LDl0yAXtyJ9Hxmlrow"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1782731743549,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -1.4896611218806584,
+          80
+        ],
+        [
+          118.51033887811936,
+          79.99999999999999
+        ],
+        [
+          158.51033887811934,
+          40.000000000000014
+        ],
+        [
+          118.51033887811934,
+          -7.105427357601002e-15
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "index": "b0DV",
+      "polygon": false
+    },
+    {
+      "type": "image",
+      "version": 3524,
+      "versionNonce": 1240819723,
+      "index": "b0E",
+      "isDeleted": false,
+      "id": "iebOUXAPuzuSdYu-pzCAx",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 1420.4417004142929,
+      "y": 284.849447,
+      "strokeColor": "transparent",
+      "backgroundColor": "#ffc9c9",
+      "width": 61.54214099463984,
+      "height": 50.681763172056336,
+      "seed": 1021177723,
+      "groupIds": [
+        "1JTEIksjIjyV7WuuoNKYD",
+        "yg_LDl0yAXtyJ9Hxmlrow"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1782731743549,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "WB7Y358LRslIlKUvQ1ImE",
+      "type": "arrow",
+      "x": 145.49534894349003,
+      "y": 111.392139085997,
+      "width": 165.87852050331384,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0G",
+      "roundness": null,
+      "seed": 1326421420,
+      "version": 270,
+      "versionNonce": 1654387589,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "NPQBXgLBdpIE62-8Pt6hE"
+        }
+      ],
+      "updated": 1782731433265,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          165.87852050331384,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "pg46CNCzBnbaa30Ny7qoo",
+        "mode": "orbit",
+        "fixedPoint": [
+          -0.27499999354838706,
+          0.5001
+        ]
+      },
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false,
+      "moveMidPointsWithElement": false
+    },
+    {
+      "id": "NPQBXgLBdpIE62-8Pt6hE",
+      "type": "text",
+      "x": 188.81060864583054,
+      "y": 91.392139085997,
+      "width": 79.24800109863281,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0H",
+      "roundness": null,
+      "seed": 577241132,
+      "version": 104,
+      "versionNonce": 306674187,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731432869,
+      "link": null,
+      "locked": false,
+      "text": "Syslog\nUDP/TCP",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "WB7Y358LRslIlKUvQ1ImE",
+      "originalText": "Syslog\nUDP/TCP",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "type": "line",
+      "version": 1395,
+      "versionNonce": 882737068,
+      "isDeleted": false,
+      "id": "bpybrH-7Nf1GLEu8HUHAO",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -17.7967499346357,
+      "y": 69.28932490940551,
+      "strokeColor": "#000000",
+      "backgroundColor": "#e9ecef",
+      "width": 160,
+      "height": 80,
+      "seed": 1951341228,
+      "groupIds": [
+        "t3q3nS9cOeVofOv865QG-"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779964972083,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          39.67197250080198
+        ],
+        [
+          -1.4210854715202004e-14,
+          80
+        ],
+        [
+          160,
+          80
+        ],
+        [
+          160,
+          0
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "index": "b0I",
+      "polygon": false
+    },
+    {
+      "type": "image",
+      "version": 3848,
+      "versionNonce": 849914412,
+      "index": "b0J",
+      "isDeleted": false,
+      "id": "4zoYaosk9cbDgAqPw2kEA",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 48.31563987960649,
+      "y": 83.1123197388512,
+      "strokeColor": "transparent",
+      "backgroundColor": "#ffc9c9",
+      "width": 61.54214099463984,
+      "height": 50.681763172056336,
+      "seed": 1601103148,
+      "groupIds": [
+        "jNUEDLAHlVDhiXd07EdiI",
+        "t3q3nS9cOeVofOv865QG-"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779964972083,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "Irtxb2PiiUV1q_PWo-i6g",
+      "type": "arrow",
+      "x": 380.41028067822754,
+      "y": 110.60335621906657,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "pTpoRVo8cHCpG-UOYpBcC"
+      ],
+      "frameId": null,
+      "index": "b0K",
+      "roundness": null,
+      "seed": 422666156,
+      "version": 447,
+      "versionNonce": 1256883372,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779964972083,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "pg46CNCzBnbaa30Ny7qoo",
+      "type": "ellipse",
+      "x": 316.8738693177716,
+      "y": 101.39013908599705,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "pTpoRVo8cHCpG-UOYpBcC"
+      ],
+      "frameId": null,
+      "index": "b0L",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 432048684,
+      "version": 432,
+      "versionNonce": 1661800236,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "id": "WB7Y358LRslIlKUvQ1ImE",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1779964972083,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "LnoVH-Y2s-6epXTi3iEXO",
+      "type": "arrow",
+      "x": 145.49534894349006,
+      "y": 211.01426359262442,
+      "width": 165.87852018554224,
+      "height": 1.0122635926244072,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0M",
+      "roundness": null,
+      "seed": 1141269676,
+      "version": 290,
+      "versionNonce": 1232237893,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "hksZX3_nwD6c0rnWYmvgl"
+        }
+      ],
+      "updated": 1782731787215,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          165.87852018554224,
+          -1.0122635926244072
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "WNYiAuCmcafflHOtV1qLs",
+        "mode": "orbit",
+        "fixedPoint": [
+          -0.27499999354838706,
+          0.5001
+        ]
+      },
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false,
+      "moveMidPointsWithElement": false
+    },
+    {
+      "id": "hksZX3_nwD6c0rnWYmvgl",
+      "type": "text",
+      "x": 197.30660877686176,
+      "y": 190.50813179631223,
+      "width": 62.25600051879883,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0N",
+      "roundness": null,
+      "seed": 229437228,
+      "version": 79,
+      "versionNonce": 854623307,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731786651,
+      "link": null,
+      "locked": false,
+      "text": "NetFlow\nIPFIX",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "LnoVH-Y2s-6epXTi3iEXO",
+      "originalText": "NetFlow\nIPFIX",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "type": "line",
+      "version": 1404,
+      "versionNonce": 2002531372,
+      "isDeleted": false,
+      "id": "Ol_jHF1WnnUn2rIUf1m6G",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -17.7967499346357,
+      "y": 168.91144941603298,
+      "strokeColor": "#000000",
+      "backgroundColor": "#e9ecef",
+      "width": 160,
+      "height": 80,
+      "seed": 656288172,
+      "groupIds": [
+        "DXDGQLWtpKtpsAE8ECKle"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779964972083,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          39.67197250080198
+        ],
+        [
+          -1.4210854715202004e-14,
+          80
+        ],
+        [
+          160,
+          80
+        ],
+        [
+          160,
+          0
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "index": "b0O",
+      "polygon": false
+    },
+    {
+      "type": "image",
+      "version": 3857,
+      "versionNonce": 77385388,
+      "index": "b0P",
+      "isDeleted": false,
+      "id": "L6c9PMA8OqYGDaH-fq2xT",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 48.31563987960649,
+      "y": 182.7344442454786,
+      "strokeColor": "transparent",
+      "backgroundColor": "#ffc9c9",
+      "width": 61.54214099463984,
+      "height": 50.681763172056336,
+      "seed": 595858476,
+      "groupIds": [
+        "u37ncgl3DvJB8DPPm4Eo3",
+        "DXDGQLWtpKtpsAE8ECKle"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779964972083,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "type": "line",
+      "version": 1411,
+      "versionNonce": 65411372,
+      "isDeleted": false,
+      "id": "zF-k2GLiBdahez-bB4JSG",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": -17.7967499346357,
+      "y": 270.39291183934836,
+      "strokeColor": "#000000",
+      "backgroundColor": "#e9ecef",
+      "width": 160,
+      "height": 80,
+      "seed": 550022828,
+      "groupIds": [
+        "0gPd5-ISjf8V8btlNAFKo"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779964972083,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          39.67197250080198
+        ],
+        [
+          -1.4210854715202004e-14,
+          80
+        ],
+        [
+          160,
+          80
+        ],
+        [
+          160,
+          0
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "index": "b0Q",
+      "polygon": false
+    },
+    {
+      "type": "image",
+      "version": 3864,
+      "versionNonce": 279057324,
+      "index": "b0R",
+      "isDeleted": false,
+      "id": "5KBFObbLhHBltO76EUuCw",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 48.31563987960649,
+      "y": 284.215906668794,
+      "strokeColor": "transparent",
+      "backgroundColor": "#ffc9c9",
+      "width": 61.54214099463984,
+      "height": 50.681763172056336,
+      "seed": 1872099628,
+      "groupIds": [
+        "6p94CXOgYfTCaI559uqus",
+        "0gPd5-ISjf8V8btlNAFKo"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1779964972083,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "pkLeOJ9sbtvCb9wAXfvQv",
+      "type": "arrow",
+      "x": 380.4102803604559,
+      "y": 209.21321713306952,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "DdaBUnSE6VYLf8q8Ma-LV"
+      ],
+      "frameId": null,
+      "index": "b0S",
+      "roundness": null,
+      "seed": 995488684,
+      "version": 466,
+      "versionNonce": 1505989652,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779965329886,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "WNYiAuCmcafflHOtV1qLs",
+      "type": "ellipse",
+      "x": 316.873869,
+      "y": 200,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "DdaBUnSE6VYLf8q8Ma-LV"
+      ],
+      "frameId": null,
+      "index": "b0T",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 842178092,
+      "version": 465,
+      "versionNonce": 1574957460,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "id": "LnoVH-Y2s-6epXTi3iEXO",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1779965329886,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "pZt3aQ2u3v_LREGfDYj-6",
+      "type": "arrow",
+      "x": 143.72615551310196,
+      "y": 307.2519358444298,
+      "width": 165.87852050331384,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0U",
+      "roundness": null,
+      "seed": 269251092,
+      "version": 325,
+      "versionNonce": 1604792293,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "CbYU7UwHTRx4W6CqmqL4q"
+        }
+      ],
+      "updated": 1782731421529,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          165.87852050331384,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "jfjy7RaGkl5TDx8TEBqsQ",
+        "mode": "orbit",
+        "fixedPoint": [
+          -0.27499999354838706,
+          0.5001
+        ]
+      },
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false,
+      "moveMidPointsWithElement": false
+    },
+    {
+      "id": "CbYU7UwHTRx4W6CqmqL4q",
+      "type": "text",
+      "x": 197.80941486449032,
+      "y": 287.2519358444298,
+      "width": 57.71200180053711,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0V",
+      "roundness": null,
+      "seed": 1398607764,
+      "version": 122,
+      "versionNonce": 627083397,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731419111,
+      "link": null,
+      "locked": false,
+      "text": "JSON\nHTTPS",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "pZt3aQ2u3v_LREGfDYj-6",
+      "originalText": "JSON\nHTTPS",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "NRaonrAZVDXMyHuhq55rG",
+      "type": "arrow",
+      "x": 378.64108724783944,
+      "y": 306.46315297749936,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "XDjOIE_cq_AFh9tzch3KM"
+      ],
+      "frameId": null,
+      "index": "b0W",
+      "roundness": null,
+      "seed": 1841167636,
+      "version": 501,
+      "versionNonce": 1913099028,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1779965023702,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "jfjy7RaGkl5TDx8TEBqsQ",
+      "type": "ellipse",
+      "x": 315.10467588738356,
+      "y": 297.24993584442984,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "XDjOIE_cq_AFh9tzch3KM"
+      ],
+      "frameId": null,
+      "index": "b0X",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 950352532,
+      "version": 500,
+      "versionNonce": 1800147092,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "id": "pZt3aQ2u3v_LREGfDYj-6",
+          "type": "arrow"
+        }
+      ],
+      "updated": 1779965023702,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "39Y5zgSNKt2SoONLMN29i",
+      "type": "arrow",
+      "x": 1247.6870923798115,
+      "y": 301.48573532923547,
+      "width": 165.87852050331384,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0a",
+      "roundness": null,
+      "seed": 190645012,
+      "version": 309,
+      "versionNonce": 441772005,
+      "isDeleted": true,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "FuMcdLdNaUDTMobH-ncp3"
+        }
+      ],
+      "updated": 1782731562770,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          165.87852050331384,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false,
+      "moveMidPointsWithElement": false
+    },
+    {
+      "id": "FuMcdLdNaUDTMobH-ncp3",
+      "type": "text",
+      "x": 1301.7703517311998,
+      "y": 281.48573532923547,
+      "width": 57.71200180053711,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0b",
+      "roundness": null,
+      "seed": 410222740,
+      "version": 76,
+      "versionNonce": 263828715,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782731562770,
+      "link": null,
+      "locked": false,
+      "text": "HTTPS\nGELF",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "39Y5zgSNKt2SoONLMN29i",
+      "originalText": "HTTPS\nGELF",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "type": "line",
+      "version": 1207,
+      "versionNonce": 593013989,
+      "isDeleted": false,
+      "id": "j9ehg7HABHCoNns9fyfcK",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 1384.2342935361737,
+      "y": 169.81326521381368,
+      "strokeColor": "#000000",
+      "backgroundColor": "#e9ecef",
+      "width": 160,
+      "height": 80,
+      "seed": 67731884,
+      "groupIds": [
+        "sik9hIGhdzn1g-Y9OThh5"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1782731747012,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -1.4896611218806584,
+          80
+        ],
+        [
+          118.51033887811936,
+          79.99999999999999
+        ],
+        [
+          158.51033887811934,
+          40.000000000000014
+        ],
+        [
+          118.51033887811934,
+          -7.105427357601002e-15
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "index": "b0bV",
+      "polygon": false
+    },
+    {
+      "type": "image",
+      "version": 3556,
+      "versionNonce": 1205585989,
+      "index": "b0c",
+      "isDeleted": false,
+      "id": "mHLH_uBoYNfJWi5VL_Cs0",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 1420.1633750180192,
+      "y": 185.0411640628148,
+      "strokeColor": "transparent",
+      "backgroundColor": "#ffc9c9",
+      "width": 61.54214099463984,
+      "height": 50.681763172056336,
+      "seed": 2034527276,
+      "groupIds": [
+        "HhH4wfC8N7WynvVn3SIaL",
+        "sik9hIGhdzn1g-Y9OThh5"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1782731747012,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "-6hJnPTjsBO9h8r_fI3mV",
+      "type": "arrow",
+      "x": 1382.744632486167,
+      "y": 209.0732319078808,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "STDJpEVebQ5RvNc6rAZOL"
+      ],
+      "frameId": null,
+      "index": "b0e",
+      "roundness": null,
+      "seed": 920803220,
+      "version": 521,
+      "versionNonce": 696701643,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731732583,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "RAEj1J_UTTa9OJvBBViDq",
+      "type": "ellipse",
+      "x": 1319.208221125711,
+      "y": 199.86001477481128,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "STDJpEVebQ5RvNc6rAZOL"
+      ],
+      "frameId": null,
+      "index": "b0f",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 1096434964,
+      "version": 522,
+      "versionNonce": 1448624491,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731732583,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "LSihc8V3zPmiRPseb8h_h",
+      "type": "arrow",
+      "x": 1182.9578474142932,
+      "y": 240.00399999999993,
+      "width": 163.95817549526487,
+      "height": 60.47621479517613,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0g",
+      "roundness": null,
+      "seed": 580733076,
+      "version": 459,
+      "versionNonce": 1884121733,
+      "isDeleted": true,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "0bTZaqdzK_97m-GSiAHIE"
+        }
+      ],
+      "updated": 1782731556633,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          70.72103710371266,
+          2.842170943040401e-14
+        ],
+        [
+          74.5,
+          -60.00399999999996
+        ],
+        [
+          163.95817549526487,
+          -60.476214795176105
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": {
+        "elementId": "RAEj1J_UTTa9OJvBBViDq",
+        "mode": "orbit",
+        "fixedPoint": [
+          0,
+          0.5001
+        ]
+      },
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false,
+      "moveMidPointsWithElement": false
+    },
+    {
+      "id": "0bTZaqdzK_97m-GSiAHIE",
+      "type": "text",
+      "x": 1115.4799995422363,
+      "y": 210,
+      "width": 89.04000091552734,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0h",
+      "roundness": null,
+      "seed": 982455828,
+      "version": 100,
+      "versionNonce": 360197195,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782731556633,
+      "link": null,
+      "locked": false,
+      "text": "OpenSearch",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "LSihc8V3zPmiRPseb8h_h",
+      "originalText": "OpenSearch",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "Qzpw4UyMurPRVGhi3YDI4",
+      "type": "image",
+      "x": 678.503728472858,
+      "y": 70.67873908368837,
+      "width": 156.4964717741934,
+      "height": 50.711400261323995,
+      "angle": 0,
+      "strokeColor": "transparent",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0i",
+      "roundness": null,
+      "seed": 10788933,
+      "version": 198,
+      "versionNonce": 1712718027,
+      "isDeleted": true,
+      "boundElements": null,
+      "updated": 1782731206671,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "5c3b38ab665fee4b0f50efac70d64b60259938b86d7144b0f00374d7f8137bc4a2d25a0c4e693b2500ad11688ec29430",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "4EESBFJqSlDItyZqrAW9E",
+      "type": "text",
+      "x": 440,
+      "y": 200,
+      "width": 163.2639923095703,
+      "height": 80,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0j",
+      "roundness": null,
+      "seed": 1237034533,
+      "version": 92,
+      "versionNonce": 337451307,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1782731076102,
+      "link": null,
+      "locked": false,
+      "text": "- DSM / Log Sources\n- Flow Sources\n- Event Collectors\n- Custom Protocols",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "- DSM / Log Sources\n- Flow Sources\n- Event Collectors\n- Custom Protocols",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "ooe5RD6Fwjnhkec13-HES",
+      "type": "text",
+      "x": 680,
+      "y": 200,
+      "width": 152.2560272216797,
+      "height": 80,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0k",
+      "roundness": null,
+      "seed": 47207973,
+      "version": 173,
+      "versionNonce": 448570117,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731076102,
+      "link": null,
+      "locked": false,
+      "text": "- Parse & Normalize\n- Time Correction\n- Deduplication\n- Enrichment",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "- Parse & Normalize\n- Time Correction\n- Deduplication\n- Enrichment",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "r7NVtadkDSVceRk7qCnSQ",
+      "type": "text",
+      "x": 920,
+      "y": 200,
+      "width": 160.60801696777344,
+      "height": 80,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0l",
+      "roundness": null,
+      "seed": 763862507,
+      "version": 271,
+      "versionNonce": 1997978571,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731076102,
+      "link": null,
+      "locked": false,
+      "text": "- Ariel Search Engine\n- Indexed Events\n- Compression\n- Retention Policies",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "- Ariel Search Engine\n- Indexed Events\n- Compression\n- Retention Policies",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "bFkpKNJwIMCRgF3U0RIUd",
+      "type": "arrow",
+      "x": 894.5,
+      "y": 230.014,
+      "width": 29,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0m",
+      "roundness": null,
+      "seed": 1714514315,
+      "version": 220,
+      "versionNonce": 1099803563,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1782731076200,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -29,
+          0
+        ]
+      ],
+      "startBinding": {
+        "elementId": "n8laQOXrQR3Vyz9nSOSMi",
+        "mode": "orbit",
+        "fixedPoint": [
+          -0.0275,
+          0.5001000000000001
+        ]
+      },
+      "endBinding": {
+        "elementId": "gzGmVNNyhiJ86kZPsOyqn",
+        "mode": "orbit",
+        "fixedPoint": [
+          1.0274999999999999,
+          0.5001000000000001
+        ]
+      },
+      "startArrowhead": "triangle",
+      "endArrowhead": null,
+      "elbowed": false,
+      "fixedSegments": null,
+      "startIsSpecial": null,
+      "endIsSpecial": null
+    },
+    {
+      "id": "S15tDFmTRU41pUFhEpacZ",
+      "type": "arrow",
+      "x": 654.5,
+      "y": 230.014,
+      "width": 29,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0n",
+      "roundness": null,
+      "seed": 744569061,
+      "version": 159,
+      "versionNonce": 122748139,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731076200,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -29,
+          0
+        ]
+      ],
+      "startBinding": {
+        "elementId": "gzGmVNNyhiJ86kZPsOyqn",
+        "mode": "orbit",
+        "fixedPoint": [
+          -0.027499999999999997,
+          0.5001000000000001
+        ]
+      },
+      "endBinding": {
+        "elementId": "rJGFFVu0NQyzvel-jAGt_",
+        "mode": "orbit",
+        "fixedPoint": [
+          1.0274999999999999,
+          0.5001000000000001
+        ]
+      },
+      "startArrowhead": "triangle",
+      "endArrowhead": null,
+      "elbowed": false,
+      "fixedSegments": null,
+      "startIsSpecial": null,
+      "endIsSpecial": null
+    },
+    {
+      "id": "NmaERoo0gixBb1gjgjvmE",
+      "type": "image",
+      "x": 639.3684064130887,
+      "y": 81.6985556906797,
+      "width": 60,
+      "height": 60,
+      "angle": 0,
+      "strokeColor": "transparent",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "6DRKtdDJokW8RpbW2sNnN"
+      ],
+      "frameId": null,
+      "index": "b0o",
+      "roundness": null,
+      "seed": 1423028075,
+      "version": 147,
+      "versionNonce": 1483621131,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1782731251103,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "d38d49d28590d01f116960cab39407b9920a1655fc748e7891ec3f9cc8f3e00f2972ebbd816628180711d1332e910957",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "nTEa1-5W_VvAaRyu5uWrc",
+      "type": "text",
+      "x": 707.3084083941343,
+      "y": 94.19655548112571,
+      "width": 172.05999755859375,
+      "height": 35,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "6DRKtdDJokW8RpbW2sNnN"
+      ],
+      "frameId": null,
+      "index": "b0p",
+      "roundness": null,
+      "seed": 1133509381,
+      "version": 138,
+      "versionNonce": 1590920997,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1782731251103,
+      "link": null,
+      "locked": false,
+      "text": "IBM QRadar",
+      "fontSize": 28,
+      "fontFamily": 5,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "IBM QRadar",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "ZQxSqVNcNFo0Vjhyqv9Nw",
+      "type": "arrow",
+      "x": 1141.3589129157529,
+      "y": 209.72134923315352,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "4LjJA9ky0JRiPzui2CjMT"
+      ],
+      "frameId": null,
+      "index": "b0q",
+      "roundness": null,
+      "seed": 2067896645,
+      "version": 583,
+      "versionNonce": 1491146475,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782731709865,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "igAjxG_2wUyR1zd5ocFgY",
+      "type": "ellipse",
+      "x": 1184.8953242762084,
+      "y": 200.508132100084,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "4LjJA9ky0JRiPzui2CjMT"
+      ],
+      "frameId": null,
+      "index": "b0r",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 547891365,
+      "version": 580,
+      "versionNonce": 26353259,
+      "isDeleted": true,
+      "boundElements": [],
+      "updated": 1782731691763,
+      "link": null,
+      "locked": false
+    },
+    {
+      "id": "cWnvuQL2Mzza9ykpVoYTh",
+      "type": "arrow",
+      "x": 1139.999999504086,
+      "y": 98.11792532407716,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "S6H8E_8JfMhgr_SaA1meG"
+      ],
+      "frameId": null,
+      "index": "b0s",
+      "roundness": null,
+      "seed": 2076114021,
+      "version": 625,
+      "versionNonce": 1248263685,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731543529,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "Dsbl2WwFEHB-THHaxRpwE",
+      "type": "ellipse",
+      "x": 1183.5364108645415,
+      "y": 88.90470819100764,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "S6H8E_8JfMhgr_SaA1meG"
+      ],
+      "frameId": null,
+      "index": "b0t",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 1842096069,
+      "version": 624,
+      "versionNonce": 1464005989,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731543529,
+      "link": null,
+      "locked": false
+    },
+    {
+      "type": "line",
+      "version": 1260,
+      "versionNonce": 1478784933,
+      "isDeleted": false,
+      "id": "-s-P2eRQnvbilxet9jVtt",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 1384.2383386107406,
+      "y": 60.00160623611312,
+      "strokeColor": "#000000",
+      "backgroundColor": "#e9ecef",
+      "width": 160,
+      "height": 80,
+      "seed": 2097384363,
+      "groupIds": [
+        "xsGtdwUDfGFveh45Nji_H"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1782731747012,
+      "link": null,
+      "locked": false,
+      "startBinding": null,
+      "endBinding": null,
+      "lastCommittedPoint": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -1.4896611218806584,
+          80
+        ],
+        [
+          118.51033887811936,
+          79.99999999999999
+        ],
+        [
+          158.51033887811934,
+          40.000000000000014
+        ],
+        [
+          118.51033887811934,
+          -7.105427357601002e-15
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      "index": "b0w",
+      "polygon": false
+    },
+    {
+      "type": "image",
+      "version": 3609,
+      "versionNonce": 1851800325,
+      "index": "b0x",
+      "isDeleted": false,
+      "id": "GJaATFmRkZiaUho_zjRT4",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "angle": 0,
+      "x": 1420.167420092586,
+      "y": 75.22950508511424,
+      "strokeColor": "transparent",
+      "backgroundColor": "#ffc9c9",
+      "width": 61.54214099463984,
+      "height": 50.681763172056336,
+      "seed": 260759115,
+      "groupIds": [
+        "3HDFaZbCch-4p3Vni8_sQ",
+        "xsGtdwUDfGFveh45Nji_H"
+      ],
+      "frameId": null,
+      "roundness": null,
+      "boundElements": [],
+      "updated": 1782731747012,
+      "link": null,
+      "locked": false,
+      "status": "saved",
+      "fileId": "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf",
+      "scale": [
+        1,
+        1
+      ],
+      "crop": null
+    },
+    {
+      "id": "9DYPebxzU4IsnEAX3683X",
+      "type": "arrow",
+      "x": 1214.6381962793248,
+      "y": 98.97371802209273,
+      "width": 165.87852050331384,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0y",
+      "roundness": null,
+      "seed": 432000619,
+      "version": 340,
+      "versionNonce": 997340811,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "gwDowGOArShTTqypZLqI5"
+        }
+      ],
+      "updated": 1782731687304,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          165.87852050331384,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false,
+      "moveMidPointsWithElement": false
+    },
+    {
+      "id": "gwDowGOArShTTqypZLqI5",
+      "type": "text",
+      "x": 1242.145461139136,
+      "y": 78.97371802209273,
+      "width": 110.8639907836914,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b0z",
+      "roundness": null,
+      "seed": 959498507,
+      "version": 137,
+      "versionNonce": 1489223909,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731686071,
+      "link": null,
+      "locked": false,
+      "text": "HTTPS REST\nAriel / AQL",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "9DYPebxzU4IsnEAX3683X",
+      "originalText": "HTTPS REST\nAriel / AQL",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "z00CClp3_is44c3In1ysj",
+      "type": "text",
+      "x": 1197.8386648443975,
+      "y": 304.22451624226846,
+      "width": 11.199999809265137,
+      "height": 35,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b10",
+      "roundness": null,
+      "seed": 1169532037,
+      "version": 3,
+      "versionNonce": 255507339,
+      "isDeleted": true,
+      "boundElements": null,
+      "updated": 1782731693905,
+      "link": null,
+      "locked": false,
+      "text": "",
+      "fontSize": 28,
+      "fontFamily": 5,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "0VB7cwjXqTQ-mu8bH1_G4",
+      "type": "arrow",
+      "x": 1151.241749330459,
+      "y": 207.79912531691082,
+      "width": 165.87852050331384,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "dotted",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b11",
+      "roundness": null,
+      "seed": 953458635,
+      "version": 421,
+      "versionNonce": 1227652805,
+      "isDeleted": false,
+      "boundElements": [
+        {
+          "type": "text",
+          "id": "eXKn8zD7hbFYt3NHxzu_-"
+        }
+      ],
+      "updated": 1782731770380,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          165.87852050331384,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false,
+      "moveMidPointsWithElement": false
+    },
+    {
+      "id": "eXKn8zD7hbFYt3NHxzu_-",
+      "type": "text",
+      "x": 1194.5570090327997,
+      "y": 187.79912531691082,
+      "width": 79.24800109863281,
+      "height": 40,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "b12",
+      "roundness": null,
+      "seed": 878997099,
+      "version": 114,
+      "versionNonce": 1896109189,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731718957,
+      "link": null,
+      "locked": false,
+      "text": "Syslog\nUDP/TCP",
+      "fontSize": 16,
+      "fontFamily": 5,
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "0VB7cwjXqTQ-mu8bH1_G4",
+      "originalText": "Syslog\nUDP/TCP",
+      "autoResize": true,
+      "lineHeight": 1.25
+    },
+    {
+      "id": "KHYu7yNzlswezNoriB2Gc",
+      "type": "arrow",
+      "x": 1374.1715528618417,
+      "y": 308.4509004576024,
+      "width": 40,
+      "height": 0,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "OuRIiFuRUaIdr05sBaGAK"
+      ],
+      "frameId": null,
+      "index": "b13",
+      "roundness": null,
+      "seed": 939365707,
+      "version": 561,
+      "versionNonce": 177451883,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731735049,
+      "link": null,
+      "locked": false,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -40,
+          0
+        ]
+      ],
+      "lastCommittedPoint": null,
+      "startBinding": null,
+      "endBinding": null,
+      "startArrowhead": null,
+      "endArrowhead": null,
+      "elbowed": false
+    },
+    {
+      "id": "4CMuMaW873SZf1gSOtfWh",
+      "type": "ellipse",
+      "x": 1310.6351415013858,
+      "y": 299.2376833245329,
+      "width": 20,
+      "height": 20,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "hachure",
+      "strokeWidth": 1,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [
+        "OuRIiFuRUaIdr05sBaGAK"
+      ],
+      "frameId": null,
+      "index": "b14",
+      "roundness": {
+        "type": 2
+      },
+      "seed": 500347883,
+      "version": 562,
+      "versionNonce": 272633355,
+      "isDeleted": false,
+      "boundElements": [],
+      "updated": 1782731735049,
+      "link": null,
+      "locked": false
+    }
+  ],
+  "appState": {
+    "gridSize": 20,
+    "gridStep": 5,
+    "gridModeEnabled": false,
+    "viewBackgroundColor": "#ffffff",
+    "lockedMultiSelections": {}
+  },
+  "files": {
+    "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf": {
+      "mimeType": "image/svg+xml",
+      "id": "d1ee05fd41e4fad60a7372901fb1a4d206070a057f9b3a48768235e2c5775230a90d16ba6804ee1fbd79befd1ec8cbbf",
+      "dataURL": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4NSIgaGVpZ2h0PSI3MCIgdmlld0JveD0iMCAwIDg1IDcwIiBmaWxsPSJub25lIj4KPHBhdGggZD0iTTI5LjQ1IDQ0LjQyTDQyLjc3IDEyLjkzQzQyLjgyNjkgMTIuODA1OCA0Mi44NTc4IDEyLjY3MTMgNDIuODYwNyAxMi41MzQ4QzQyLjg2MzYgMTIuMzk4MiA0Mi44Mzg2IDEyLjI2MjUgNDIuNzg3IDEyLjEzNkM0Mi43MzU1IDEyLjAwOTUgNDIuNjU4NiAxMS44OTQ5IDQyLjU2MTEgMTEuNzk5M0M0Mi40NjM1IDExLjcwMzcgNDIuMzQ3NSAxMS42MjkgNDIuMjIgMTEuNThDNDIuMDkyOCAxMS41Mjg2IDQxLjk1NzEgMTEuNTAxNSA0MS44MiAxMS41SDkuMjc5OTlDOS4wNzYzMiAxMS40OTU4IDguODc2MjEgMTEuNTUzOCA4LjcwNjQzIDExLjY2NjRDOC41MzY2NiAxMS43NzkgOC40MDUzMiAxMS45NDA3IDguMzI5OTkgMTIuMTNMMy4xMDk5OSAyNC42M0MzLjA1IDI0Ljc1NTggMy4wMTY5NSAyNC44OTI3IDMuMDEyOTggMjUuMDMyQzMuMDA5MDEgMjUuMTcxMyAzLjAzNDE5IDI1LjMwOTkgMy4wODY5MiAyNS40Mzg5QzMuMTM5NjUgMjUuNTY3OSAzLjIxODc1IDI1LjY4NDQgMy4zMTkxNiAyNS43ODExQzMuNDE5NTcgMjUuODc3NyAzLjUzOTA3IDI1Ljk1MjMgMy42Njk5OSAyNkMzLjc5MzMxIDI2LjA1MjUgMy45MjU5NCAyNi4wNzk3IDQuMDU5OTkgMjYuMDhIMTkuODJDMjAuMDg1MiAyNi4wOCAyMC4zMzk2IDI2LjE4NTQgMjAuNTI3MSAyNi4zNzI5QzIwLjcxNDYgMjYuNTYwNCAyMC44MiAyNi44MTQ4IDIwLjgyIDI3LjA4QzIwLjgxODUgMjcuMjE3MiAyMC43OTE0IDI3LjM1MjggMjAuNzQgMjcuNDhMNy41OTk5OSA1OS4wN0M3LjU0MzMyIDU5LjE5NDggNy41MTI5MiA1OS4zMjk5IDcuNTEwNjUgNTkuNDY2OUM3LjUwODM5IDU5LjYwNCA3LjUzNDMyIDU5Ljc0IDcuNTg2ODMgNTkuODY2NkM3LjYzOTM1IDU5Ljk5MzIgNy43MTczMiA2MC4xMDc3IDcuODE1OTIgNjAuMjAyOUM3LjkxNDUyIDYwLjI5OCA4LjAzMTYzIDYwLjM3MiA4LjE1OTk5IDYwLjQyQzguMjgzMzEgNjAuNDcyNSA4LjQxNTk0IDYwLjQ5OTcgOC41NDk5OSA2MC41SDQzQzQzLjIxMzIgNjAuNTE0MSA0My40MjUzIDYwLjQ1OTYgNDMuNjA1MiA2MC4zNDQ1QzQzLjc4NTIgNjAuMjI5MyA0My45MjM1IDYwLjA1OTUgNDQgNTkuODZMNDkuMjIgNDcuMjhDNDkuMjc2NyA0Ny4xNTUyIDQ5LjMwNzEgNDcuMDIwMSA0OS4zMDkzIDQ2Ljg4MzFDNDkuMzExNiA0Ni43NDYgNDkuMjg1NyA0Ni42MSA0OS4yMzMxIDQ2LjQ4MzRDNDkuMTgwNiA0Ni4zNTY4IDQ5LjEwMjcgNDYuMjQyNCA0OS4wMDQxIDQ2LjE0NzJDNDguOTA1NSA0Ni4wNTIgNDguNzg4MyA0NS45NzggNDguNjYgNDUuOTNDNDguNTM2NyA0NS44Nzc1IDQ4LjQwNCA0NS44NTAzIDQ4LjI3IDQ1Ljg1SDMwLjRDMzAuMTM0OCA0NS44NSAyOS44ODA0IDQ1Ljc0NDYgMjkuNjkyOSA0NS41NTcxQzI5LjUwNTMgNDUuMzY5NiAyOS40IDQ1LjExNTIgMjkuNCA0NC44NUMyOS4zODggNDQuNzA0OCAyOS40MDUgNDQuNTU4NiAyOS40NSA0NC40MloiIGZpbGw9IiMxMjEyMTIiLz4KPHBhdGggZD0iTTM3LjE3IDQxLjU4SDUwLjg4QzUxLjA4MzcgNDEuNTg0MyA1MS4yODM4IDQxLjUyNjIgNTEuNDUzNSA0MS40MTM2QzUxLjYyMzMgNDEuMzAxIDUxLjc1NDcgNDEuMTM5MyA1MS44MyA0MC45NUw1Ny44MyAyNi42OUM1Ny45MDUzIDI2LjUwMDcgNTguMDM2NyAyNi4zMzkgNTguMjA2NCAyNi4yMjY0QzU4LjM3NjIgMjYuMTEzOCA1OC41NzYzIDI2LjA1NTcgNTguNzggMjYuMDZINzYuNDFDNzYuNjIyIDI2LjA3NDkgNzYuODMzMiAyNi4wMjE4IDc3LjAxMyAyNS45MDg1Qzc3LjE5MjggMjUuNzk1MyA3Ny4zMzE5IDI1LjYyNzYgNzcuNDEgMjUuNDNMODIuNjMgMTIuOTNDODIuNjg1MiAxMi44MDA3IDgyLjcxMjYgMTIuNjYxMyA4Mi43MTAzIDEyLjUyMDdDODIuNzA3OSAxMi4zODAxIDgyLjY3NiAxMi4yNDE2IDgyLjYxNjYgMTIuMTE0M0M4Mi41NTcxIDExLjk4NjkgODIuNDcxNSAxMS44NzM0IDgyLjM2NTIgMTEuNzgxNEM4Mi4yNTkgMTEuNjg5MyA4Mi4xMzQ1IDExLjYyMDcgODIgMTEuNThDODEuODc2NyAxMS41Mjc1IDgxLjc0NCAxMS41MDAzIDgxLjYxIDExLjVINDguODJDNDguNjA4IDExLjQ4NTEgNDguMzk2OCAxMS41MzgyIDQ4LjIxNyAxMS42NTE1QzQ4LjAzNzEgMTEuNzY0NyA0Ny44OTgxIDExLjkzMjQgNDcuODIgMTIuMTNMMzYuMTcgNDAuMTNDMzYuMTEzMSA0MC4yNTQyIDM2LjA4MjIgNDAuMzg4NyAzNi4wNzkzIDQwLjUyNTJDMzYuMDc2MyA0MC42NjE4IDM2LjEwMTQgNDAuNzk3NSAzNi4xNTI5IDQwLjkyNEMzNi4yMDQ1IDQxLjA1MDUgMzYuMjgxNCA0MS4xNjUxIDM2LjM3ODkgNDEuMjYwN0MzNi40NzY0IDQxLjM1NjMgMzYuNTkyNSA0MS40MzEgMzYuNzIgNDEuNDhDMzYuODYxMiA0MS41NDQ3IDM3LjAxNDYgNDEuNTc4OCAzNy4xNyA0MS41OFoiIGZpbGw9IiMxMjEyMTIiLz4KPC9zdmc+",
+      "created": 1684733732697
+    },
+    "d38d49d28590d01f116960cab39407b9920a1655fc748e7891ec3f9cc8f3e00f2972ebbd816628180711d1332e910957": {
+      "mimeType": "image/svg+xml",
+      "id": "d38d49d28590d01f116960cab39407b9920a1655fc748e7891ec3f9cc8f3e00f2972ebbd816628180711d1332e910957",
+      "dataURL": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiMwMDAwMDAiIHdpZHRoPSI4MDBweCIgaGVpZ2h0PSI4MDBweCIgdmlld0JveD0iMCAwIDMyIDMyIiBpZD0iaWNvbiI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOm5vbmU7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5pYm0tc2VjdXJpdHk8L3RpdGxlPjxwYXRoIGlkPSJJQk1fU2VjdXJpdHlfU2hpZWxkIiBkYXRhLW5hbWU9IklCTSBTZWN1cml0eSBTaGllbGQiIGQ9Ik0xNiwuMDAwNSw0LDUuOTc4NFYyMC4wNDQzYTEyLDEyLDAsMCwwLDI0LDBWNS45Nzg0Wm02LjgzLDI3LjMxMzhMMTYsMjMuOTExOVYyNi4xNGw1LjAzNjEsMi41MDg4QTEwLjAwMjUsMTAuMDAyNSwwLDAsMSw2LDIwLjA0NDNWNy4yMUwxNiwyLjIyODQsMjYsNy4yMXYzLjc1TDE2LDUuOTc4M1Y4LjIwNjJsMTAsNC45ODE2djMuNzVMMTYsMTEuOTU2MnYyLjIyNzlsMTAsNC45ODE1di44Nzg3YTkuOTA0NSw5LjkwNDUsMCwwLDEtLjM3LDIuNjg3MUwxNiwxNy45MzR2Mi4yMjc5bDguODk1Miw0LjQzMTNBMTAuMDI1MiwxMC4wMjUyLDAsMCwxLDIyLjgzLDI3LjMxNDNaIi8+PHJlY3QgaWQ9Il9UcmFuc3BhcmVudF9SZWN0YW5nbGVfIiBkYXRhLW5hbWU9IiZsdDtUcmFuc3BhcmVudCBSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTEiIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIvPjwvc3ZnPg==",
+      "created": 1782731210783,
+      "lastRetrieved": 1782731210783
+    }
+  }
+}

--- a/src/content/docs/integrations/qradar.mdx
+++ b/src/content/docs/integrations/qradar.mdx
@@ -1,0 +1,229 @@
+---
+title: IBM QRadar
+---
+
+[IBM QRadar SIEM][qradar] is a security information and event management
+platform. Tenzir can send events to QRadar as Log Event Extended Format (LEEF)
+over Syslog, write LEEF files for batch import, receive QRadar-compatible LEEF
+streams, and query QRadar APIs for targeted backfill.
+
+QRadar also supports proprietary collection and appliance workflows. Tenzir
+does not provide a dedicated QRadar operator. Prefer LEEF over TLS Syslog when
+QRadar should ingest live events from Tenzir.
+
+![IBM QRadar integration paths](qradar.excalidraw)
+
+## Choose an integration path
+
+Use the path that matches where QRadar sits in your deployment:
+
+| Goal | QRadar side | Tenzir operators and functions |
+| :--- | :--- | :--- |
+| Send live events to QRadar | Universal LEEF Syslog log source over TLS Syslog | <Fn>print_leef</Fn>, <Op>to_tcp</Op>, <Op>write_syslog</Op> |
+| Send live events without TLS | Universal LEEF Syslog log source over TCP | <Fn>print_leef</Fn>, <Op>to_tcp</Op>, <Op>write_syslog</Op> |
+| Send one event per UDP datagram | Universal LEEF Syslog log source over UDP | <Fn>print_leef</Fn>, <Op>to_udp</Op> |
+| Hand off historical or offline batches | Log File Protocol polling a transfer location | <Fn>print_leef</Fn>, <Op>to_file</Op>, <Op>write_lines</Op> |
+| Receive QRadar-compatible LEEF in Tenzir | Raw line-based LEEF sender | <Op>accept_tcp</Op>, <Op>read_leef</Op> |
+| Query stored QRadar events | QRadar Ariel REST API | <Op>from_http</Op>, <Op>read_json</Op> |
+
+See the IBM documentation for the [LEEF overview][leef-overview],
+[LEEF event components][leef-components], [Universal LEEF Syslog log source
+parameters][universal-leef-syslog], [TLS Syslog protocol
+configuration][tls-syslog], and [log source setup][log-source].
+
+## Send events to QRadar over Syslog
+
+QRadar can parse LEEF messages that arrive through a Universal LEEF Syslog log
+source. Build the LEEF payload with <Fn>print_leef</Fn>, put it into the Syslog
+message body, and send the result with <Op>to_tcp</Op> and
+<Op>write_syslog</Op>.
+
+```tql
+subscribe "detections"
+leef = {
+  src: src_ip?,
+  dst: dest_ip?,
+  srcPort: src_port?,
+  dstPort: dest_port?,
+  usrName: user_name?,
+  sev: severity? else 5,
+  cat: category? else "detection",
+  msg: message? else event_name? else "Tenzir event",
+}.print_leef(
+  vendor="Tenzir",
+  product_name="Tenzir Pipeline",
+  product_version="6",
+  event_class_id=event_type? else "tenzir.event",
+  delimiter="^",
+)
+this = {
+  facility: 4,
+  severity: 6,
+  hostname: "tenzir-node",
+  app_name: "tenzir",
+  message: leef,
+}
+to_tcp "qradar.example.com:514" {
+  write_syslog
+}
+```
+
+Replace `qradar.example.com:514` with the host and port of the QRadar event
+collector or gateway. Adapt the LEEF attributes to the source schema that you
+forward. Use IBM's predefined LEEF attribute names where they fit, and use
+custom attribute names for fields that do not have a predefined QRadar
+equivalent.
+
+Prefer TCP over UDP when you need connection-level delivery feedback or
+backpressure.
+
+## Send events with TLS Syslog
+
+IBM documents `6514` as the default port for TLS Syslog. Configure QRadar's TLS
+Syslog protocol with the certificates and client authentication policy for your
+deployment, then enable TLS on <Op>to_tcp</Op>:
+
+```tql
+let $tls = {
+  cacert: "/etc/tenzir/qradar-ca.pem",
+  certfile: "/etc/tenzir/tenzir-client.pem",
+  keyfile: "/etc/tenzir/tenzir-client-key.pem",
+}
+
+subscribe "detections"
+leef = {
+  src: src_ip?,
+  dst: dest_ip?,
+  srcPort: src_port?,
+  dstPort: dest_port?,
+  usrName: user_name?,
+  sev: severity? else 5,
+  cat: category? else "detection",
+  msg: message? else event_name? else "Tenzir event",
+}.print_leef(
+  vendor="Tenzir",
+  product_name="Tenzir Pipeline",
+  product_version="6",
+  event_class_id=event_type? else "tenzir.event",
+  delimiter="^",
+)
+this = {
+  facility: 4,
+  severity: 6,
+  hostname: "tenzir-node",
+  app_name: "tenzir",
+  message: leef,
+}
+to_tcp "qradar.example.com:6514", tls=$tls {
+  write_syslog
+}
+```
+
+If QRadar does not require client certificates, omit `certfile` and `keyfile`.
+Keep `cacert` when the QRadar certificate is signed by a private CA.
+
+## Export LEEF files for backfill
+
+Use file export for historical backfill, replay, or offline transfer when
+QRadar cannot receive live Syslog from Tenzir but can poll a directory or
+remote transfer location with the Log File Protocol. For live event streams,
+prefer TLS Syslog.
+
+<Fn>print_leef</Fn> returns a string, so select the LEEF field and write one
+line per event:
+
+```tql
+subscribe "detections"
+leef = {
+  src: src_ip?,
+  dst: dest_ip?,
+  srcPort: src_port?,
+  dstPort: dest_port?,
+  sev: severity? else 5,
+  msg: message? else event_name? else "Tenzir event",
+}.print_leef(
+  vendor="Tenzir",
+  product_name="Tenzir Pipeline",
+  product_version="6",
+  event_class_id=event_type? else "tenzir.event",
+  delimiter="^",
+)
+to_file "/var/spool/qradar/tenzir-{uuid}.leef", timeout=1min {
+  select leef
+  write_lines
+}
+```
+
+Use a rotation condition such as `timeout` or `max_size` to produce bounded
+handoff files. Match the directory path, polling interval, and file naming
+pattern to the QRadar Log File Protocol configuration.
+
+## Receive LEEF in Tenzir
+
+Use Tenzir as a LEEF receiver when a QRadar-compatible sender forwards raw
+line-based LEEF over TCP. This path expects each event to be a LEEF message, not
+a Syslog envelope.
+
+```tql
+accept_tcp "0.0.0.0:1514" {
+  read_leef
+}
+publish "qradar"
+```
+
+Use TLS options on <Op>accept_tcp</Op> if the sender expects TLS, while keeping
+the payload format as raw line-based LEEF.
+
+## Query QRadar events
+
+Use the QRadar Ariel REST API for scheduled backfill, investigations, or
+targeted enrichment. Do not use API polling as the primary live integration path
+when QRadar can forward or receive events through Syslog.
+
+The QRadar API uses an authorized service token in the `SEC` header. The
+following example starts an Ariel search. Poll the returned search ID and fetch
+the results with the matching API endpoints for your QRadar version:
+
+```tql
+let $qradar = "https://qradar.example.com"
+let $query = "SELECT * FROM events LAST 5 MINUTES"
+let $headers = {
+  "Accept": "application/json",
+  "SEC": secret("QRADAR_API_TOKEN"),
+  "Version": "20.0",
+}
+let $url = f"{$qradar}/api/ariel/searches?query_expression={$query.encode_url()}"
+
+from_http $url, method="post", headers=$headers {
+  read_json
+}
+```
+
+Use QRadar's interactive API documentation to verify the API version, endpoint
+parameters, and result pagination behavior in your deployment.
+
+## See Also
+
+- <Op>accept_tcp</Op>
+- <Op>from_http</Op>
+- <Op>read_json</Op>
+- <Op>read_leef</Op>
+- <Op>to_file</Op>
+- <Op>to_tcp</Op>
+- <Op>to_udp</Op>
+- <Op>write_lines</Op>
+- <Op>write_syslog</Op>
+- <Fn>encode_url</Fn>
+- <Fn>print_leef</Fn>
+- <Integration>file</Integration>
+- <Integration>http</Integration>
+- <Integration>syslog</Integration>
+- <Integration>tcp</Integration>
+- <Integration>udp</Integration>
+
+[leef-components]: https://www.ibm.com/docs/en/dsm?topic=overview-leef-event-components
+[leef-overview]: https://www.ibm.com/docs/en/dsm?topic=leef-overview
+[log-source]: https://www.ibm.com/docs/en/dsm?topic=management-adding-log-source
+[qradar]: https://www.ibm.com/products/qradar-siem
+[tls-syslog]: https://www.ibm.com/docs/en/dsm?topic=options-tls-syslog-protocol-configuration
+[universal-leef-syslog]: https://www.ibm.com/docs/en/dsm?topic=leef-syslog-protocol-log-source-parameters-universal

--- a/src/content/docs/integrations/qradar.mdx
+++ b/src/content/docs/integrations/qradar.mdx
@@ -31,6 +31,16 @@ See the IBM documentation for the [LEEF overview][leef-overview],
 parameters][universal-leef-syslog], [TLS Syslog protocol
 configuration][tls-syslog], and [log source setup][log-source].
 
+## LEEF mapping
+
+LEEF has fixed header fields and a small set of predefined event attributes. For
+agent-assisted work, follow
+<Guide>ai-workbench/use-agent-skills#use-the-leef-skill</Guide> to install the
+`tenzir-leef` skill. The skill helps choose LEEF 1.0 or 2.0, pick delimiters,
+use predefined attributes such as `src`, `dst`, `srcPort`, `dstPort`,
+`usrName`, `sev`, and `msg`, and format `devTime` and `devTimeFormat` values
+before you build messages with <Fn>print_leef</Fn>.
+
 ## Send events to QRadar over Syslog
 
 QRadar can parse LEEF messages that arrive through a Universal LEEF Syslog log
@@ -215,6 +225,7 @@ parameters, and result pagination behavior in your deployment.
 - <Op>write_syslog</Op>
 - <Fn>encode_url</Fn>
 - <Fn>print_leef</Fn>
+- <Guide>ai-workbench/use-agent-skills#use-the-leef-skill</Guide>
 - <Integration>file</Integration>
 - <Integration>http</Integration>
 - <Integration>syslog</Integration>

--- a/src/content/docs/reference/functions/parse_leef.mdx
+++ b/src/content/docs/reference/functions/parse_leef.mdx
@@ -50,10 +50,11 @@ output = input.parse_leef()
 
 ## See Also
 
-- <Fn>parse_cef</Fn>
-- <Fn>print_leef</Fn>
 - <Op>read_leef</Op>
 - <Op>read_syslog</Op>
 - <Op>write_syslog</Op>
+- <Fn>parse_cef</Fn>
+- <Fn>print_leef</Fn>
 - <Guide>parsing/parse-string-fields</Guide>
+- <Integration>qradar</Integration>
 - <Integration>syslog</Integration>

--- a/src/content/docs/reference/functions/print_leef.mdx
+++ b/src/content/docs/reference/functions/print_leef.mdx
@@ -100,8 +100,9 @@ write_syslog
 
 ## See Also
 
-- <Fn>parse_leef</Fn>
 - <Op>read_leef</Op>
 - <Op>read_syslog</Op>
 - <Op>write_syslog</Op>
+- <Fn>parse_leef</Fn>
+- <Integration>qradar</Integration>
 - <Integration>syslog</Integration>

--- a/src/content/docs/reference/operators/read_leef.mdx
+++ b/src/content/docs/reference/operators/read_leef.mdx
@@ -81,4 +81,5 @@ import ParsingOptions from '@partials/operators/ParsingOptions.mdx';
 - <Op>write_syslog</Op>
 - <Fn>parse_leef</Fn>
 - <Fn>print_leef</Fn>
+- <Integration>qradar</Integration>
 - <Integration>syslog</Integration>

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -423,6 +423,7 @@ export const integrations = [
       "integrations/arcsight",
       "integrations/crowdstrike",
       "integrations/graylog",
+      "integrations/qradar",
       "integrations/sentinelone-data-lake",
       "integrations/suricata",
       "integrations/velociraptor",


### PR DESCRIPTION
## 🔍 Problem

- The integrations section does not document how to connect Tenzir with IBM QRadar SIEM.
- The existing LEEF primitives are spread across reference and guide pages, so readers lack a single QRadar integration path.

## 🛠️ Solution

- Add an IBM QRadar integration page that recommends LEEF over TLS Syslog for live ingestion.
- Cover TCP/UDP Syslog, LEEF file export, receiving QRadar-compatible LEEF, and Ariel API backfill with existing Tenzir primitives.
- Link the page from Security Tools and from the LEEF reference pages.

## 💬 Review

- Focus on the QRadar integration path recommendations and the TQL examples.
- The page intentionally has no diagram or asset reference; the Excalidraw diagram will be added manually later.
