### PR TITLE
Fix metrics reference for Tenzir v6

### DIFF
--- a/src/content/docs/guides/analytics/collect-metrics.mdx
+++ b/src/content/docs/guides/analytics/collect-metrics.mdx
@@ -35,14 +35,13 @@ ordinary data, for example, write aggregations over metrics to compute runtime
 statistics suitable for reporting or dashboarding:
 
 ```tql
-metrics "operator"
-where sink == true
-summarize runtime=sum(duration), pipeline_id
-sort -runtime
+metrics "operator_profile"
+summarize cpu=sum(cpu), pipeline_id
+sort -cpu
 ```
 
-The previous example computes the total runtime over all pipelines grouped by
-their unique ID.
+The previous example sums the per-second CPU usage of each operator, grouped by
+pipeline ID, to surface the most CPU-intensive pipelines.
 
 ## Inspect pipeline throughput
 

--- a/src/content/docs/reference/operators/metrics.mdx
+++ b/src/content/docs/reference/operators/metrics.mdx
@@ -642,7 +642,7 @@ TCP connection.
   hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
   timestamp: time, // The time at which this metric was recorded.
   operator_id: uint64, // The ID of the operator owning the TCP connection.
-  handle: string, // The native handle of the connection (on Unix, the file descriptor).
+  handle: string, // An identifier for the connection (for example, the peer address).
   reads: uint64, // The number of attempted reads since the last metric.
   writes: uint64, // The number of attempted writes since the last metric.
   bytes_read: uint64, // The number of bytes received since the last metrics.
@@ -652,7 +652,9 @@ TCP connection.
 
 ### `tenzir.metrics.throttle`
 
-Contains metrics for the `throttle` operator, emitted once every second.
+Contains metrics for the `throttle` operator. Emitted once per second only while
+the operator is dropping events — that is, when it is configured with `drop=true`
+and the rate limit is being exceeded.
 
 ```tql
 {

--- a/src/content/docs/reference/operators/metrics.mdx
+++ b/src/content/docs/reference/operators/metrics.mdx
@@ -73,25 +73,27 @@ to <Op>to_prometheus</Op>.
 }
 ```
 
+:::caution[Limited to node health metrics]
+Only the periodic node health metrics carry a Prometheus shape: `tenzir.metrics.cpu`,
+`tenzir.metrics.disk`, `tenzir.metrics.memory`, `tenzir.metrics.process`, and
+`tenzir.metrics.caf`. All other metrics — including `pipeline`, the
+operator-scoped metrics (`import`, `export`, `publish`, `subscribe`,
+`subscribe_buffer`, `tcp`, `throttle`, `enrich`, `lookup`), `operator_profile`,
+`api`, `actor`, `ingest`, `rebuild`, and `platform` — are omitted from the
+Prometheus shape. The operator emits a warning for each omitted schema.
+:::
+
 The Prometheus shape recursively flattens numeric metric fields into individual
 records. Duration values are converted to seconds and emitted with a `_seconds`
 metric suffix.
 
-Only selected low-cardinality dimensions become labels. Tenzir omits
-high-cardinality metadata such as `schema_id`, request IDs, and native handles.
-When multiple raw metrics differ only in omitted metadata, Tenzir aggregates
-their values into one Prometheus-shaped sample.
+Only selected low-cardinality dimensions become labels:
 
-The Prometheus shape emits the following labels:
-
-- API metrics: `method`, `path`, and `status_code`.
-- Actor metrics: `name`.
-- CAF actor-list metrics: `name`.
 - Disk metrics: `path`.
-- Operator-scoped metrics: `pipeline_id` and `operator_id`.
-- Pipeline metrics: `pipeline_id`.
-- Schema-scoped import, export, ingest, publish, and subscribe metrics:
-  `schema`.
+- Memory metrics: `name` (for the per-actor allocator statistics).
+- CAF metrics: `name`.
+
+CPU and process metrics carry no labels.
 
 ## Schemas
 

--- a/src/content/docs/reference/operators/metrics.mdx
+++ b/src/content/docs/reference/operators/metrics.mdx
@@ -25,17 +25,8 @@ tenzir:
     metrics: 7d
 ```
 
-Legacy operator metrics use the separate
-`tenzir.retention.operator-metrics` setting:
-
-```yaml
-tenzir:
-  retention:
-    operator-metrics: 0s
-```
-
-Operator profile metrics use
-`tenzir.retention.operator-profile-metrics`:
+Operator profile metrics use the separate
+`tenzir.retention.operator-profile-metrics` setting:
 
 ```yaml
 tenzir:
@@ -43,9 +34,8 @@ tenzir:
     operator-profile-metrics: 1d
 ```
 
-Set either option to `0s` to disable persistence for the corresponding
-`tenzir.metrics.operator` or `tenzir.metrics.operator_profile` events. Live
-subscribers can still receive them.
+Set this option to `0s` to disable persistence for `tenzir.metrics.operator_profile`
+events. Live subscribers can still receive them.
 
 :::
 
@@ -106,6 +96,26 @@ The Prometheus shape emits the following labels:
 ## Schemas
 
 Tenzir collects metrics with the following schemas.
+
+### `tenzir.metrics.actor`
+
+Contains the current mailbox size of selected core actors (such as `node`,
+`importer`, and `index`), emitted once per second per instrumented actor.
+
+:::caution[Aimed at Developers]
+Actor metrics primarily exist for debugging purposes. Actor names and IDs are
+documented only in source code, and we may change them without notice. Do not
+rely on specific actor names or IDs in production systems.
+:::
+
+```tql
+{
+  timestamp: time, // The time at which this metric was recorded.
+  id: string, // The unique ID of the actor.
+  name: string, // The name of the actor.
+  inbox_size: uint64, // The number of messages currently in the actor's mailbox.
+}
+```
 
 ### `tenzir.metrics.api`
 
@@ -170,23 +180,6 @@ in production systems.
 }
 ```
 
-### `tenzir.metrics.buffer`
-
-Contains information about the `buffer` operator's internal buffer.
-
-```tql
-{
-  pipeline_id: string, // The ID of the pipeline where the associated operator is from.
-  run: uint64, // The number of the run, starting at 1 for the first run.
-  hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
-  timestamp: time, // The time at which this metric was recorded.
-  operator_id: uint64, // The ID of the `buffer` operator in the pipeline.
-  used: uint64, // The number of events stored in the buffer.
-  free: uint64, // The remaining capacity of the buffer.
-  dropped: uint64, // The number of events dropped by the buffer.
-}
-```
-
 ### `tenzir.metrics.cpu`
 
 Contains a measurement of CPU utilization.
@@ -221,6 +214,7 @@ Contains a measurement of the `enrich` operator, emitted once every second.
 ```tql
 {
   pipeline_id: string, // The ID of the pipeline where the associated operator is from.
+  pipeline_name: string, // The name of the pipeline. Note that pipeline names are not unique.
   run: uint64, // The number of the run, starting at 1 for the first run.
   hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
   timestamp: time, // The time at which this metric was recorded.
@@ -240,6 +234,7 @@ metrics themselves.
 ```tql
 {
   pipeline_id: string, // The ID of the pipeline where the associated operator is from.
+  pipeline_name: string, // The name of the pipeline. Note that pipeline names are not unique.
   run: uint64, // The number of the run, starting at 1 for the first run.
   hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
   timestamp: time, // The time at which this metric was recorded.
@@ -260,6 +255,7 @@ metrics themselves.
 ```tql
 {
   pipeline_id: string, // The ID of the pipeline where the associated operator is from.
+  pipeline_name: string, // The name of the pipeline. Note that pipeline names are not unique.
   run: uint64, // The number of the run, starting at 1 for the first run.
   hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
   timestamp: time, // The time at which this metric was recorded.
@@ -291,6 +287,7 @@ Contains a measurement of the `lookup` operator, emitted once every second.
 ```tql
 {
   pipeline_id: string, // The ID of the pipeline where the associated operator is from.
+  pipeline_name: string, // The name of the pipeline. Note that pipeline names are not unique.
   run: uint64, // The number of the run, starting at 1 for the first run.
   hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
   timestamp: time, // The time at which this metric was recorded.
@@ -317,14 +314,36 @@ Contains statistics about allocated memory.
 {
   timestamp: time, // The time at which this metric was recorded.
   system: { // Information about the systems memory state.
-    total_bytes: int, // Total available memory in the system.
-    used_bytes: int, // Amount of memory used on the system.
-    free_bytes: int, // Amount of free memory on the system.
+    total_bytes: uint64, // Total available memory in the system.
+    used_bytes: uint64, // Amount of memory used on the system.
+    free_bytes: uint64, // Amount of free memory on the system.
   },
   process: {
-    peak_bytes: int, // Peak memory usage during the runtime of the process.
-    current_bytes: int, // Current memory usage of the entire process.
-    swap_bytes: int, // Swap space used by the process.
+    peak_bytes: uint64, // Peak memory usage during the runtime of the process.
+    current_bytes: uint64, // Current memory usage of the entire process.
+    swap_bytes: uint64, // Swap space used by the process.
+  },
+  procfs: { // Memory statistics read from the Linux procfs. Only available on Linux.
+    status: { // Values parsed from `/proc/self/status`.
+      vm_rss_bytes: uint64, // Resident set size (physical memory in use).
+      vm_data_bytes: uint64, // Size of the data segment.
+      vm_swap_bytes: uint64, // Amount of swapped-out memory.
+      rss_anon_bytes: uint64, // Resident anonymous memory.
+      file_rss_bytes: uint64, // Resident file-backed memory.
+      rss_shmem_bytes: uint64, // Resident shared memory.
+    },
+    smaps: { // Values aggregated from `/proc/self/smaps`.
+      rss_bytes: uint64, // Resident set size.
+      pss_bytes: uint64, // Proportional set size.
+      private_clean_bytes: uint64, // Private clean pages.
+      private_dirty_bytes: uint64, // Private dirty pages.
+      anonymous_rss_bytes: uint64, // Resident anonymous memory.
+      swap_bytes: uint64, // Swapped-out memory.
+      hugetlb_bytes: uint64, // Memory backed by huge pages.
+    },
+    heap: {
+      break_bytes: uint64, // Size of the heap as defined by the program break.
+    },
   },
   arrow: { // Information about memory allocated by Arrow buffers.
     bytes: {
@@ -402,7 +421,26 @@ Contains statistics about allocated memory.
         },
       },
     }
-  ]
+  ],
+  malloc: { // Statistics from glibc's `mallinfo2`. Only available with glibc.
+    arena_bytes: uint64, // Total bytes allocated in the main arena.
+    uordblks_bytes: uint64, // Total bytes used by in-use allocations.
+    fordblks_bytes: uint64, // Total free bytes within the arena.
+    keepcost_bytes: uint64, // Releasable free space at the top of the heap.
+    hblkhd_bytes: uint64, // Total bytes allocated via `mmap`.
+    ordblks_count: uint64, // Number of ordinary (non-fastbin) free blocks.
+    smblks_count: uint64, // Number of fastbin free blocks.
+  },
+  table_slices: { // Memory used by table slices (the in-memory event batches).
+    serialized_bytes: uint64, // Bytes used by serialized table slices.
+    non_serialized_bytes: uint64, // Bytes used by non-serialized table slices.
+    batch_count: uint64, // Number of table slice batches currently alive.
+    event_count: uint64, // Number of events across all live table slices.
+  },
+  chunks: { // Memory used by reference-counted byte chunks.
+    bytes: uint64, // Total bytes held by chunks.
+    count: uint64, // Number of chunks currently alive.
+  },
 }
 ```
 
@@ -416,50 +454,48 @@ The `actor` statistics in `tenzir.metrics.memory` are only collected
 if Tenzir was build with allocator support (enabled by default)
 **and** the environment variable `TENZIR_ALLOC_ACTOR_STATS=true` is set.
 `TENZIR_ALLOC_ACTOR_STATS_<component>` can also be used to enable only a specific component.
+
+The `procfs` record is only populated on Linux, and the `malloc` record is only
+populated when Tenzir is linked against glibc. On other platforms these records
+are present but their fields are null.
 :::
 
-### `tenzir.metrics.operator`
+### `tenzir.metrics.operator_buffers`
 
-Contains input and output measurements over some amount of time for a single
-operator instantiation.
-
-:::caution[Deprecation Notice]
-Operator metrics are deprecated and will be removed in a future release. Use
-[pipeline metrics](#tenzirmetricspipeline) instead. While they offered great
-insight into the performance of operators, they were not as useful as pipeline
-metrics for understanding the overall performance of a pipeline, and were too
-expensive to collect and store.
-:::
+Contains the aggregate size of the internal buffers between the operators of a
+pipeline. Emitted once per second per pipeline that currently has buffered data.
 
 ```tql
 {
+  timestamp: time, // The time at which this metric was recorded.
+  pipeline_id: string, // The ID of the pipeline these metrics represent.
+  bytes: uint64, // Approximate size of all buffered data in bytes.
+  events: uint64, // The number of events currently buffered.
+}
+```
+
+### `tenzir.metrics.operator_profile`
+
+Contains per-operator performance measurements, emitted once every second per
+operator. This replaces the `operator` metrics that were removed in Tenzir v6.
+
+```tql
+{
+  timestamp: time, // The time at which this metric was recorded.
   pipeline_id: string, // The ID of the pipeline where the associated operator is from.
-  run: uint64, // The number of the run, starting at 1 for the first run.
-  hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
-  timestamp: time, // The time when this event was emitted (immediately after the collection period).
-  operator_id: uint64, // The ID of the operator inside the pipeline referenced above.
-  source: bool, // True if this is the first operator in the pipeline.
-  transformation: bool, // True if this is neither the first nor the last operator.
-  sink: bool, // True if this is the last operator in the pipeline.
-  internal: bool, // True if the data flow is considered to internal to Tenzir.
-  duration: duration, // The timespan over which this data was collected.
-  starting_duration: duration, // The time spent to start the operator.
-  processing_duration: duration, // The time spent processing the data.
-  scheduled_duration: duration, // The time that the operator was scheduled.
-  running_duration: duration, // The time that the operator was running.
-  paused_duration: duration, // The time that the operator was paused.
-  input: { // Measurement of the incoming data stream.
-    unit: string, // The type of the elements, which is `void`, `bytes` or `events`.
-    elements: uint64, // Number of elements that were seen during the collection period.
-    approx_bytes: uint64, // An approximation for the number of bytes transmitted.
-    batches: uint64, // The number of batches included in this metric.
-  },
-  output: { // Measurement of the outgoing data stream.
-    unit: string, // The type of the elements, which is `void`, `bytes` or `events`.
-    elements: uint64, // Number of elements that were seen during the collection period.
-    approx_bytes: uint64, // An approximation for the number of bytes transmitted.
-    batches: uint64, // The number of batches included in this metric.
-  },
+  operator_id: string, // The ID of the operator within the pipeline.
+  name: string, // The name of the operator.
+  input_bytes: uint64, // Approximate number of bytes currently buffered at the operator's input.
+  cpu: double, // CPU usage of the operator as a percentage of wall-clock time over the last second.
+  task_count: uint64, // The number of scheduling tasks executed since the last metric.
+  bytes_in: uint64, // The number of bytes that entered the operator since the last metric.
+  bytes_out: uint64, // The number of bytes that left the operator since the last metric.
+  batches_in: uint64, // The number of batches that entered the operator since the last metric.
+  batches_out: uint64, // The number of batches that left the operator since the last metric.
+  events_in: uint64, // The number of events that entered the operator since the last metric.
+  events_out: uint64, // The number of events that left the operator since the last metric.
+  signals_in: uint64, // The number of control signals that entered the operator since the last metric.
+  signals_out: uint64, // The number of control signals that left the operator since the last metric.
 }
 ```
 
@@ -472,6 +508,7 @@ seconds.
 {
   timestamp: time, // The time at which this metric was recorded.
   pipeline_id: string, // The ID of the pipeline these metrics represent.
+  pipeline_name: string, // The name of the pipeline. Note that pipeline names are not unique.
   ingress: { // Measurement of data entering the pipeline.
     duration: duration, // The timespan over which this data was collected.
     events: uint64, // Number of events that passed through during this period.
@@ -528,6 +565,7 @@ schema.
 ```tql
 {
   pipeline_id: string, // The ID of the pipeline where the associated operator is from.
+  pipeline_name: string, // The name of the pipeline. Note that pipeline names are not unique.
   run: uint64, // The number of the run, starting at 1 for the first run.
   hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
   timestamp: time, // The time at which this metric was recorded.
@@ -560,6 +598,7 @@ per schema.
 ```tql
 {
   pipeline_id: string, // The ID of the pipeline where the associated operator is from.
+  pipeline_name: string, // The name of the pipeline. Note that pipeline names are not unique.
   run: uint64, // The number of the run, starting at 1 for the first run.
   hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
   timestamp: time, // The time at which this metric was recorded.
@@ -579,6 +618,7 @@ once every second.
 ```tql
 {
   pipeline_id: string, // The ID of the pipeline where the associated operator is from.
+  pipeline_name: string, // The name of the pipeline. Note that pipeline names are not unique.
   run: uint64, // The number of the run, starting at 1 for the first run.
   hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
   timestamp: time, // The time at which this metric was recorded.
@@ -597,11 +637,12 @@ TCP connection.
 ```tql
 {
   pipeline_id: string, // The ID of the pipeline where the associated operator is from.
+  pipeline_name: string, // The name of the pipeline. Note that pipeline names are not unique.
   run: uint64, // The number of the run, starting at 1 for the first run.
   hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
   timestamp: time, // The time at which this metric was recorded.
-  operator_id: uint64, // The ID of the `publish` operator in the pipeline.
-  native: string, // The native handle of the connection (unix: file descriptor).
+  operator_id: uint64, // The ID of the operator owning the TCP connection.
+  handle: string, // The native handle of the connection (on Unix, the file descriptor).
   reads: uint64, // The number of attempted reads since the last metric.
   writes: uint64, // The number of attempted writes since the last metric.
   bytes_read: uint64, // The number of bytes received since the last metrics.
@@ -616,6 +657,7 @@ Contains metrics for the `throttle` operator, emitted once every second.
 ```tql
 {
   pipeline_id: string, // The ID of the pipeline where the associated operator is from.
+  pipeline_name: string, // The name of the pipeline. Note that pipeline names are not unique.
   run: uint64, // The number of the run, starting at 1 for the first run.
   hidden: bool, // Indicates whether the corresponding pipeline is hidden from the list of managed pipelines.
   timestamp: time, // The time at which this metric was recorded.
@@ -662,24 +704,22 @@ select timestamp, percent=loadavg_1m
 metrics "memory"
 sort -timestamp
 tail 1
-select current_memory_usage
+select current_bytes=process.current_bytes
 ```
 
 ```tql
-{current_memory_usage: 1083031552}
+{current_bytes: 1083031552}
 ```
 
 ### Show the total pipeline ingress in bytes
 
-Show the inggress for every day over the last week, excluding pipelines that run
-in the Explorer:
+Show the ingress for every day over the last week, excluding internal data flows:
 
 ```tql
-metrics "operator"
+metrics "pipeline"
 where timestamp > now() - 1week
-where source and not hidden
 timestamp = floor(timestamp, 1day)
-summarize timestamp, bytes=sum(output.approx_bytes)
+summarize timestamp, bytes=sum(ingress.bytes if not ingress.internal)
 ```
 
 ```tql
@@ -698,17 +738,16 @@ Show the three operator instantiations that produced the most events in total
 and their pipeline IDs:
 
 ```tql
-metrics "operator"
-where output.unit == "events"
-summarize pipeline_id, operator_id, events=max(output.elements)
+metrics "operator_profile"
+summarize pipeline_id, operator_id, events=sum(events_out)
 sort -events
 head 3
 ```
 
 ```tql
-{pipeline_id: "70a25089-b16c-448d-9492-af5566789b99", operator_id: 0, events: 391008694 }
-{pipeline_id: "7842733c-06d6-4713-9b80-e20944927207", operator_id: 0, events: 246914949 }
-{pipeline_id: "6df003be-0841-45ad-8be0-56ff4b7c19ef", operator_id: 1, events: 83013294 }
+{pipeline_id: "70a25089-b16c-448d-9492-af5566789b99", operator_id: "0/0", events: 391008694 }
+{pipeline_id: "7842733c-06d6-4713-9b80-e20944927207", operator_id: "0/0", events: 246914949 }
+{pipeline_id: "6df003be-0841-45ad-8be0-56ff4b7c19ef", operator_id: "1/0", events: 83013294 }
 ```
 
 ### Get the disk usage over time
@@ -738,7 +777,7 @@ to_prometheus "https://prometheus.example/api/v1/write"
 ```tql
 metrics "memory"
 sort timestamp
-select timestamp, used_bytes
+select timestamp, used_bytes=system.used_bytes
 ```
 
 ```tql
@@ -754,13 +793,12 @@ select timestamp, used_bytes
 ```tql
 metrics "tcp"
 sort timestamp
-select timestamp, port, handle, reads, bytes
+select timestamp, handle, reads, writes, bytes_read, bytes_written
 ```
 
 ```tql
 {
   timestamp: 2024-09-04T15:43:38.011350,
-  port: 10000,
   handle: "12",
   reads: 884,
   writes: 0,
@@ -769,7 +807,6 @@ select timestamp, port, handle, reads, bytes
 }
 {
   timestamp: 2024-09-04T15:43:39.013575,
-  port: 10000,
   handle: "12",
   reads: 428,
   writes: 0,
@@ -778,7 +815,6 @@ select timestamp, port, handle, reads, bytes
 }
 {
   timestamp: 2024-09-04T15:43:40.015376,
-  port: 10000,
   handle: "12",
   reads: 429,
   writes: 0,


### PR DESCRIPTION
The `metrics` reference and the analytics guide had drifted from what Tenzir v6
nodes actually emit. This aligns them with the v6 source and verifies everything
end-to-end against a **v6.4.0 node**.

## Schemas

- **Add** `tenzir.metrics.actor`, `tenzir.metrics.operator_profile`, and
  `tenzir.metrics.operator_buffers` (new in v6).
- **Remove** `tenzir.metrics.operator` and `tenzir.metrics.buffer` — both error
  out in v6 (`"operator metrics have been removed"`, `"buffer has been
  removed"`).
- **Add `pipeline_name`** to every pipeline- and operator-scoped metric
  (`pipeline`, `publish`, `subscribe`, `subscribe_buffer`, `import`, `export`,
  `enrich`, `lookup`, `tcp`, `throttle`). Added in v5.31.0 but never documented.
- **Rewrite `tenzir.metrics.memory`**: add the missing `procfs`, `malloc`,
  `table_slices`, and `chunks` records, correct field types to `uint64`, and
  note the Linux/glibc availability of `procfs`/`malloc`.
- **Fix `tenzir.metrics.tcp`**: the field is `handle` (a connection identifier,
  e.g. the peer address), not `native`; the `operator_id` comment was a
  copy-paste from `publish`.
- **Fix `tenzir.metrics.throttle`**: it is emitted only in `drop=true` mode while
  events are being dropped, not once per second unconditionally.

## Examples

- Fix broken samples referencing non-existent fields: `current_memory_usage` →
  `process.current_bytes`, `used_bytes` → `system.used_bytes`, and a stray
  `port` in the TCP example.
- Replace the two removed `metrics "operator"` examples with `pipeline` and
  `operator_profile` equivalents (note `operator_id` is now a string).
- Guide: swap the deprecated `operator` aggregation for `operator_profile`.
- Drop the stale `operator-metrics` retention setting from the intro.

## Verification

Stood up a **v6.4.0** node, installed the `demo` and `suricata` packages, and
deployed managed pipelines exercising every operator-scoped metric
(`import`, `export`, `publish`, `subscribe`, `subscribe_buffer`, `enrich`,
`lookup`, `tcp`, `throttle`). Confirmed:

- every documented schema emits with the documented fields;
- `pipeline_name` is present on all ten operator-scoped metrics;
- all 11 runnable TQL examples execute against the node and pass;
- `markdownlint` is clean.

Docs-only; no companion code PR (the v6 source is already correct — only the
docs had drifted).
